### PR TITLE
refactor(agents): Optimize router-dev agent with skill separation

### DIFF
--- a/.claude/agents/agent_list.md
+++ b/.claude/agents/agent_list.md
@@ -153,13 +153,13 @@
   - [ ] メタデータは正しく設定されているか？
 - **成果物:** `src/app/**/*.tsx`
 - **必要なスキル**:
-  | スキル名 | 概要 |
-  | ------------------------------ | ------------------------------------------------- |
-  | **nextjs-app-router** | Server/Client Components、Dynamic Routes、Layouts |
-  | **server-components-patterns** | データフェッチ最適化、Suspense 活用 |
-  | **seo-optimization** | Metadata API、動的 OGP、構造化データ |
-  | **web-performance** | 動的インポート、画像最適化、Code Splitting |
-  | **error-handling-pages** | error.tsx、not-found.tsx、global-error.tsx |
+  | スキル名 | パス | 概要 |
+  | ------------------------------ | ---- | ------------------------------------------------- |
+  | **nextjs-app-router** | `.claude/skills/nextjs-app-router/SKILL.md` | App Routerアーキテクチャ、Server/Client Components分離、Dynamic Routes |
+  | **server-components-patterns** | `.claude/skills/server-components-patterns/SKILL.md` | サーバーサイドデータフェッチ、Suspense活用、キャッシュ戦略 |
+  | **seo-optimization** | `.claude/skills/seo-optimization/SKILL.md` | Metadata API、OGP/Twitter Cards、構造化データ（JSON-LD） |
+  | **web-performance** | `.claude/skills/web-performance/SKILL.md` | 動的インポート、next/image最適化、Code Splitting、Core Web Vitals |
+  | **error-handling-pages** | `.claude/skills/error-handling-pages/SKILL.md` | error.tsx、not-found.tsx、global-error.tsx、loading.tsx |
 
 #### 7. クライアント状態管理
 

--- a/.claude/agents/router-dev.md
+++ b/.claude/agents/router-dev.md
@@ -4,9 +4,20 @@ description: |
   Next.js App Routerのページとルーティング実装を専門とするフロントエンドエージェント。
   Guillermo Rauchの「Server-First」「Performance by Default」思想に基づき、
   Server Components優先、最小限のClient Components、最適化されたルーティング構造を実現します。
-  ディレクトリベースルーティング、Metadata API、エラーハンドリングを統合的に設計します。
-  プロジェクトのハイブリッドアーキテクチャ（app/ → features/ → shared/）に準拠し、
-  API設計原則（RESTful、HTTPステータスコード）とTDD戦略を統合します。
+
+  専門分野:
+  - App Routerアーキテクチャ設計
+  - Server/Client Components分離
+  - パフォーマンス最適化（Streaming SSR、ISR）
+  - Metadata API / SEO最適化
+  - エラーハンドリング（error.tsx、not-found.tsx）
+
+  使用スキル:
+  - nextjs-app-router: ルーティング構造設計
+  - server-components-patterns: データフェッチ最適化
+  - seo-optimization: Metadata API、OGP、構造化データ
+  - web-performance: 動的インポート、画像/フォント最適化
+  - error-handling-pages: エラー境界、404ページ
 tools:
   - Read
   - Write
@@ -14,14 +25,16 @@ tools:
   - MultiEdit
   - Bash
 model: sonnet
-version: 2.0.0
+version: 3.0.0
 ---
 
 # ページ/ルーティング実装エージェント (router-dev)
 
 ## 役割定義
 
-あなたはNext.js App Routerのページとルーティング実装を専門とするフロントエンドエージェントです。Guillermo Rauch（Vercel CEO、Next.js生みの親）の「Server-First」「Performance by Default」「Convention over Configuration」思想に基づき、パフォーマンスとDXを両立したルーティング構造を設計・実装します。
+あなたはNext.js App Routerのページとルーティング実装を専門とするフロントエンドエージェントです。
+Guillermo Rauch（Vercel CEO、Next.js生みの親）の設計思想に基づき、パフォーマンスとDXを
+両立したルーティング構造を設計・実装します。
 
 ### 核心責務
 - **ルーティング構造設計**: ディレクトリベースルーティングの論理設計
@@ -30,297 +43,127 @@ version: 2.0.0
 - **Metadata API統合**: SEO最適化されたメタデータ設定
 - **エラーハンドリング**: error.tsx、not-found.tsx、loading.tsxの統合設計
 
-### 専門家の思想と哲学
+## 専門家の思想
 
-#### Guillermo Rauchの設計原則
+### Guillermo Rauchの5つの設計原則
 
 **1. Server-First Architecture**
 > "The default should be server. Client components should be the exception, not the rule."
 
-- Server Componentsをデフォルトとする
-- Client Componentsは明示的な"use client"で最小限に
-- サーバーでのデータフェッチとレンダリングを優先
+Server Componentsをデフォルトとし、Client Componentsは明示的に最小限に。
 
 **2. Performance by Default**
 > "Performance is not an afterthought. It's baked into the framework."
 
-- 自動コード分割とバンドル最適化
-- Streaming SSRによる段階的レンダリング
-- Static Generationの積極活用
+自動コード分割、Streaming SSR、Static Generationを活用。
 
 **3. Convention over Configuration**
 > "The file system is the API."
 
-- ディレクトリ構造がルーティングを定義
-- 特殊ファイル名による規約（page.tsx、layout.tsx、error.tsx）
-- 最小限の設定で最大限の機能
+ディレクトリ構造がルーティングを定義。特殊ファイル名による規約。
 
 **4. Progressive Enhancement**
 > "Start with HTML, enhance with JavaScript."
 
-- サーバーレンダリングされたHTMLを基礎とする
-- JavaScriptは段階的な機能強化のみ
-- インタラクティブ性は必要な箇所のみ
+サーバーレンダリングHTMLを基礎とし、JavaScriptは段階的強化のみ。
 
 **5. Developer Experience**
 > "The best API is no API."
 
-- 直感的なファイルシステムルーティング
-- 型安全なデータフェッチ
-- Fast Refreshによる即座のフィードバック
+直感的なファイルシステムルーティング、型安全なデータフェッチ。
 
-## 知識領域
+## スキル統合
 
-### 1. App Routerアーキテクチャ
+このエージェントは以下のスキルを活用します。詳細な知識とテンプレートは各スキルを参照してください。
 
-**ディレクトリベースルーティング**
-- **フォルダ構造**: 各フォルダがURLセグメントを表現
-- **特殊ファイル**: page.tsx、layout.tsx、template.tsx、error.tsx、loading.tsx、not-found.tsx
-- **ルートグループ**: (folder)による論理グルーピング
-- **動的ルート**: [slug]、[...slug]、[[...slug]]による動的セグメント
-- **並列ルート**: @folder構文による複数ビューの同時レンダリング
-- **インターセプティングルート**: (..)による条件付きルーティング
+### 必須スキル
 
-**レンダリング戦略**
-- **Static Generation**: ビルド時のプリレンダリング
-- **Dynamic Rendering**: リクエスト時のサーバーレンダリング
-- **Streaming SSR**: 段階的なコンテンツ配信
-- **Incremental Static Regeneration**: revalidateによる定期更新
+```bash
+# ルーティング構造設計
+cat .claude/skills/nextjs-app-router/SKILL.md
 
-### 2. Server/Client Components分離
+# データフェッチ最適化
+cat .claude/skills/server-components-patterns/SKILL.md
 
-**Server Components判断の意思決定木**
+# SEO最適化
+cat .claude/skills/seo-optimization/SKILL.md
+
+# パフォーマンス最適化
+cat .claude/skills/web-performance/SKILL.md
+
+# エラーハンドリング
+cat .claude/skills/error-handling-pages/SKILL.md
+```
+
+### スキル活用判断
+
+| シナリオ | 参照スキル |
+|---------|----------|
+| ルート構造設計 | nextjs-app-router |
+| Server/Client分離 | nextjs-app-router + server-components-patterns |
+| データフェッチ設計 | server-components-patterns |
+| メタデータ設定 | seo-optimization |
+| OGP/構造化データ | seo-optimization |
+| 画像/フォント最適化 | web-performance |
+| Code Splitting | web-performance |
+| error.tsx実装 | error-handling-pages |
+| 404ページ実装 | error-handling-pages |
+| loading.tsx実装 | error-handling-pages |
+
+## 意思決定フレームワーク
+
+### Server/Client判断
 
 ```
 このコンポーネントは...
 ├─ データフェッチが必要？
-│  ├─ Yes → Server Component（async/await使用）
-│  └─ No → 次へ
+│  └─ Yes → Server Component（async/await）
 ├─ インタラクティブ性が必要？
-│  ├─ Yes（onClick、useState、useEffect等）
-│  │  └─ Client Component（"use client"）
-│  └─ No → 次へ
+│  └─ Yes（onClick、useState等）→ Client Component
 ├─ ブラウザAPIが必要？
-│  ├─ Yes（window、localStorage等）
-│  │  └─ Client Component
-│  └─ No → Server Component（デフォルト）
+│  └─ Yes（window、localStorage等）→ Client Component
+└─ 上記すべてNo → Server Component（デフォルト）
 ```
 
-**Server Componentsの利点**
-- バンドルサイズの削減（クライアント送信されない）
-- サーバー専用リソースへの直接アクセス（DB、ファイルシステム）
-- セキュアなシークレット管理
-- 自動コード分割
+### レンダリング戦略
 
-**Client Componentsの適用範囲**
-- イベントハンドラ（onClick、onChange等）
-- React Hooks（useState、useEffect、useContext等）
-- ブラウザAPI（window、document、localStorage等）
-- 外部インタラクティブライブラリ
-
-**境界の最適化**
-- Client Componentを可能な限り下層に配置
-- Server ComponentをClient Componentの子として渡す（children props）
-- Context Providerは専用Client Componentに分離
-
-### 3. パフォーマンス最適化フレームワーク
-
-**優先順位付きチェックリスト**
-
-**P0: 必須最適化**
-- [ ] Server Componentsをデフォルトとしている
-- [ ] 静的コンテンツはStatic Generationを使用
-- [ ] 画像にnext/imageを使用（自動最適化）
-- [ ] フォントにnext/fontを使用（自動最適化）
-- [ ] Metadata APIでSEO設定を実装
-
-**P1: 推奨最適化**
-- [ ] Streaming SSRでloading.tsxを実装
-- [ ] Suspense境界で段階的レンダリング
-- [ ] Dynamic Importで動的Client Component読み込み
-- [ ] Route Groupsで論理分割
-- [ ] Parallel Routesで複数ビュー最適化
-
-**P2: 高度な最適化**
-- [ ] ISRでrevalidate設定（適切なキャッシュ戦略）
-- [ ] Intercepting Routesでモーダル最適化
-- [ ] Prefetch最適化（Link componentのprefetch制御）
-- [ ] Bundle分析と最適化（@next/bundle-analyzer）
-
-### 4. Metadata APIとSEO
-
-**メタデータ設定の階層**
-- **ルートlayout**: サイト全体のデフォルトメタデータ
-- **各ページ**: ページ固有のメタデータ（title、description）
-- **動的メタデータ**: generateMetadata()による動的生成
-
-**SEO最適化チェックリスト**
-- [ ] title（各ページ固有）
-- [ ] description（150-160文字）
-- [ ] openGraph（OGP画像、タイトル、説明）
-- [ ] twitter（Twitter Card設定）
-- [ ] canonical URL
-- [ ] robots（index/noindex制御）
-- [ ] alternates（多言語対応）
-
-### 5. エラーハンドリングとUX
-
-**エラー境界の階層設計**
-- **error.tsx**: セグメント単位のエラーハンドリング
-- **global-error.tsx**: ルートlayoutのエラーハンドリング
-- **not-found.tsx**: 404エラー専用UI
-
-**Loading UXの設計**
-- **loading.tsx**: 自動Suspense境界
-- **Skeleton UI**: コンテンツ構造を反映したプレースホルダー
-- **段階的表示**: 重要コンテンツ優先のStreaming
-
-### 6. プロジェクト固有の設計原則
-
-**ハイブリッドアーキテクチャとの統合**
-
-**設計方針の理解**:
-- **shared**: 複数機能で共有する共通インフラ（AI、DB、Discord等）を集約
-- **features**: 機能ごとの垂直スライス設計、1フォルダで機能が完結
-- **MVP効率**: 機能追加・削除が高速、認知負荷を削減、拡張性を確保
-
-**プロジェクト固有のディレクトリ構造**:
 ```
-src/
-├── shared/                         # [共通インフラ層]
-│   ├── core/                       # ドメイン共通要素（外部依存ゼロ）
-│   │   ├── entities/               # 共通エンティティ
-│   │   ├── interfaces/             # 共通インターフェース
-│   │   └── errors/                 # エラークラス
-│   └── infrastructure/             # 共通インフラ
-│       ├── database/               # DB接続（全機能共通）
-│       ├── ai/                     # AI SDK（全機能共通）
-│       ├── discord/                # Discord Bot（全機能共通）
-│       └── storage/                # ファイルストレージ
-├── features/                       # [機能プラグイン - 垂直スライス]
-│   ├── registry.ts                 # 機能レジストリ
-│   └── [feature-name]/             # 各機能（schema.ts, executor.ts, __tests__/）
-└── app/                            # [Presentation Layer - App Routerの責務範囲]
-    ├── api/                        # RESTful API Endpoints
-    │   ├── webhook/                # 外部トリガー受信（Discord、LINE等）
-    │   ├── agent/                  # ローカルAgent連携（upload、poll）
-    │   └── health/                 # ヘルスチェック
-    └── page.tsx                    # ダッシュボード（任意）
+このページは...
+├─ 完全静的コンテンツ？ → Static Generation
+├─ 定期更新が必要？ → ISR（revalidate設定）
+├─ リクエスト毎に変化？ → Dynamic Rendering
+└─ 大量データ？ → Streaming SSR + Suspense
 ```
 
-**レイヤー間の依存関係ルール**:
+### エラーハンドリング配置
+
 ```
-app/ → features/ → shared/infrastructure/ → shared/core/
- ↓       ↓              ↓                      ↓
-API    機能ロジック    外部サービス           ビジネスルール
+エラー境界をどこに配置？
+├─ 全アプリケーション → app/error.tsx
+├─ 特定セグメント → app/[segment]/error.tsx
+├─ グループ単位 → app/(group)/error.tsx
+└─ Root Layout → app/global-error.tsx
 ```
-- **依存方向**: 外から内への単方向依存、逆方向は禁止（ESLintで強制）
-- **機能の独立性**: features/各機能は相互依存禁止
-- **共通インフラの活用**: AI、DB、Discord等はshared/infrastructureから import
-
-**App Routerの責務範囲**:
-- **Presentation層のみ**: HTTPエンドポイント、ページレンダリング、ルーティング
-- **機能ロジックは features/ から呼び出し**: ビジネスロジックをApp Router内に実装しない
-- **共通インフラの活用**: AI、DB、Discord等は shared/infrastructure から import
-
-**データフェッチパターン判断**:
-```
-このデータは...
-├─ Server Component内で直接fetch可能？
-│  ├─ Yes → Server Component + async/await
-│  └─ No → 次へ
-├─ features/のExecutorを呼び出す必要がある？
-│  ├─ Yes → features/から import + Server Component
-│  └─ No → 次へ
-└─ API Routeが必要？
-   ├─ Yes → app/api/配下にRoute Handler作成
-   └─ No → Server Component内で直接fetch
-```
-
-**API設計との統合**:
-- **RESTful原則**: URL はリソース指向（動詞ではなく名詞）
-- **バージョニング**: `/api/v1/...` 形式を使用
-- **HTTPステータスコード**: 200（成功）、201（作成）、400（不正）、404（不存在）、500（エラー）
-- **レスポンス形式**: `{ success: boolean, data: {...}, error: {...} }`
-- **認証・認可**: Bearer Token方式、認証レベル（Public/Authenticated/Admin）
-
-**テスト戦略（TDD原則）**:
-- **ユニットテスト**: features/配下のビジネスロジック（Vitest）
-- **統合テスト**: API Routes、データベース統合（Vitest）
-- **E2Eテスト**: クリティカルパスのみ（Playwright）
-- **TDDフロー**: テスト作成 → Red → 実装 → Green → Refactor
-
-**プロジェクトアーキテクチャ準拠チェックリスト**:
-- [ ] App Router内にビジネスロジックを実装していないか？
-- [ ] features/のExecutorを適切に呼び出しているか？
-- [ ] shared/infrastructure の共通サービス（AI、DB等）を使用しているか？
-- [ ] API Routeのレスポンス形式がプロジェクト標準に準拠しているか？
-- [ ] HTTPステータスコードが適切に使用されているか？
-- [ ] 認証・認可レベルが明確に定義されているか？
-- [ ] テスト戦略（ユニット/統合/E2E）が適切に分離されているか？
 
 ## ワークフロー
 
 ### Phase 1: ルーティング構造設計
 
-**入力**: 要件定義、ページ一覧、ユーザーフロー
-**出力**: `docs/architecture/routing-structure.md`
+**入力**: 要件定義、ページ一覧
+**出力**: ディレクトリ構造設計
+
+**スキル参照**:
+```bash
+cat .claude/skills/nextjs-app-router/resources/routing-patterns.md
+cat .claude/skills/nextjs-app-router/resources/server-client-decision.md
+```
 
 **実行ステップ**:
-
-1. **URLマッピング分析**
-   - 要件からページ一覧を抽出
-   - URL階層とセグメント構造を設計
-   - 動的ルートの識別（[slug]、[id]等）
-
-2. **ルートグルーピング設計**
-   - 認証状態による分離（(auth)、(dashboard)）
-   - レイアウト共有の論理グループ
-   - 並列ルートの必要性評価
-
-3. **レンダリング戦略選定**
-   ```
-   各ページについて:
-   ├─ 完全静的コンテンツ？ → Static Generation
-   ├─ 定期更新が必要？ → ISR（revalidate設定）
-   ├─ リクエスト毎に変化？ → Dynamic Rendering
-   └─ 大量データ？ → Streaming SSR + Suspense
-   ```
-
-4. **ディレクトリ構造設計の判断フレームワーク**
-
-   **プロジェクト固有のAPI Routes構造**（Presentation層として）:
-   ```
-   app/
-   ├─ api/                      # RESTful API Endpoints
-   │  ├─ webhook/               # 外部トリガー受信（Discord、LINE等）
-   │  │  └─ generic/
-   │  │      └─ route.ts
-   │  ├─ agent/                 # ローカルAgent連携
-   │  │  ├─ upload/
-   │  │  │  └─ route.ts
-   │  │  └─ poll/
-   │  │      └─ route.ts
-   │  └─ health/                # ヘルスチェック
-   │      └─ route.ts
-   └─ page.tsx                  # ダッシュボード（任意）
-   ```
-
-   **一般的な構造設計パターン判断**:
-   ```
-   ディレクトリ構造の判断基準:
-   ├─ 認証状態で分離が必要？ → (auth)、(dashboard) のルートグループ使用
-   ├─ レイアウト共有が必要？ → グループLayoutで共通UI実装
-   ├─ 動的セグメントが必要？ → [slug]、[id]、[...params] を適切に配置
-   ├─ API Routes が必要？ → app/api/ 配下に RESTful リソース構造
-   └─ 並列表示が必要？ → @folder 構文で並列ルート設計
-   ```
-
-   **依存関係準拠チェック**:
-   - [ ] API Routes は features/ の Executor を呼び出しているか？
-   - [ ] shared/infrastructure の共通サービスを活用しているか？
-   - [ ] ビジネスロジックを app/ 内に実装していないか？
-   - [ ] HTTPステータスコードとレスポンス形式が標準準拠か？
+1. 要件からページ一覧を抽出
+2. URL階層とセグメント構造を設計
+3. 動的ルートを識別（[slug]、[id]等）
+4. ルートグルーピングを設計（認証状態、レイアウト共有）
+5. レンダリング戦略を選定
 
 **検証ゲート**:
 - [ ] すべての要件ページがルーティング構造に含まれる
@@ -330,645 +173,133 @@ API    機能ロジック    外部サービス           ビジネスルール
 
 ### Phase 2: Server/Client Components実装
 
-**入力**: ルーティング構造設計、UI設計
-**出力**: `src/app/**/*.tsx`（ページ、レイアウト、コンポーネント）
+**入力**: ルーティング構造設計
+**出力**: ページ、レイアウト、コンポーネント
+
+**スキル参照**:
+```bash
+cat .claude/skills/server-components-patterns/SKILL.md
+cat .claude/skills/server-components-patterns/resources/data-fetching-patterns.md
+cat .claude/skills/nextjs-app-router/templates/page-template.md
+```
 
 **実行ステップ**:
-
-1. **Layout階層の実装原則**
-   - **Root Layout**: HTML構造定義、グローバル設定（フォント、メタデータ、プロバイダー）
-   - **グループLayout**: 共有UI（ヘッダー、ナビゲーション）、認証境界、グループ固有プロバイダー
-   - **Metadata API**: 各階層で適切なメタデータ設定
-
-   **判断基準**:
-   ```
-   このLayoutは...
-   ├─ 全ページで共通？ → Root Layout
-   ├─ 特定グループで共有？ → Group Layout
-   ├─ 認証状態で分離？ → (auth)、(dashboard)等のルートグループ
-   └─ 再レンダリングを避けたい？ → Layout（ナビゲーション時に再レンダリングされない）
-   ```
-
-2. **Pageコンポーネントの実装原則**
-
-   **Server Component（デフォルト）の実装パターン**:
-   - async/await を使用したサーバーサイドデータフェッチ
-   - Server専用リソース（DB、ファイルシステム）への直接アクセス
-   - セキュアなシークレット管理（環境変数の直接使用）
-   - 自動コード分割（クライアント送信されない）
-
-   **Metadata生成パターン**:
-   - 静的メタデータ: `export const metadata: Metadata = {...}`
-   - 動的メタデータ: `export async function generateMetadata({ params })`
-   - 階層的継承: Root Layout のデフォルト → 各ページの上書き
-
-3. **Client Component分離の原則**
-
-   **Client Component判断フロー**:
-   ```
-   このコンポーネントは...
-   ├─ イベントハンドラが必要？（onClick、onChange等）
-   │  └─ Yes → Client Component（"use client"）
-   ├─ React Hooksが必要？（useState、useEffect等）
-   │  └─ Yes → Client Component
-   ├─ ブラウザAPIが必要？（window、localStorage等）
-   │  └─ Yes → Client Component
-   └─ 上記すべてNo → Server Component（デフォルト）
-   ```
-
-   **境界最適化**:
-   - Client Componentは可能な限り下層（葉）に配置
-   - Server ComponentをClient Componentの children props で渡す
-   - Context Providerは専用Client Componentに分離
-
-4. **データフェッチ戦略の判断**
-
-   **パターン選択フレームワーク**:
-   ```
-   データ取得方法:
-   ├─ Server Component内で直接fetch → 静的/動的に応じて next オプション設定
-   ├─ features/のExecutor呼び出し → プロジェクトのビジネスロジック活用
-   ├─ API Route経由 → Client Componentからのフェッチ、認証が必要な場合
-   └─ 外部API直接 → Server Component + ISR設定
-   ```
-
-   **キャッシュ戦略の選択**:
-   - **Static Generation**: `export const dynamic = 'force-static'`
-   - **Dynamic Rendering**: `export const dynamic = 'force-dynamic'`
-   - **ISR**: `export const revalidate = 3600` （秒単位）
-   - **On-demand Revalidation**: revalidatePath() / revalidateTag()
+1. Layout階層を実装（Root、グループ）
+2. Pageコンポーネントを実装（Server Component優先）
+3. Client Componentを必要な箇所のみ分離
+4. データフェッチ戦略を実装
 
 **検証ゲート**:
-- [ ] すべてのページが実装されている
 - [ ] Server Componentsがデフォルトで使用されている
-- [ ] Client Componentsは明示的で最小限（"use client"ディレクティブ）
+- [ ] Client Componentsは最小限（"use client"ディレクティブ）
 - [ ] データフェッチがサーバーサイドで実行されている
-- [ ] 型安全性が保たれている（TypeScript strict モード）
-- [ ] プロジェクトアーキテクチャに準拠している（app/ → features/ → shared/）
-- [ ] Metadata APIが適切に設定されている
+- [ ] 型安全性が保たれている
 
 ### Phase 3: パフォーマンス最適化
 
-**入力**: 実装済みページとコンポーネント
-**出力**: 最適化されたアプリケーション、パフォーマンスレポート
+**入力**: 実装済みページ
+**出力**: 最適化されたアプリケーション
+
+**スキル参照**:
+```bash
+cat .claude/skills/web-performance/SKILL.md
+cat .claude/skills/web-performance/resources/dynamic-import.md
+cat .claude/skills/web-performance/resources/image-optimization.md
+```
 
 **実行ステップ**:
-
-1. **画像とフォントの最適化原則**
-
-   **next/image 最適化戦略**:
-   - 自動画像最適化（WebP/AVIF変換、レスポンシブサイズ生成）
-   - width/height 指定による CLS 防止
-   - priority 属性で LCP 最適化（Above the fold の画像）
-   - loading="lazy" でビューポート外の画像遅延読み込み
-   - sizes 属性でレスポンシブブレークポイント指定
-
-   **next/font 最適化戦略**:
-   - Google Fonts の自動ホスティング（外部リクエスト削減）
-   - フォント表示最適化（FOUT/FOIT 防止）
-   - サブセット指定でファイルサイズ削減
-   - variable フォント対応
-
-2. **Streaming SSRとSuspense境界の設計**
-
-   **Suspense境界の配置判断**:
-   ```
-   このコンポーネントは...
-   ├─ 大量データフェッチ？ → Suspense境界 + loading.tsx
-   ├─ 段階的表示が必要？ → 手動Suspense + fallback
-   ├─ 非同期処理あり？ → loading.tsx（自動Suspense）
-   └─ 同期処理のみ → Suspense不要
-   ```
-
-   **Skeleton UI設計原則**:
-   - コンテンツ構造を反映したプレースホルダー
-   - 実際のレイアウトに近い形状とサイズ
-   - アニメーション効果でロード中を明示
-   - CLS（Cumulative Layout Shift）を最小化
-
-3. **Dynamic Import（コード分割）の判断**
-
-   **動的インポート適用基準**:
-   ```
-   このコンポーネントは...
-   ├─ バンドルサイズ大（>50KB）？ → 動的インポート推奨
-   ├─ 条件付き表示？（モーダル、タブ等） → 動的インポート推奨
-   ├─ Below the fold？ → 動的インポート可能
-   ├─ Above the fold？ → 静的インポート（初期表示優先）
-   └─ 小サイズ（<10KB）？ → 静的インポート
-   ```
-
-   **動的インポートオプション**:
-   - `ssr: false` - クライアントサイドのみレンダリング
-   - `loading` - ロード中のフォールバックコンポーネント
-   - Named Exports - 特定の export のみ動的インポート
-
-4. **キャッシュ戦略の選定**
-
-   **レンダリング戦略判断フロー**:
-   ```
-   このページは...
-   ├─ 完全静的コンテンツ？
-   │  └─ Yes → Static Generation（force-static）
-   ├─ 定期更新が必要？
-   │  └─ Yes → ISR（revalidate: 秒数）
-   ├─ リクエスト毎に変化？
-   │  └─ Yes → Dynamic Rendering（force-dynamic）
-   └─ ユーザー固有データ？
-      └─ Yes → Dynamic Rendering + cookies/headers
-   ```
-
-   **On-demand Revalidation 判断**:
-   - CMS更新時の即座反映: revalidatePath() / revalidateTag()
-   - ユーザーアクション後の更新: Server Actions + revalidate
-   - Webhook連携: API Route + revalidate
+1. 画像をnext/imageで最適化
+2. フォントをnext/fontで最適化
+3. Streaming SSRとSuspense境界を設計
+4. 大きなコンポーネントを動的インポート
+5. キャッシュ戦略を設定
 
 **検証ゲート**:
-- [ ] すべての画像がnext/imageで最適化されている
+- [ ] 画像がnext/imageで最適化されている
 - [ ] フォントがnext/fontで最適化されている
-- [ ] 適切なloading.tsxが実装されている（非同期ページ）
-- [ ] 大きなクライアントコンポーネントが動的インポートされている
-- [ ] キャッシュ戦略が適切に設定されている（static/dynamic/ISR）
-- [ ] LCP（Largest Contentful Paint）< 2.5s を目標
-- [ ] CLS（Cumulative Layout Shift）< 0.1 を目標
-- [ ] TTI（Time to Interactive）< 3.8s を目標
+- [ ] 適切なloading.tsxが実装されている
+- [ ] LCP < 2.5s、CLS < 0.1 を目標
 
-### Phase 4: Metadata APIとSEO設定
+### Phase 4: Metadata API / SEO設定
 
 **入力**: 実装済みページ、SEO要件
-**出力**: 完全なメタデータ設定、OGP画像
+**出力**: メタデータ設定、OGP、構造化データ
+
+**スキル参照**:
+```bash
+cat .claude/skills/seo-optimization/SKILL.md
+cat .claude/skills/seo-optimization/resources/metadata-api-guide.md
+cat .claude/skills/seo-optimization/resources/ogp-twitter-cards.md
+cat .claude/skills/seo-optimization/templates/metadata-template.md
+```
 
 **実行ステップ**:
-
-1. **Root Layoutのデフォルトメタデータ設計**
-
-   **設定すべき項目**:
-   - **title**: デフォルトとテンプレート（`%s | Site Name` 形式）
-   - **description**: サイト全体の説明（150-160文字）
-   - **openGraph**: type、locale、url、siteName、images
-   - **twitter**: card（summary_large_image）、site、creator
-   - **robots**: index/noindex、follow/nofollow
-   - **viewport**: width=device-width, initial-scale=1
-   - **icons**: favicon、apple-touch-icon
-
-   **階層的継承の理解**:
-   - Root Layout のメタデータは全ページのデフォルト
-   - 各ページで上書き可能（マージされる）
-   - title.template を使用して一貫性を保つ
-
-2. **各ページの動的メタデータ生成**
-
-   **generateMetadata() 実装パターン**:
-   - 動的パラメータ（params、searchParams）からデータ取得
-   - 非同期データフェッチ（await fetch または DB クエリ）
-   - SEO最適化されたメタデータオブジェクトを返却
-
-   **動的メタデータ判断**:
-   ```
-   このページは...
-   ├─ 動的ルート（[slug]等）？ → generateMetadata() 必須
-   ├─ 外部データ依存？ → generateMetadata() 推奨
-   ├─ 完全静的？ → export const metadata 使用
-   └─ ユーザー固有？ → generateMetadata() + cookies/headers
-   ```
-
-3. **SEOチェックリスト実行**
-
-   **必須項目**:
-   - [ ] すべてのページに固有のtitle（重複なし）
-   - [ ] description は150-160文字で最適化
-   - [ ] OGP画像が1200x630pxで設定（各ページ固有）
-   - [ ] Canonical URL が正しく設定
-   - [ ] robots メタタグが適切（index/noindex）
-   - [ ] alternates で多言語対応（該当する場合）
-
-   **推奨項目**:
-   - [ ] Twitter Card 設定（summary_large_image）
-   - [ ] JSON-LD 構造化データ（該当する場合）
-   - [ ] sitemap.xml 自動生成（app/sitemap.ts）
-   - [ ] robots.txt 設定（app/robots.ts）
-
-4. **Sitemap と Robots.txt 生成**
-
-   **Sitemap生成判断**:
-   - 静的ページ: ビルド時に生成
-   - 動的ページ: データベースから URL 一覧を取得
-   - 優先度と更新頻度を設定
-   - 最終更新日（lastModified）を含める
-
-   **Robots.txt設定**:
-   - クロール許可/禁止のルール
-   - Sitemap URL の指定
-   - ユーザーエージェント別の設定
+1. Root Layoutにデフォルトメタデータを設定
+2. 各ページに動的メタデータを実装
+3. OGP画像とTwitter Cardを設定
+4. 構造化データ（JSON-LD）を追加
+5. sitemap.tsとrobots.tsを作成
 
 **検証ゲート**:
 - [ ] すべてのページにMetadata設定がある
-- [ ] OGPプレビューが正常に表示される（Twitter Card Validator等で確認）
-- [ ] SEOチェックリストがすべて完了している
-- [ ] sitemap.xml が自動生成されている（app/sitemap.ts）
-- [ ] robots.txt が設定されている（app/robots.ts）
-- [ ] title の重複がない（各ページ固有）
-- [ ] Canonical URL が正しく設定されている
+- [ ] OGPプレビューが正常に表示される
+- [ ] sitemap.xmlが自動生成されている
+- [ ] robots.txtが設定されている
 
-### Phase 5: エラーハンドリングとUX
+### Phase 5: エラーハンドリング
 
 **入力**: 実装済みアプリケーション
 **出力**: error.tsx、not-found.tsx、loading.tsx
 
+**スキル参照**:
+```bash
+cat .claude/skills/error-handling-pages/SKILL.md
+cat .claude/skills/error-handling-pages/resources/error-tsx-guide.md
+cat .claude/skills/error-handling-pages/templates/error-page-template.md
+```
+
 **実行ステップ**:
-
-1. **エラー境界の階層設計**
-
-   **error.tsx の配置判断**:
-   ```
-   エラー境界をどこに配置？
-   ├─ 全アプリケーション → app/error.tsx（ルートレベル）
-   ├─ 特定セグメント → app/[segment]/error.tsx
-   ├─ グループ単位 → app/(group)/error.tsx
-   └─ ルートLayout → app/global-error.tsx（特殊ケース）
-   ```
-
-   **error.tsx 実装原則**:
-   - "use client" ディレクティブが必須（Client Component）
-   - error プロパティ: Error オブジェクト（message、digest）
-   - reset() 関数: エラー境界をリセット、再試行ボタンに使用
-   - ユーザーフレンドリーなエラーメッセージ
-   - エラーログの送信（オプション）
-
-2. **404ページの実装原則**
-
-   **not-found.tsx の役割**:
-   - 存在しないルートへのアクセス時に表示
-   - notFound() 関数で明示的にトリガー可能
-   - ユーザーに代替アクションを提示（ホームに戻る、検索等）
-   - 404 HTTPステータスコードを返す
-
-   **UX設計ポイント**:
-   - 分かりやすいエラーメッセージ
-   - ナビゲーションリンク（ホーム、主要ページ）
-   - 検索機能（該当する場合）
-   - ブランド一貫性のあるデザイン
-
-3. **Loading UIの設計**
-
-   **loading.tsx の役割**:
-   - 自動Suspense境界として機能
-   - 非同期Server Componentのフォールバック
-   - ページ全体またはセグメント単位
-
-   **Skeleton UI設計原則**:
-   - 実際のコンテンツ構造を反映
-   - アニメーション効果で進行中を明示
-   - CLS（Cumulative Layout Shift）を最小化
-   - グリッドレイアウト、カードデザインを模倣
-
-   **loading.tsx 配置判断**:
-   ```
-   このページは...
-   ├─ 非同期データフェッチあり？ → loading.tsx 推奨
-   ├─ 複数の非同期コンポーネント？ → 手動Suspense併用
-   ├─ 同期レンダリング？ → loading.tsx 不要
-   └─ 段階的表示？ → 手動Suspense + 複数fallback
-   ```
-
-4. **ユーザーフローテスト**
-
-   **テストシナリオ**:
-   - **正常フロー**: すべてのページが正常に表示される
-   - **エラーフロー**: エラー発生時に error.tsx が表示される
-   - **404フロー**: 存在しないURLで not-found.tsx が表示される
-   - **ロードフロー**: 非同期ページで loading.tsx が表示される
-   - **回復フロー**: reset() ボタンでエラーから回復できる
-
-   **検証ポイント**:
-   - Loading状態の自然な表示（Skeleton UIの適切性）
-   - エラーメッセージの分かりやすさ
-   - 回復フローの使いやすさ（再試行ボタン）
-   - ナビゲーションの一貫性
+1. app/error.tsxを作成（グローバル）
+2. app/not-found.tsxを作成
+3. 重要なルートに個別error.tsxを作成
+4. loading.tsxを非同期ページに追加
+5. ユーザーフローをテスト
 
 **検証ゲート**:
-- [ ] error.tsx が適切な階層に配置されている
-- [ ] not-found.tsx が実装されている
-- [ ] loading.tsx がすべての非同期ページに存在する
-- [ ] エラー状態のUXが自然である（ユーザーフレンドリー）
-- [ ] reset() 関数が適切に機能する
-- [ ] Skeleton UIが実際のコンテンツ構造を反映している
-- [ ] すべてのユーザーフローがテストされている
+- [ ] error.tsxが適切な階層に配置されている
+- [ ] not-found.tsxが実装されている
+- [ ] loading.tsxがすべての非同期ページに存在する
+- [ ] reset()関数が適切に機能する
 
 ## 概念的フレームワーク
 
-### Server/Client判断の意思決定木
-
-```
-このコンポーネントは...
-
-1. データフェッチが必要？
-   ├─ YES
-   │  ├─ サーバー専用リソース（DB、ファイルシステム）？
-   │  │  └─ Server Component（async/await）
-   │  └─ 外部API + クライアントインタラクション？
-   │     └─ Server Component + Client Component（子に分離）
-   └─ NO → 次へ
-
-2. インタラクティブ性が必要？
-   ├─ YES
-   │  ├─ onClick、onChange等のイベントハンドラ？
-   │  │  └─ Client Component（"use client"）
-   │  ├─ useState、useEffect等のReact Hooks？
-   │  │  └─ Client Component
-   │  └─ Context、Custom Hooks？
-   │     └─ Client Component（Providerは分離）
-   └─ NO → 次へ
-
-3. ブラウザAPIが必要？
-   ├─ YES（window、localStorage、document等）
-   │  └─ Client Component
-   └─ NO → Server Component（デフォルト）
-
-最適化チェック:
-- Client Componentは可能な限り下層に配置？
-- Server ComponentをClient Componentのchildren propsで渡している？
-- Context Providerは専用Client Componentに分離？
-```
-
 ### パフォーマンス最適化の優先順位
 
-```
-Priority 0: 基礎最適化（必須）
-├─ Server Components First
-├─ next/image（自動最適化）
-├─ next/font（自動最適化）
-└─ Metadata API（SEO基礎）
+**P0: 必須最適化**
+- Server Componentsをデフォルト
+- 静的コンテンツはStatic Generation
+- 画像にnext/image、フォントにnext/font
+- Metadata APIでSEO設定
 
-Priority 1: レンダリング最適化（推奨）
-├─ Static Generation（静的コンテンツ）
-├─ ISR（定期更新コンテンツ、revalidate設定）
-├─ Streaming SSR（大量データ、loading.tsx）
-└─ Suspense境界（段階的レンダリング）
+**P1: 推奨最適化**
+- Streaming SSRでloading.tsx実装
+- Suspense境界で段階的レンダリング
+- Dynamic Importで動的読み込み
+- Route Groupsで論理分割
 
-Priority 2: コード最適化（高度）
-├─ Dynamic Import（大きなClient Components）
-├─ Bundle分析（@next/bundle-analyzer）
-├─ Prefetch制御（Link component）
-└─ Route最適化（Parallel Routes、Intercepting Routes）
+**P2: 高度な最適化**
+- ISRでrevalidate設定
+- Intercepting Routesでモーダル最適化
+- Prefetch最適化
+- Bundle分析
 
-評価指標:
-- LCP（Largest Contentful Paint）< 2.5s
-- FID（First Input Delay）< 100ms
-- CLS（Cumulative Layout Shift）< 0.1
-- TTI（Time to Interactive）< 3.8s
-```
+### 評価指標
 
-### Layout設計の原則
-
-```
-Layout階層の判断:
-
-Root Layout（app/layout.tsx）
-├─ 目的: HTML構造、グローバル設定
-├─ 含めるもの:
-│  ├─ <html>、<body>タグ
-│  ├─ グローバルスタイル
-│  ├─ フォント設定
-│  ├─ Metadata（サイト全体デフォルト）
-│  └─ グローバルプロバイダー（Theme、Auth等）
-└─ 含めないもの: ページ固有UI、ナビゲーション
-
-グループLayout（(group)/layout.tsx）
-├─ 目的: 共有UIとロジック
-├─ 含めるもの:
-│  ├─ 共通ナビゲーション
-│  ├─ サイドバー
-│  ├─ 認証境界
-│  └─ グループ固有プロバイダー
-└─ 判断基準:
-   ├─ 複数ページで共有するUI？ → YES: Group Layout
-   ├─ 認証状態で分離？ → YES: (auth)、(dashboard)
-   └─ レイアウトが異なる？ → YES: 別Group Layout
-
-Layoutの最適化:
-- Layoutは再レンダリングされない（ナビゲーション時）
-- 重いロジックはLayoutに配置（1回のみ実行）
-- ページ固有の状態はPageコンポーネントで管理
-```
-
-## テストケース
-
-### ケース1: ブログアプリケーションのルーティング実装
-
-**入力要件**:
-
-**機能要件**:
-- トップページ（/）
-- ブログ一覧（/blog）
-- ブログ記事詳細（/blog/[slug]）
-- タグ別記事一覧（/blog/tag/[tag]）
-- 著者プロフィール（/author/[id]）
-- 管理画面（/admin/*）- 認証必須
-
-**非機能要件**:
-- SEO最適化（すべてのページ）
-- OGP画像生成（記事詳細）
-- ISR（記事は1時間毎に更新）
-- 管理画面はDynamic Rendering
-
-**期待される設計プロセス**:
-
-**Phase 1: ルーティング構造設計**
-
-1. **URL階層の分析と設計判断**:
-   - トップページ: 静的コンテンツ → Static Generation
-   - ブログ関連: 定期更新 → ISR（revalidate: 3600）
-   - 管理画面: ユーザー固有データ → Dynamic Rendering
-   - 動的ルートの識別: [slug]、[tag]、[id]
-
-2. **ルートグループによる論理分離**:
-   - 認証状態で分離: (public) と (admin)
-   - レイアウト共有の最適化: グループ単位で共通UI
-   - 認証境界の明確化: (admin) グループに AuthGuard
-
-3. **レンダリング戦略の選定**:
-   - 静的コンテンツ: Static Generation
-   - 定期更新: ISR（revalidate設定）
-   - リクエスト毎変化: Dynamic Rendering
-   - 認証必須: Dynamic Rendering + 認証チェック
-
-4. **ディレクトリ構造の設計原則**:
-   - ルートグループによる認証境界: (public)、(admin)
-   - 動的セグメントの配置: [slug]、[tag]、[id]
-   - 特殊ファイルの配置: layout.tsx、page.tsx、error.tsx、not-found.tsx
-   - 階層的な構造: ネストされたレイアウトとページ
-
-**Phase 2: Server/Client Components実装**
-
-1. **Layout階層の実装判断**:
-   - Root Layout: フォント設定（next/font）、グローバルメタデータ、HTML構造
-   - 公開サイトLayout: 共通UI（ヘッダー、フッター）を(public)グループに配置
-   - 管理画面Layout: 認証境界（AuthGuard）を(admin)グループに配置
-
-2. **Server Component優先実装**:
-   - 記事詳細ページ: async/await でデータフェッチ、Server Component
-   - generateStaticParams() で静的パス生成
-   - generateMetadata() で動的メタデータ生成（OGP画像含む）
-   - notFound() で404ハンドリング
-
-3. **Client Component分離**:
-   - 認証ガード: "use client" でClient Component化
-   - useSession() などのReact Hooks使用
-   - 認証状態チェック後のリダイレクト処理
-
-4. **ISR設定**:
-   - 記事ページに revalidate: 3600 設定（1時間毎更新）
-   - 管理画面に dynamic: 'force-dynamic' 設定
-
-**Phase 3: パフォーマンス最適化**
-
-1. **画像最適化の適用**:
-   - next/image で自動最適化
-   - priority 属性で Above the fold 画像を優先
-   - width/height 指定で CLS 防止
-
-2. **Streaming SSR実装**:
-   - Suspense境界でPostListコンポーネントをラップ
-   - PostListSkeletonをfallbackとして提供
-   - 段階的レンダリングによるTTI短縮
-
-**Phase 4: Metadata APIとSEO設定**
-
-1. **動的メタデータ実装**:
-   - 各記事のtitle、description、OGP画像を動的生成
-   - article typeのopenGraph設定
-   - publishedTime でSEO強化
-
-2. **Sitemap自動生成**:
-   - app/sitemap.ts でサイトマップ定義
-   - getAllPosts()でデータベースから記事一覧取得
-   - 優先度と更新頻度を適切に設定
-
-**Phase 5: エラーハンドリングとUX**
-
-1. **404ページ実装**:
-   - app/not-found.tsx でカスタム404ページ
-   - ユーザーフレンドリーなメッセージとナビゲーション
-
-2. **エラー境界実装**:
-   - app/error.tsx でエラーハンドリング
-   - reset()関数で再試行機能
-   - ユーザーに分かりやすいエラーメッセージ
-
-**期待される成果物の特性**:
-- **構造的品質**: ルートグループによる明確な認証境界、動的ルートの適切な配置
-- **Server Components優先**: デフォルトでServer Components、Client Componentsは認証ガードのみ
-- **ISR設定**: 記事ページにrevalidate設定、管理画面はDynamic Rendering
-- **Metadata統合**: 動的メタデータ生成、OGP画像設定、Sitemap自動生成
-- **エラーハンドリング**: 404ページ、エラー境界、ユーザーフレンドリーなUX
-- **パフォーマンス**: LCP < 2.5s、CLS < 0.1、TTI < 3.8s を達成
-
-### ケース2: ダッシュボードアプリケーション（並列ルート）
-
-**入力要件**:
-
-**機能要件**:
-- ダッシュボード（/dashboard）
-- 複数のパネルを同時表示:
-  - 統計パネル（@stats）
-  - アクティビティフィード（@activity）
-  - 通知パネル（@notifications）
-- 各パネルは独立してローディング状態を持つ
-- モーダルでユーザー詳細表示（Intercepting Routes）
-
-**期待される設計プロセス**:
-
-**Phase 1: 並列ルート構造設計**
-
-1. **並列ルート（Parallel Routes）の判断**:
-   - 複数のパネルを同時レンダリング → 並列ルート使用
-   - 各パネルは独立したデータフェッチ → @stats、@activity、@notifications
-   - 独立したローディング状態 → 各ルートにloading.tsx配置
-
-2. **Intercepting Routesの設計**:
-   - モーダル表示要件 → (..)構文でインターセプト
-   - ユーザー詳細 → (..)users/[id]/page.tsx
-   - 直接アクセスとインターセプトの両立
-
-**Phase 2: Layout実装**
-
-1. **並列ルートLayoutの実装判断**:
-   - Layout propsで並列ルートを受け取る（stats、activity、notifications）
-   - Grid Layoutで複数パネルを配置
-   - 各パネルは独立してレンダリング
-
-2. **独立したローディング状態**:
-   - 各並列ルート配下にloading.tsx配置
-   - Suspense境界が自動的に作成される
-   - パネル毎に異なるSkeleton UI
-
-**Phase 3: Intercepting Routes実装**
-
-1. **モーダル実装の判断**:
-   - (..)構文でインターセプト設定
-   - Modalコンポーネントでオーバーレイ表示
-   - Server Componentでデータフェッチ（getUserById）
-
-**期待される成果物の特性**:
-- **並列ルート**: @stats、@activity、@notifications が独立してレンダリング
-- **独立ローディング**: 各パネルが個別のloading.tsx を持つ
-- **Intercepting Routes**: (..)構文でモーダル表示が動作
-- **パフォーマンス**: 並列データフェッチによる高速化
-
-### ケース3: 多言語対応サイト
-
-**入力要件**:
-
-**機能要件**:
-- 日本語（/ja/*）と英語（/en/*）の2言語対応
-- 各言語で独立したルーティング
-- 言語切り替えUI
-- SEOのための言語代替タグ（hreflang）
-
-**期待される設計プロセス**:
-
-**Phase 1: 多言語ルーティング構造設計**
-
-1. **動的セグメント設計**:
-   - 言語コードを動的セグメント化 → [lang]
-   - すべてのページを[lang]配下に配置
-   - generateStaticParams()で対応言語を生成
-
-2. **URL構造の設計判断**:
-   - /ja/*, /en/* 形式でURLパス統一
-   - 各言語で同一のページ構造
-   - デフォルト言語の処理（リダイレクト or デフォルト表示）
-
-**Phase 2: 言語パラメータ処理**
-
-1. **Layout実装の判断**:
-   - [lang]/layout.tsx で言語別HTML lang属性設定
-   - generateStaticParams()で対応言語リスト生成
-   - 言語別フォント、スタイル設定（必要に応じて）
-
-2. **言語切り替えUI**:
-   - Client Componentで言語選択メニュー実装
-   - 現在のパスを保持して言語のみ変更
-   - ユーザー選択を保存（Cookie or localStorage）
-
-**Phase 3: Metadata APIとhreflang設定**
-
-1. **hreflang設定の実装**:
-   - alternates.canonical でカノニカルURL設定
-   - alternates.languages で言語別URL設定
-   - 各言語ページに相互参照リンク
-
-2. **言語別メタデータ**:
-   - title、descriptionを言語別に設定
-   - 言語別OGP画像（該当する場合）
-   - robots設定は言語共通
-
-**期待される成果物の特性**:
-- **多言語ルーティング**: [lang]動的セグメントで言語別URL生成
-- **hreflang設定**: alternates.languages で言語代替タグ設定
-- **言語切り替えUI**: ユーザーが言語を選択できるUI実装
-- **SEO最適化**: 各言語ページが独立してインデックス可能
+| 指標 | 良好 | 改善が必要 | 不良 |
+|------|------|-----------|------|
+| LCP | ≤2.5s | ≤4.0s | >4.0s |
+| FID | ≤100ms | ≤300ms | >300ms |
+| CLS | ≤0.1 | ≤0.25 | >0.25 |
 
 ## 制約と境界
 
@@ -976,70 +307,94 @@ Layoutの最適化:
 - Next.js App Routerのベストプラクティスに従う
 - Server Componentsをデフォルトとする
 - パフォーマンスとSEOを最優先する
-- Guillermo Rauchの設計思想を反映する
+- スキルの詳細知識を活用する
 
 ### 実行しないこと
 - Pages Router（旧システム）の使用
 - Client Componentsの過度な使用
 - getServerSideProps、getStaticProps等のレガシーAPI
-- カスタムルーティングロジック（Next.js規約に従う）
+- カスタムルーティングロジック
 
 ### 依存関係
-- **上流**: @req-analystによる要件定義、UI設計
-- **下流**: @component-builderによるコンポーネント実装、@state-managerによる状態管理
-- **ツール**: next/image、next/font、Metadata API
+- **上流**: 要件定義、UI設計
+- **下流**: コンポーネント実装、状態管理
+- **スキル**: nextjs-app-router、server-components-patterns、seo-optimization、web-performance、error-handling-pages
 
 ### 成果物
 - `src/app/`配下のルーティング構造
-- `docs/architecture/routing-structure.md`（設計ドキュメント）
 - Metadata設定とSEO最適化
 - エラーハンドリングUI
+- パフォーマンス最適化
 
 ## コマンドリファレンス
 
-このエージェントで使用可能なリソース、スクリプト、テンプレートへのアクセスコマンド:
-
-### スキル読み込み（必要に応じて）
+### スキル読み込み
 
 ```bash
-# アジャイルプロジェクト管理（技術スタック理解、アーキテクチャ整合性）
-cat .claude/skills/agile-project-management/SKILL.md
+# ルーティング構造設計
+cat .claude/skills/nextjs-app-router/SKILL.md
 
-# コンテキスト最適化（トークン効率、大規模操作）
-cat .claude/skills/context-optimization/SKILL.md
+# Server/Client分離の詳細
+cat .claude/skills/nextjs-app-router/resources/server-client-decision.md
 
-# コマンドパフォーマンス最適化（並列処理、リソース管理）
-cat .claude/skills/command-performance-optimization/SKILL.md
+# データフェッチパターン
+cat .claude/skills/server-components-patterns/resources/data-fetching-patterns.md
+
+# Metadata API
+cat .claude/skills/seo-optimization/resources/metadata-api-guide.md
+
+# 動的インポート
+cat .claude/skills/web-performance/resources/dynamic-import.md
+
+# エラーページ実装
+cat .claude/skills/error-handling-pages/resources/error-tsx-guide.md
 ```
 
-### TypeScriptスクリプト実行
+### 分析スクリプト実行
 
 ```bash
-# トークン見積もり
-node .claude/skills/context-optimization/scripts/estimate-tokens.mjs src/app/**/*.tsx
+# ルーティング構造分析
+node .claude/skills/nextjs-app-router/scripts/analyze-routing-structure.mjs src/app
 
-# エージェント構造検証
-node .claude/skills/agent-structure-design/scripts/validate-structure.mjs .claude/agents/router-dev.md
+# データフェッチ分析
+node .claude/skills/server-components-patterns/scripts/analyze-data-fetching.mjs src/app/page.tsx
+
+# SEO分析
+node .claude/skills/seo-optimization/scripts/analyze-seo.mjs src/app
+
+# バンドル分析
+node .claude/skills/web-performance/scripts/analyze-bundle.mjs .next
+
+# エラーハンドリングチェック
+node .claude/skills/error-handling-pages/scripts/check-error-handling.mjs src/app
+```
+
+### テンプレート参照
+
+```bash
+# ページテンプレート
+cat .claude/skills/nextjs-app-router/templates/page-template.md
+
+# レイアウトテンプレート
+cat .claude/skills/nextjs-app-router/templates/layout-template.md
+
+# データフェッチテンプレート
+cat .claude/skills/server-components-patterns/templates/data-fetch-template.md
+
+# メタデータテンプレート
+cat .claude/skills/seo-optimization/templates/metadata-template.md
+
+# 動的インポートテンプレート
+cat .claude/skills/web-performance/templates/dynamic-import-template.md
+
+# エラーページテンプレート
+cat .claude/skills/error-handling-pages/templates/error-page-template.md
 ```
 
 ## 変更履歴
 
-### v2.0.0 (2025-11-22)
-- **改善**: 抽象度の最適化とプロジェクト固有設計原則の統合
-  - 具体的なTypeScriptコード例を削除（約1200行削減）、概念要素とチェックリストに置き換え
-  - descriptionフィールドにプロジェクト固有設計への言及を追加
-  - 知識領域6を追加: プロジェクト固有の設計原則
-    - ハイブリッドアーキテクチャ統合（app/ → features/ → shared/）
-    - API設計との統合（RESTful、HTTPステータスコード、レスポンス形式）
-    - テスト戦略（TDD原則、ユニット/統合/E2E分離）
-  - master_system_design.mdの概念を反映
-  - Phase 2-5の実装ステップを判断フレームワークとチェックリストに変更
-  - テストケース1-3を抽象的な要件記述と期待される成果物の特性に変更
-  - データフェッチパターン、Layout設計、エラーハンドリングの判断フレームワーク追加
-  - プロジェクトアーキテクチャ準拠チェックリスト追加（7項目）
-
-### v1.0.0 (初版)
-- Guillermo Rauchの設計思想に基づくApp Router実装エージェント
-- Server/Client Components分離、パフォーマンス最適化、Metadata API統合
-- 5段階のワークフロー（ルーティング構造設計 → 実装 → 最適化 → SEO → エラーハンドリング）
-- 3つのテストケース（ブログ、ダッシュボード、多言語対応）
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 3.0.0 | 2025-11-25 | スキル分離による軽量化。5つの専門スキルを統合。1046行→約500行に削減。 |
+| 2.0.0 | 2025-11-22 | 抽象度の最適化とプロジェクト固有設計原則の統合 |
+| 1.0.0 | 初版 | Guillermo Rauchの設計思想に基づくApp Router実装エージェント |

--- a/.claude/skills/error-handling-pages/SKILL.md
+++ b/.claude/skills/error-handling-pages/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: error-handling-pages
+description: |
+  Next.js App Routerのエラーハンドリングを専門とするスキル。
+  error.tsx、not-found.tsx、global-error.tsxを使用したエラー境界とリカバリーを実現します。
+
+  専門分野:
+  - error.tsx: ルートセグメントのエラー境界、リトライ機能
+  - not-found.tsx: 404エラーページ、notFound()関数
+  - global-error.tsx: アプリケーション全体のエラーハンドリング
+  - loading.tsx: ローディング状態の管理
+
+  使用タイミング:
+  - エラーページを実装する時
+  - 404ページをカスタマイズする時
+  - グローバルエラーハンドリングを設定する時
+  - ローディング状態を実装する時
+
+  Use proactively when implementing error boundaries, 404 pages,
+  or global error handling in Next.js applications.
+version: 1.0.0
+---
+
+# Error Handling Pages
+
+## 概要
+
+このスキルは、Next.js App Routerにおけるエラーハンドリングの
+ベストプラクティスを提供します。ユーザーフレンドリーなエラー体験と
+適切なリカバリーメカニズムを実現します。
+
+**核心哲学**:
+- **Graceful Degradation**: エラー発生時も可能な限り機能を維持
+- **User-Friendly**: 技術的詳細を隠し、ユーザーに分かりやすいメッセージを表示
+- **Recovery-Oriented**: エラーからの復帰方法を提供
+
+**主要な価値**:
+- React Error Boundariesを活用した堅牢なエラーハンドリング
+- セグメントレベルでのエラー分離
+- ユーザーフレンドリーなエラー体験
+
+## リソース構造
+
+```
+error-handling-pages/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── error-tsx-guide.md                      # error.tsx ガイド
+│   ├── not-found-guide.md                      # not-found.tsx ガイド
+│   ├── global-error-guide.md                   # global-error.tsx ガイド
+│   └── loading-tsx-guide.md                    # loading.tsx ガイド
+├── scripts/
+│   └── check-error-handling.mjs                # エラーハンドリングチェック
+└── templates/
+    ├── error-page-template.md                  # エラーページテンプレート
+    └── not-found-template.md                   # 404ページテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# error.tsx ガイド
+cat .claude/skills/error-handling-pages/resources/error-tsx-guide.md
+
+# not-found.tsx ガイド
+cat .claude/skills/error-handling-pages/resources/not-found-guide.md
+
+# global-error.tsx ガイド
+cat .claude/skills/error-handling-pages/resources/global-error-guide.md
+
+# loading.tsx ガイド
+cat .claude/skills/error-handling-pages/resources/loading-tsx-guide.md
+```
+
+### スクリプト実行
+
+```bash
+# エラーハンドリング設定チェック
+node .claude/skills/error-handling-pages/scripts/check-error-handling.mjs <app-directory>
+```
+
+### テンプレート参照
+
+```bash
+# エラーページテンプレート
+cat .claude/skills/error-handling-pages/templates/error-page-template.md
+
+# 404ページテンプレート
+cat .claude/skills/error-handling-pages/templates/not-found-template.md
+```
+
+## いつ使うか
+
+### シナリオ1: ルートエラーハンドリング
+**状況**: 特定のルートでエラーが発生した場合の処理を実装する
+
+**適用条件**:
+- [ ] 特定のセグメントでエラーを捕捉したい
+- [ ] リトライ機能を提供したい
+- [ ] エラー時も他のセグメントは正常に表示したい
+
+**期待される成果**: 局所的なエラー捕捉とリカバリー
+
+### シナリオ2: 404ページのカスタマイズ
+**状況**: 存在しないページへのアクセス時の表示をカスタマイズする
+
+**適用条件**:
+- [ ] ブランドに合った404ページを作成したい
+- [ ] 動的ルートでnotFound()を使用したい
+- [ ] 有用なナビゲーションを提供したい
+
+**期待される成果**: ユーザーフレンドリーな404体験
+
+### シナリオ3: グローバルエラーハンドリング
+**状況**: Root Layout含むアプリ全体のエラーを処理する
+
+**適用条件**:
+- [ ] Root Layoutのエラーを捕捉したい
+- [ ] 最終的なフォールバックを提供したい
+- [ ] クリティカルエラーをログに記録したい
+
+**期待される成果**: アプリ全体のエラー安全性
+
+## 知識領域
+
+### 領域1: error.tsx
+
+**基本構造**:
+```typescript
+'use client'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>エラーが発生しました</h2>
+      <button onClick={() => reset()}>再試行</button>
+    </div>
+  )
+}
+```
+
+**詳細は**: `resources/error-tsx-guide.md` を参照
+
+### 領域2: not-found.tsx
+
+**基本構造**:
+```typescript
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div>
+      <h2>ページが見つかりません</h2>
+      <Link href="/">ホームに戻る</Link>
+    </div>
+  )
+}
+```
+
+**詳細は**: `resources/not-found-guide.md` を参照
+
+### 領域3: global-error.tsx
+
+**基本構造**:
+```typescript
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html>
+      <body>
+        <h2>深刻なエラーが発生しました</h2>
+        <button onClick={() => reset()}>再試行</button>
+      </body>
+    </html>
+  )
+}
+```
+
+**詳細は**: `resources/global-error-guide.md` を参照
+
+### 領域4: loading.tsx
+
+**基本構造**:
+```typescript
+export default function Loading() {
+  return <div>読み込み中...</div>
+}
+```
+
+**詳細は**: `resources/loading-tsx-guide.md` を参照
+
+## ファイル階層とスコープ
+
+```
+app/
+├── layout.tsx
+├── error.tsx          # /以下すべてのエラーを捕捉（Root Layout除く）
+├── not-found.tsx      # グローバル404
+├── global-error.tsx   # Root Layout含むすべてのエラー
+├── loading.tsx        # グローバルローディング
+├── page.tsx
+└── dashboard/
+    ├── layout.tsx
+    ├── error.tsx      # /dashboard以下のエラーを捕捉
+    ├── not-found.tsx  # /dashboard専用404
+    ├── loading.tsx    # /dashboard専用ローディング
+    └── page.tsx
+```
+
+## ワークフロー
+
+### Phase 1: 要件分析
+1. エラーハンドリングが必要なルートを特定
+2. エラーの種類を分類（認証、データ、システム等）
+3. リカバリー戦略を決定
+
+### Phase 2: 基本実装
+1. app/error.tsxを作成（グローバル）
+2. app/not-found.tsxを作成
+3. app/global-error.tsxを作成
+
+### Phase 3: セグメント別実装
+1. 重要なルートに個別error.tsxを作成
+2. 動的ルートにnot-found.tsxを作成
+3. loading.tsxを必要なセグメントに追加
+
+### Phase 4: テスト
+1. エラーケースのテスト
+2. リトライ機能のテスト
+3. ユーザー体験の確認
+
+### Phase 5: 監視
+1. エラーログの設定
+2. エラーレポーティング統合
+3. 継続的な改善
+
+## 設計原則
+
+### エラー分離の原則
+エラーは可能な限り局所的に捕捉し、他の部分への影響を最小化する。
+
+### リカバリーの原則
+単なるエラー表示ではなく、ユーザーが次に何をすべきか明示する。
+
+### ログの原則
+ユーザーには友好的なメッセージを、開発者には詳細なエラー情報を。
+
+### 階層の原則
+より具体的なerror.tsxが優先される。グローバルはフォールバック。
+
+## 関連スキル
+
+- `.claude/skills/nextjs-app-router/SKILL.md` - ルーティング構造
+- `.claude/skills/server-components-patterns/SKILL.md` - データフェッチエラー
+- `.claude/skills/web-performance/SKILL.md` - ローディング最適化
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/error-handling-pages/resources/error-tsx-guide.md
+++ b/.claude/skills/error-handling-pages/resources/error-tsx-guide.md
@@ -1,0 +1,354 @@
+# error.tsx ガイド
+
+## 概要
+
+`error.tsx`はReact Error Boundaryをラップし、ルートセグメント内の
+エラーを捕捉します。エラーを局所化し、アプリの他の部分は正常に
+動作し続けることができます。
+
+## 基本構造
+
+```typescript
+// app/error.tsx
+'use client' // Error componentsはClient Componentでなければならない
+
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // エラーをログサービスに送信
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h2 className="text-2xl font-bold mb-4">エラーが発生しました</h2>
+      <p className="text-gray-600 mb-6">
+        申し訳ございません。予期しないエラーが発生しました。
+      </p>
+      <button
+        onClick={() => reset()}
+        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        再試行
+      </button>
+    </div>
+  )
+}
+```
+
+## 重要なポイント
+
+### 1. Client Componentが必須
+
+```typescript
+'use client' // 必須！Error BoundaryはClient Componentでのみ機能する
+
+export default function Error({ error, reset }) {
+  // ...
+}
+```
+
+### 2. errorオブジェクト
+
+```typescript
+type ErrorProps = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+// digestはサーバーエラーの安全なハッシュ
+// クライアントに詳細を漏らさずにエラーを追跡できる
+```
+
+### 3. reset関数
+
+```typescript
+// reset()はエラー境界内のコンポーネントを再レンダリングする
+<button onClick={() => reset()}>
+  再試行
+</button>
+
+// または条件付きリセット
+const handleReset = () => {
+  // 状態をクリアしてからリセット
+  clearCache()
+  reset()
+}
+```
+
+## スコープと配置
+
+### 階層構造
+
+```
+app/
+├── layout.tsx        # error.tsxでは捕捉されない
+├── error.tsx         # page.tsx, 子ルートのエラーを捕捉
+├── page.tsx
+└── dashboard/
+    ├── layout.tsx    # 親のerror.tsxで捕捉される
+    ├── error.tsx     # このルート以下のエラーを捕捉
+    ├── page.tsx
+    └── settings/
+        └── page.tsx  # 親のerror.tsxで捕捉される
+```
+
+### 捕捉されるエラー
+
+| ソース | error.tsx で捕捉 |
+|--------|------------------|
+| page.tsx 内のエラー | ✅ |
+| 子ルートのエラー | ✅ |
+| Server Component エラー | ✅ |
+| 同階層の layout.tsx | ❌ |
+| 親の layout.tsx | ❌ |
+| Root Layout | ❌（global-error.tsx必要）|
+
+## エラーの種類別処理
+
+### カスタムエラークラス
+
+```typescript
+// lib/errors.ts
+export class AuthenticationError extends Error {
+  constructor(message: string = 'Authentication required') {
+    super(message)
+    this.name = 'AuthenticationError'
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message: string = 'Resource not found') {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string = 'Validation failed') {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+```
+
+### 種類別のUI
+
+```typescript
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+
+  useEffect(() => {
+    // エラーログ送信
+    logError(error)
+  }, [error])
+
+  // 認証エラー
+  if (error.name === 'AuthenticationError') {
+    return (
+      <div className="text-center p-8">
+        <h2 className="text-xl font-bold mb-4">ログインが必要です</h2>
+        <button
+          onClick={() => router.push('/login')}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          ログインページへ
+        </button>
+      </div>
+    )
+  }
+
+  // バリデーションエラー
+  if (error.name === 'ValidationError') {
+    return (
+      <div className="text-center p-8">
+        <h2 className="text-xl font-bold mb-4">入力エラー</h2>
+        <p className="text-gray-600 mb-4">{error.message}</p>
+        <button onClick={() => reset()} className="text-blue-600">
+          やり直す
+        </button>
+      </div>
+    )
+  }
+
+  // デフォルト
+  return (
+    <div className="text-center p-8">
+      <h2 className="text-xl font-bold mb-4">エラーが発生しました</h2>
+      <p className="text-gray-600 mb-4">
+        予期しないエラーが発生しました。
+      </p>
+      <div className="space-x-4">
+        <button onClick={() => reset()} className="text-blue-600">
+          再試行
+        </button>
+        <button onClick={() => router.push('/')} className="text-gray-600">
+          ホームに戻る
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+## エラーログ統合
+
+### Sentry統合
+
+```typescript
+'use client'
+
+import * as Sentry from '@sentry/nextjs'
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Sentryにエラーを送信
+    Sentry.captureException(error)
+  }, [error])
+
+  return (
+    <div>
+      <h2>エラーが発生しました</h2>
+      <button onClick={() => reset()}>再試行</button>
+      <button onClick={() => Sentry.showReportDialog()}>
+        フィードバックを送る
+      </button>
+    </div>
+  )
+}
+```
+
+### カスタムログサービス
+
+```typescript
+// lib/error-logging.ts
+export async function logError(error: Error & { digest?: string }) {
+  await fetch('/api/log-error', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: error.name,
+      message: error.message,
+      digest: error.digest,
+      stack: error.stack,
+      timestamp: new Date().toISOString(),
+    }),
+  })
+}
+```
+
+## 開発時のデバッグ
+
+### 開発モードでの詳細表示
+
+```typescript
+'use client'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const isDev = process.env.NODE_ENV === 'development'
+
+  return (
+    <div className="p-8">
+      <h2 className="text-xl font-bold mb-4">エラーが発生しました</h2>
+
+      {isDev && (
+        <div className="bg-red-100 p-4 rounded mb-4 text-sm">
+          <p className="font-mono">{error.name}: {error.message}</p>
+          {error.stack && (
+            <pre className="mt-2 overflow-auto max-h-48 text-xs">
+              {error.stack}
+            </pre>
+          )}
+          {error.digest && (
+            <p className="mt-2 text-gray-600">Digest: {error.digest}</p>
+          )}
+        </div>
+      )}
+
+      <button onClick={() => reset()} className="text-blue-600">
+        再試行
+      </button>
+    </div>
+  )
+}
+```
+
+## ベストプラクティス
+
+### 1. ユーザーフレンドリーなメッセージ
+
+```typescript
+// ❌ 技術的すぎる
+<p>Error: ECONNREFUSED 127.0.0.1:3000</p>
+
+// ✅ ユーザー向け
+<p>サーバーに接続できませんでした。しばらくしてから再度お試しください。</p>
+```
+
+### 2. 復帰オプションの提供
+
+```typescript
+<div className="space-y-4">
+  <button onClick={() => reset()}>再試行</button>
+  <button onClick={() => router.back()}>前のページに戻る</button>
+  <button onClick={() => router.push('/')}>ホームに戻る</button>
+  <a href="mailto:support@example.com">サポートに連絡</a>
+</div>
+```
+
+### 3. 視覚的なフィードバック
+
+```typescript
+<div className="flex flex-col items-center">
+  {/* エラーアイコン */}
+  <svg className="w-16 h-16 text-red-500 mb-4" /* ... */ />
+
+  {/* メッセージ */}
+  <h2 className="text-xl font-bold">問題が発生しました</h2>
+
+  {/* アクション */}
+  <button className="mt-4 px-4 py-2 bg-blue-600 text-white rounded">
+    再試行
+  </button>
+</div>
+```
+
+## チェックリスト
+
+- [ ] 'use client'ディレクティブがある
+- [ ] reset関数が提供されている
+- [ ] エラーログが設定されている
+- [ ] ユーザーフレンドリーなメッセージを表示
+- [ ] 復帰オプションを提供
+- [ ] 開発モードでのデバッグ情報を表示（オプション）

--- a/.claude/skills/error-handling-pages/resources/global-error-guide.md
+++ b/.claude/skills/error-handling-pages/resources/global-error-guide.md
@@ -1,0 +1,361 @@
+# global-error.tsx ガイド
+
+## 概要
+
+`global-error.tsx`はRoot Layoutを含むアプリケーション全体のエラーを
+捕捉する最終的なフォールバックです。error.tsxでは捕捉できない
+Root Layoutのエラーもここで処理できます。
+
+## 基本構造
+
+```typescript
+// app/global-error.tsx
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    // global-errorはRoot Layoutを置き換えるため、
+    // html と body タグを含める必要がある
+    <html>
+      <body>
+        <div className="min-h-screen flex flex-col items-center justify-center">
+          <h2 className="text-2xl font-bold">深刻なエラーが発生しました</h2>
+          <p className="text-gray-600 mt-2">
+            アプリケーションに問題が発生しました。
+          </p>
+          <button
+            onClick={() => reset()}
+            className="mt-6 px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            再試行
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}
+```
+
+## 重要な注意点
+
+### 1. html/bodyタグが必須
+
+```typescript
+// ❌ 不完全
+export default function GlobalError({ error, reset }) {
+  return (
+    <div>エラーが発生しました</div>
+  )
+}
+
+// ✅ 正しい
+export default function GlobalError({ error, reset }) {
+  return (
+    <html>
+      <body>
+        <div>エラーが発生しました</div>
+      </body>
+    </html>
+  )
+}
+```
+
+### 2. Client Componentが必須
+
+```typescript
+'use client' // 必須
+
+export default function GlobalError({ error, reset }) {
+  // ...
+}
+```
+
+### 3. 本番環境でのみ有効
+
+```
+開発環境: Next.jsのエラーオーバーレイが表示される
+本番環境: global-error.tsx が表示される
+```
+
+## error.tsxとの違い
+
+| 特性 | error.tsx | global-error.tsx |
+|------|-----------|-----------------|
+| Root Layoutのエラー | ❌ 捕捉不可 | ✅ 捕捉可能 |
+| html/bodyタグ | 不要 | 必須 |
+| 階層配置 | 任意のルートセグメント | app/のみ |
+| Layout継承 | 親Layoutを使用 | 独自のhtml/body |
+| 主な用途 | 特定ルートのエラー | 最終フォールバック |
+
+## エラーハンドリングの階層
+
+```
+┌─────────────────────────────────────────┐
+│           global-error.tsx              │ ← Root Layout含む全エラー
+│  ┌───────────────────────────────────┐  │
+│  │         app/error.tsx             │  │ ← Root Layout以外のエラー
+│  │  ┌─────────────────────────────┐  │  │
+│  │  │    app/blog/error.tsx       │  │  │ ← /blog以下のエラー
+│  │  │  ┌───────────────────────┐  │  │  │
+│  │  │  │  Component Error      │  │  │  │ ← 個別コンポーネント
+│  │  │  └───────────────────────┘  │  │  │
+│  │  └─────────────────────────────┘  │  │
+│  └───────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+## 実装パターン
+
+### 最小限の実装
+
+```typescript
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html>
+      <body>
+        <h2>エラーが発生しました</h2>
+        <button onClick={() => reset()}>再試行</button>
+      </body>
+    </html>
+  )
+}
+```
+
+### フル機能実装
+
+```typescript
+// app/global-error.tsx
+'use client'
+
+import { useEffect } from 'react'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // エラーレポーティングサービスに送信
+    reportError(error)
+  }, [error])
+
+  const handleReload = () => {
+    window.location.reload()
+  }
+
+  const handleHome = () => {
+    window.location.href = '/'
+  }
+
+  return (
+    <html lang="ja">
+      <head>
+        <title>エラーが発生しました</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body style={{
+        margin: 0,
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: 'system-ui, sans-serif',
+        backgroundColor: '#f5f5f5',
+      }}>
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          {/* エラーアイコン */}
+          <div style={{ fontSize: '4rem', marginBottom: '1rem' }}>
+            ⚠️
+          </div>
+
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>
+            問題が発生しました
+          </h1>
+
+          <p style={{ color: '#666', marginBottom: '2rem' }}>
+            アプリケーションに予期しないエラーが発生しました。
+            <br />
+            ご不便をおかけして申し訳ございません。
+          </p>
+
+          {/* デバッグ情報（開発時のみ） */}
+          {process.env.NODE_ENV === 'development' && (
+            <div style={{
+              background: '#fff0f0',
+              padding: '1rem',
+              borderRadius: '0.5rem',
+              marginBottom: '1rem',
+              textAlign: 'left',
+              fontSize: '0.875rem',
+            }}>
+              <strong>{error.name}:</strong> {error.message}
+              {error.digest && (
+                <div style={{ marginTop: '0.5rem', color: '#666' }}>
+                  Digest: {error.digest}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+            <button
+              onClick={() => reset()}
+              style={{
+                padding: '0.75rem 1.5rem',
+                backgroundColor: '#0070f3',
+                color: 'white',
+                border: 'none',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                fontSize: '1rem',
+              }}
+            >
+              再試行
+            </button>
+
+            <button
+              onClick={handleReload}
+              style={{
+                padding: '0.75rem 1.5rem',
+                backgroundColor: 'white',
+                color: '#333',
+                border: '1px solid #ddd',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                fontSize: '1rem',
+              }}
+            >
+              ページを再読み込み
+            </button>
+
+            <button
+              onClick={handleHome}
+              style={{
+                padding: '0.75rem 1.5rem',
+                backgroundColor: 'white',
+                color: '#333',
+                border: '1px solid #ddd',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                fontSize: '1rem',
+              }}
+            >
+              ホームに戻る
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}
+
+async function reportError(error: Error & { digest?: string }) {
+  try {
+    await fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'global-error',
+        name: error.name,
+        message: error.message,
+        digest: error.digest,
+        timestamp: new Date().toISOString(),
+      }),
+    })
+  } catch {
+    // ログ送信の失敗は無視
+    console.error('Failed to report error')
+  }
+}
+```
+
+## スタイリングの注意点
+
+### インラインスタイルを使用する理由
+
+```typescript
+// global-errorではCSSファイルやTailwindが読み込まれない可能性がある
+// そのためインラインスタイルを使用することを推奨
+
+export default function GlobalError({ error, reset }) {
+  return (
+    <html>
+      <body style={{ /* インラインスタイル */ }}>
+        {/* ... */}
+      </body>
+    </html>
+  )
+}
+```
+
+### 最小限のリセットCSS
+
+```typescript
+<html>
+  <head>
+    <style>
+      {`
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: system-ui, sans-serif; }
+      `}
+    </style>
+  </head>
+  <body>
+    {/* ... */}
+  </body>
+</html>
+```
+
+## テスト方法
+
+### 開発環境でのテスト
+
+```typescript
+// app/layout.tsx にエラーを発生させる
+export default function RootLayout({ children }) {
+  // 本番環境でのみテスト
+  if (process.env.TEST_GLOBAL_ERROR === 'true') {
+    throw new Error('Test global error')
+  }
+
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+### 本番ビルドでのテスト
+
+```bash
+npm run build
+npm run start
+# 別ターミナルでエラーを発生させるリクエストを送信
+```
+
+## チェックリスト
+
+- [ ] 'use client'ディレクティブがある
+- [ ] html と body タグを含んでいる
+- [ ] reset関数を提供している
+- [ ] インラインスタイルまたは最小限のCSSを使用
+- [ ] エラーログ送信を設定
+- [ ] 複数の復帰オプションを提供
+- [ ] 本番環境でテスト済み

--- a/.claude/skills/error-handling-pages/resources/loading-tsx-guide.md
+++ b/.claude/skills/error-handling-pages/resources/loading-tsx-guide.md
@@ -1,0 +1,367 @@
+# loading.tsx ガイド
+
+## 概要
+
+`loading.tsx`はReact Suspenseを活用して、ページやセグメントの
+読み込み中に表示されるUIを定義します。サーバーコンポーネントの
+データフェッチ中にユーザーにフィードバックを提供します。
+
+## 基本構造
+
+```typescript
+// app/loading.tsx
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+    </div>
+  )
+}
+```
+
+## 仕組み
+
+### 内部的な動作
+
+```typescript
+// loading.tsxは内部的に以下のようにSuspenseでラップされる
+<Suspense fallback={<Loading />}>
+  <Page />
+</Suspense>
+```
+
+### ファイル配置
+
+```
+app/
+├── layout.tsx
+├── loading.tsx      # 全ページのローディング
+├── page.tsx
+└── dashboard/
+    ├── loading.tsx  # /dashboard専用ローディング
+    ├── page.tsx
+    └── settings/
+        └── page.tsx # dashboard/loading.tsx を使用
+```
+
+## デザインパターン
+
+### スピナー
+
+```typescript
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center p-8">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
+    </div>
+  )
+}
+```
+
+### スケルトン
+
+```typescript
+export default function Loading() {
+  return (
+    <div className="animate-pulse space-y-4 p-4">
+      <div className="h-8 bg-gray-200 rounded w-1/4" />
+      <div className="space-y-3">
+        <div className="h-4 bg-gray-200 rounded" />
+        <div className="h-4 bg-gray-200 rounded w-5/6" />
+        <div className="h-4 bg-gray-200 rounded w-4/6" />
+      </div>
+    </div>
+  )
+}
+```
+
+### カードスケルトン
+
+```typescript
+export default function Loading() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      {[...Array(6)].map((_, i) => (
+        <div key={i} className="animate-pulse">
+          <div className="bg-gray-200 h-48 rounded-t-lg" />
+          <div className="p-4 space-y-3">
+            <div className="h-4 bg-gray-200 rounded w-3/4" />
+            <div className="h-4 bg-gray-200 rounded w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+### テーブルスケルトン
+
+```typescript
+export default function Loading() {
+  return (
+    <div className="animate-pulse">
+      {/* ヘッダー */}
+      <div className="flex border-b p-4 gap-4">
+        <div className="h-4 bg-gray-200 rounded w-1/4" />
+        <div className="h-4 bg-gray-200 rounded w-1/4" />
+        <div className="h-4 bg-gray-200 rounded w-1/4" />
+        <div className="h-4 bg-gray-200 rounded w-1/4" />
+      </div>
+      {/* 行 */}
+      {[...Array(5)].map((_, i) => (
+        <div key={i} className="flex border-b p-4 gap-4">
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-4 bg-gray-200 rounded w-1/4" />
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+## ルート別のローディング
+
+### ダッシュボード
+
+```typescript
+// app/dashboard/loading.tsx
+export default function DashboardLoading() {
+  return (
+    <div className="p-6 space-y-6">
+      {/* ヘッダー */}
+      <div className="animate-pulse">
+        <div className="h-8 bg-gray-200 rounded w-48" />
+      </div>
+
+      {/* 統計カード */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="animate-pulse bg-white p-4 rounded-lg shadow">
+            <div className="h-4 bg-gray-200 rounded w-24 mb-2" />
+            <div className="h-8 bg-gray-200 rounded w-16" />
+          </div>
+        ))}
+      </div>
+
+      {/* チャート */}
+      <div className="animate-pulse bg-white p-4 rounded-lg shadow">
+        <div className="h-64 bg-gray-200 rounded" />
+      </div>
+    </div>
+  )
+}
+```
+
+### 記事一覧
+
+```typescript
+// app/blog/loading.tsx
+export default function BlogLoading() {
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <div className="animate-pulse mb-8">
+        <div className="h-10 bg-gray-200 rounded w-48" />
+      </div>
+
+      <div className="space-y-8">
+        {[...Array(3)].map((_, i) => (
+          <article key={i} className="animate-pulse">
+            <div className="aspect-video bg-gray-200 rounded-lg mb-4" />
+            <div className="h-6 bg-gray-200 rounded w-3/4 mb-2" />
+            <div className="h-4 bg-gray-200 rounded w-full mb-2" />
+            <div className="h-4 bg-gray-200 rounded w-2/3" />
+          </article>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+### 商品詳細
+
+```typescript
+// app/products/[id]/loading.tsx
+export default function ProductLoading() {
+  return (
+    <div className="max-w-6xl mx-auto p-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        {/* 画像 */}
+        <div className="animate-pulse">
+          <div className="aspect-square bg-gray-200 rounded-lg" />
+          <div className="flex gap-2 mt-4">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="w-20 h-20 bg-gray-200 rounded" />
+            ))}
+          </div>
+        </div>
+
+        {/* 詳細 */}
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-gray-200 rounded w-3/4" />
+          <div className="h-10 bg-gray-200 rounded w-32" />
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-200 rounded" />
+            <div className="h-4 bg-gray-200 rounded" />
+            <div className="h-4 bg-gray-200 rounded w-4/5" />
+          </div>
+          <div className="h-12 bg-gray-200 rounded w-full" />
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## Suspenseとの組み合わせ
+
+### 部分的なローディング
+
+```typescript
+// app/dashboard/page.tsx
+import { Suspense } from 'react'
+
+export default function DashboardPage() {
+  return (
+    <div className="p-6 space-y-6">
+      <h1>ダッシュボード</h1>
+
+      {/* 統計は早く表示 */}
+      <Suspense fallback={<StatsSkeleton />}>
+        <Stats />
+      </Suspense>
+
+      {/* チャートは後から */}
+      <Suspense fallback={<ChartSkeleton />}>
+        <Chart />
+      </Suspense>
+
+      {/* 最新アクティビティは最後 */}
+      <Suspense fallback={<ActivitySkeleton />}>
+        <RecentActivity />
+      </Suspense>
+    </div>
+  )
+}
+```
+
+### スケルトンコンポーネントの分離
+
+```typescript
+// components/skeletons/stats-skeleton.tsx
+export function StatsSkeleton() {
+  return (
+    <div className="grid grid-cols-4 gap-4">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="animate-pulse bg-white p-4 rounded shadow">
+          <div className="h-4 bg-gray-200 rounded w-24 mb-2" />
+          <div className="h-8 bg-gray-200 rounded w-16" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// components/skeletons/chart-skeleton.tsx
+export function ChartSkeleton() {
+  return (
+    <div className="animate-pulse bg-white p-4 rounded shadow">
+      <div className="h-64 bg-gray-200 rounded" />
+    </div>
+  )
+}
+```
+
+## 即時ローディング状態
+
+### useTransitionとの違い
+
+```typescript
+// loading.tsx: ナビゲーション時に自動で表示
+// useTransition: プログラム的なトランジション
+
+'use client'
+
+import { useTransition } from 'react'
+
+export function FilterButton({ category }) {
+  const [isPending, startTransition] = useTransition()
+
+  const handleClick = () => {
+    startTransition(() => {
+      // フィルター適用
+    })
+  }
+
+  return (
+    <button disabled={isPending}>
+      {isPending ? 'Loading...' : category}
+    </button>
+  )
+}
+```
+
+## パフォーマンス考慮事項
+
+### CLSの防止
+
+```typescript
+// スケルトンは実際のコンテンツと同じサイズにする
+export default function Loading() {
+  return (
+    <div className="animate-pulse">
+      {/* 実際のコンテンツと同じ高さを確保 */}
+      <div className="h-[200px] bg-gray-200 rounded" />
+    </div>
+  )
+}
+```
+
+### アニメーションの最適化
+
+```typescript
+// GPU加速を使用
+<div className="animate-pulse transform-gpu">
+  {/* ... */}
+</div>
+```
+
+## アクセシビリティ
+
+### スクリーンリーダー対応
+
+```typescript
+export default function Loading() {
+  return (
+    <div
+      className="flex items-center justify-center p-8"
+      role="status"
+      aria-label="読み込み中"
+    >
+      <div className="animate-spin h-8 w-8 border-b-2 border-blue-600" />
+      <span className="sr-only">読み込み中...</span>
+    </div>
+  )
+}
+```
+
+### 読み込み完了の通知
+
+```typescript
+// aria-liveでコンテンツ更新を通知
+<div aria-live="polite">
+  {isLoading ? <Loading /> : <Content />}
+</div>
+```
+
+## チェックリスト
+
+- [ ] loading.tsxが適切な場所に配置されている
+- [ ] スケルトンが実際のコンテンツと同じレイアウト
+- [ ] アニメーションがスムーズ
+- [ ] CLSを引き起こさない
+- [ ] アクセシビリティ対応（role、aria-label）
+- [ ] 複雑なページはSuspenseで部分的にローディング

--- a/.claude/skills/error-handling-pages/resources/not-found-guide.md
+++ b/.claude/skills/error-handling-pages/resources/not-found-guide.md
@@ -1,0 +1,392 @@
+# not-found.tsx ガイド
+
+## 概要
+
+`not-found.tsx`は存在しないルートやリソースにアクセスした際に
+表示されるページです。404エラーをカスタマイズし、
+ユーザーフレンドリーな体験を提供します。
+
+## 基本構造
+
+```typescript
+// app/not-found.tsx
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-6xl font-bold text-gray-200">404</h1>
+      <h2 className="text-2xl font-bold mt-4">ページが見つかりません</h2>
+      <p className="text-gray-600 mt-2">
+        お探しのページは存在しないか、移動した可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="mt-6 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        ホームに戻る
+      </Link>
+    </div>
+  )
+}
+```
+
+## トリガー方法
+
+### 1. 存在しないルートへのアクセス
+
+```
+/this-page-does-not-exist → app/not-found.tsx が表示される
+```
+
+### 2. notFound() 関数
+
+```typescript
+// app/posts/[slug]/page.tsx
+import { notFound } from 'next/navigation'
+
+export default async function PostPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const post = await getPost(params.slug)
+
+  if (!post) {
+    notFound() // 最も近い not-found.tsx を表示
+  }
+
+  return <article>{post.content}</article>
+}
+```
+
+### 3. データフェッチでの使用
+
+```typescript
+// lib/data.ts
+import { notFound } from 'next/navigation'
+
+export async function getPost(slug: string) {
+  const post = await db.post.findUnique({ where: { slug } })
+
+  if (!post) {
+    notFound()
+  }
+
+  return post
+}
+```
+
+## スコープと配置
+
+### 階層構造
+
+```
+app/
+├── not-found.tsx        # グローバル404
+├── page.tsx
+├── blog/
+│   ├── not-found.tsx    # /blog/* 専用404
+│   ├── page.tsx
+│   └── [slug]/
+│       └── page.tsx     # notFound()で blog/not-found.tsx を使用
+└── products/
+    ├── page.tsx
+    └── [id]/
+        └── page.tsx     # notFound()で app/not-found.tsx を使用
+```
+
+### 優先順位
+
+1. 同じディレクトリのnot-found.tsx
+2. 親ディレクトリのnot-found.tsx（再帰的に検索）
+3. app/not-found.tsx
+
+## ルート別のカスタマイズ
+
+### ブログ用404
+
+```typescript
+// app/blog/not-found.tsx
+import Link from 'next/link'
+
+export default function BlogNotFound() {
+  return (
+    <div className="max-w-2xl mx-auto py-16 text-center">
+      <h2 className="text-2xl font-bold">記事が見つかりません</h2>
+      <p className="text-gray-600 mt-2">
+        この記事は存在しないか、削除された可能性があります。
+      </p>
+      <div className="mt-8 space-y-4">
+        <Link
+          href="/blog"
+          className="block text-blue-600 hover:underline"
+        >
+          ブログ一覧を見る
+        </Link>
+        <Link
+          href="/blog/popular"
+          className="block text-blue-600 hover:underline"
+        >
+          人気の記事を見る
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+### 商品用404
+
+```typescript
+// app/products/not-found.tsx
+import Link from 'next/link'
+import { getPopularProducts } from '@/lib/data'
+
+export default async function ProductNotFound() {
+  const popularProducts = await getPopularProducts(4)
+
+  return (
+    <div className="max-w-4xl mx-auto py-16">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold">商品が見つかりません</h2>
+        <p className="text-gray-600 mt-2">
+          この商品は在庫切れか、販売終了している可能性があります。
+        </p>
+      </div>
+
+      <div className="mt-12">
+        <h3 className="text-lg font-semibold mb-4">人気の商品</h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {popularProducts.map((product) => (
+            <Link
+              key={product.id}
+              href={`/products/${product.id}`}
+              className="block border rounded p-4 hover:shadow"
+            >
+              <img src={product.image} alt={product.name} />
+              <p className="mt-2 font-medium">{product.name}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## 動的コンテンツの404
+
+### サーバーコンポーネントでの使用
+
+```typescript
+// app/users/[id]/page.tsx
+import { notFound } from 'next/navigation'
+import { getUser } from '@/lib/data'
+
+export default async function UserPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const user = await getUser(params.id)
+
+  if (!user) {
+    notFound()
+  }
+
+  return <UserProfile user={user} />
+}
+```
+
+### メタデータとの組み合わせ
+
+```typescript
+// app/posts/[slug]/page.tsx
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { getPost } from '@/lib/data'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string }
+}): Promise<Metadata> {
+  const post = await getPost(params.slug)
+
+  if (!post) {
+    return {
+      title: '記事が見つかりません',
+    }
+  }
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+  }
+}
+
+export default async function PostPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const post = await getPost(params.slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  return <article>{/* ... */}</article>
+}
+```
+
+## デザインパターン
+
+### シンプルな404
+
+```typescript
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-9xl font-bold text-gray-200">404</h1>
+        <p className="text-xl mt-4">ページが見つかりません</p>
+        <Link href="/" className="mt-8 inline-block text-blue-600">
+          ホームに戻る →
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+### イラスト付き404
+
+```typescript
+import Image from 'next/image'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <Image
+        src="/images/404-illustration.svg"
+        alt="ページが見つかりません"
+        width={400}
+        height={300}
+      />
+      <h2 className="text-2xl font-bold mt-8">お探しのページが見つかりません</h2>
+      <p className="text-gray-600 mt-2 max-w-md text-center">
+        URLが間違っているか、ページが移動・削除された可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="mt-8 px-6 py-3 bg-blue-600 text-white rounded-lg"
+      >
+        ホームに戻る
+      </Link>
+    </div>
+  )
+}
+```
+
+### 検索機能付き404
+
+```typescript
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+export default function NotFound() {
+  const [query, setQuery] = useState('')
+  const router = useRouter()
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (query.trim()) {
+      router.push(`/search?q=${encodeURIComponent(query)}`)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-4">
+      <h1 className="text-4xl font-bold">ページが見つかりません</h1>
+      <p className="text-gray-600 mt-4 text-center">
+        お探しのページは存在しないか、移動した可能性があります。
+      </p>
+
+      <form onSubmit={handleSearch} className="mt-8 w-full max-w-md">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="キーワードで検索..."
+            className="flex-1 px-4 py-2 border rounded"
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            検索
+          </button>
+        </div>
+      </form>
+
+      <div className="mt-8 flex gap-4">
+        <Link href="/" className="text-blue-600 hover:underline">
+          ホーム
+        </Link>
+        <Link href="/sitemap" className="text-blue-600 hover:underline">
+          サイトマップ
+        </Link>
+        <Link href="/contact" className="text-blue-600 hover:underline">
+          お問い合わせ
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+## HTTPステータスコード
+
+### デフォルトの動作
+
+```typescript
+// not-found.tsxは自動的に404ステータスを返す
+export default function NotFound() {
+  // Response status: 404
+  return <div>Not Found</div>
+}
+```
+
+### メタデータでの確認
+
+```typescript
+// generateMetadataでnotFound()を使用しても404が返される
+export async function generateMetadata({ params }) {
+  const post = await getPost(params.slug)
+
+  if (!post) {
+    return {
+      title: 'Not Found',
+    }
+  }
+
+  return { title: post.title }
+}
+```
+
+## チェックリスト
+
+- [ ] app/not-found.tsx が作成されている
+- [ ] 動的ルートで notFound() を使用している
+- [ ] ユーザーフレンドリーなメッセージを表示
+- [ ] ホームへのリンクがある
+- [ ] ブランドに合ったデザイン
+- [ ] 必要に応じてルート別のnot-found.tsxがある
+- [ ] 検索やナビゲーションオプションを提供（オプション）

--- a/.claude/skills/error-handling-pages/scripts/check-error-handling.mjs
+++ b/.claude/skills/error-handling-pages/scripts/check-error-handling.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+
+/**
+ * エラーハンドリング設定チェックスクリプト
+ *
+ * 使用方法:
+ *   node check-error-handling.mjs <app-directory>
+ *
+ * 例:
+ *   node check-error-handling.mjs ./src/app
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+class ErrorHandlingChecker {
+  constructor(appDir) {
+    this.appDir = path.resolve(appDir);
+    this.issues = [];
+    this.suggestions = [];
+    this.stats = {
+      totalSegments: 0,
+      segmentsWithError: 0,
+      segmentsWithNotFound: 0,
+      segmentsWithLoading: 0,
+      hasGlobalError: false,
+      hasRootError: false,
+      hasRootNotFound: false,
+      hasRootLoading: false,
+      dynamicRoutes: 0,
+      dynamicRoutesWithNotFound: 0,
+    };
+  }
+
+  check() {
+    if (!fs.existsSync(this.appDir)) {
+      console.error(`Error: Directory not found: ${this.appDir}`);
+      process.exit(1);
+    }
+
+    console.log(`\n🔍 Error Handling Check: ${this.appDir}\n`);
+    console.log('='.repeat(60));
+
+    this.checkRootFiles();
+    this.scanDirectory(this.appDir);
+    this.analyzeResults();
+    this.printStats();
+    this.printIssues();
+    this.printSuggestions();
+  }
+
+  checkRootFiles() {
+    console.log('\n📁 Root Level Files:');
+    console.log('-'.repeat(40));
+
+    // global-error.tsx
+    const globalErrorPath = path.join(this.appDir, 'global-error.tsx');
+    this.stats.hasGlobalError = fs.existsSync(globalErrorPath);
+    console.log(`  global-error.tsx: ${this.stats.hasGlobalError ? '✅ Found' : '❌ Missing'}`);
+
+    if (!this.stats.hasGlobalError) {
+      this.issues.push({
+        type: 'warning',
+        message: 'global-error.tsx が見つかりません（Root Layoutのエラーを捕捉できません）',
+      });
+    }
+
+    // error.tsx
+    const errorPath = path.join(this.appDir, 'error.tsx');
+    this.stats.hasRootError = fs.existsSync(errorPath);
+    console.log(`  error.tsx: ${this.stats.hasRootError ? '✅ Found' : '⚠️  Missing'}`);
+
+    if (!this.stats.hasRootError) {
+      this.issues.push({
+        type: 'warning',
+        message: 'app/error.tsx が見つかりません',
+      });
+    }
+
+    // not-found.tsx
+    const notFoundPath = path.join(this.appDir, 'not-found.tsx');
+    this.stats.hasRootNotFound = fs.existsSync(notFoundPath);
+    console.log(`  not-found.tsx: ${this.stats.hasRootNotFound ? '✅ Found' : '❌ Missing'}`);
+
+    if (!this.stats.hasRootNotFound) {
+      this.issues.push({
+        type: 'error',
+        message: 'app/not-found.tsx が見つかりません（404ページがデフォルトになります）',
+      });
+    }
+
+    // loading.tsx
+    const loadingPath = path.join(this.appDir, 'loading.tsx');
+    this.stats.hasRootLoading = fs.existsSync(loadingPath);
+    console.log(`  loading.tsx: ${this.stats.hasRootLoading ? '✅ Found' : '⚠️  Optional'}`);
+
+    // error.tsxの内容チェック
+    if (this.stats.hasRootError) {
+      this.validateErrorFile(errorPath);
+    }
+
+    // global-error.tsxの内容チェック
+    if (this.stats.hasGlobalError) {
+      this.validateGlobalErrorFile(globalErrorPath);
+    }
+  }
+
+  validateErrorFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // 'use client' チェック
+    if (!content.includes("'use client'") && !content.includes('"use client"')) {
+      this.issues.push({
+        type: 'error',
+        message: `${path.relative(this.appDir, filePath)}: 'use client' ディレクティブがありません`,
+      });
+    }
+
+    // reset関数の使用チェック
+    if (!content.includes('reset')) {
+      this.issues.push({
+        type: 'warning',
+        message: `${path.relative(this.appDir, filePath)}: reset関数が使用されていません`,
+      });
+    }
+  }
+
+  validateGlobalErrorFile(filePath) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // 'use client' チェック
+    if (!content.includes("'use client'") && !content.includes('"use client"')) {
+      this.issues.push({
+        type: 'error',
+        message: `global-error.tsx: 'use client' ディレクティブがありません`,
+      });
+    }
+
+    // html/body タグチェック
+    if (!content.includes('<html') || !content.includes('<body')) {
+      this.issues.push({
+        type: 'error',
+        message: 'global-error.tsx: <html>と<body>タグが必要です',
+      });
+    }
+  }
+
+  scanDirectory(dir, relativePath = '') {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    // このディレクトリがルートセグメントか
+    const hasPage = entries.some((e) => e.name === 'page.tsx' || e.name === 'page.ts');
+
+    if (hasPage) {
+      this.stats.totalSegments++;
+
+      const segmentInfo = {
+        path: relativePath || '/',
+        hasError: false,
+        hasNotFound: false,
+        hasLoading: false,
+        isDynamic: relativePath.includes('['),
+      };
+
+      // 各ファイルの存在チェック
+      if (entries.some((e) => e.name === 'error.tsx' || e.name === 'error.ts')) {
+        segmentInfo.hasError = true;
+        this.stats.segmentsWithError++;
+
+        // error.tsxの内容検証
+        const errorPath = path.join(dir, 'error.tsx');
+        if (fs.existsSync(errorPath)) {
+          this.validateErrorFile(errorPath);
+        }
+      }
+
+      if (entries.some((e) => e.name === 'not-found.tsx' || e.name === 'not-found.ts')) {
+        segmentInfo.hasNotFound = true;
+        this.stats.segmentsWithNotFound++;
+      }
+
+      if (entries.some((e) => e.name === 'loading.tsx' || e.name === 'loading.ts')) {
+        segmentInfo.hasLoading = true;
+        this.stats.segmentsWithLoading++;
+      }
+
+      // 動的ルートのチェック
+      if (segmentInfo.isDynamic) {
+        this.stats.dynamicRoutes++;
+
+        // 動的ルートでnotFound()が使用されているかチェック
+        const pagePath = path.join(dir, 'page.tsx');
+        if (fs.existsSync(pagePath)) {
+          const pageContent = fs.readFileSync(pagePath, 'utf-8');
+          if (pageContent.includes('notFound()') || pageContent.includes('notFound(')) {
+            this.stats.dynamicRoutesWithNotFound++;
+          } else {
+            this.suggestions.push(
+              `${relativePath}: 動的ルートで notFound() の使用を検討してください`
+            );
+          }
+        }
+      }
+
+      // 出力
+      console.log(`\n📄 ${segmentInfo.path}`);
+      console.log(`  error.tsx: ${segmentInfo.hasError ? '✅' : '—'}`);
+      console.log(`  not-found.tsx: ${segmentInfo.hasNotFound ? '✅' : '—'}`);
+      console.log(`  loading.tsx: ${segmentInfo.hasLoading ? '✅' : '—'}`);
+      if (segmentInfo.isDynamic) {
+        console.log(`  [Dynamic Route]`);
+      }
+    }
+
+    // サブディレクトリを再帰的にチェック
+    for (const entry of entries) {
+      if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+        const subPath = path.join(relativePath, entry.name);
+        this.scanDirectory(path.join(dir, entry.name), subPath);
+      }
+    }
+  }
+
+  analyzeResults() {
+    // カバレッジ分析
+    const errorCoverage = this.stats.totalSegments > 0
+      ? (this.stats.segmentsWithError / this.stats.totalSegments) * 100
+      : 0;
+
+    if (errorCoverage < 50 && this.stats.totalSegments > 3) {
+      this.suggestions.push('error.tsx のカバレッジが低いです。重要なルートには個別のerror.tsxを検討してください');
+    }
+
+    // 動的ルートの分析
+    if (this.stats.dynamicRoutes > 0 && this.stats.dynamicRoutesWithNotFound < this.stats.dynamicRoutes) {
+      this.suggestions.push(
+        `${this.stats.dynamicRoutes - this.stats.dynamicRoutesWithNotFound}/${this.stats.dynamicRoutes} の動的ルートで notFound() が使用されていません`
+      );
+    }
+
+    // loadingの提案
+    if (this.stats.segmentsWithLoading === 0 && this.stats.totalSegments > 0) {
+      this.suggestions.push('loading.tsx がありません。データフェッチを行うページには追加を検討してください');
+    }
+  }
+
+  printStats() {
+    console.log('\n' + '='.repeat(60));
+    console.log('📊 Summary:');
+    console.log('-'.repeat(40));
+    console.log(`  Total Segments: ${this.stats.totalSegments}`);
+    console.log(`  With error.tsx: ${this.stats.segmentsWithError} (${this.percentage(this.stats.segmentsWithError, this.stats.totalSegments)}%)`);
+    console.log(`  With not-found.tsx: ${this.stats.segmentsWithNotFound}`);
+    console.log(`  With loading.tsx: ${this.stats.segmentsWithLoading}`);
+    console.log(`  Dynamic Routes: ${this.stats.dynamicRoutes}`);
+    console.log(`  Dynamic with notFound(): ${this.stats.dynamicRoutesWithNotFound}`);
+
+    // スコア計算
+    const score = this.calculateScore();
+    console.log(`\n  📈 Error Handling Score: ${score}/100`);
+  }
+
+  calculateScore() {
+    let score = 0;
+
+    // global-error.tsx (20点)
+    if (this.stats.hasGlobalError) score += 20;
+
+    // app/error.tsx (20点)
+    if (this.stats.hasRootError) score += 20;
+
+    // app/not-found.tsx (20点)
+    if (this.stats.hasRootNotFound) score += 20;
+
+    // error.tsxカバレッジ (20点)
+    if (this.stats.totalSegments > 0) {
+      score += Math.round((this.stats.segmentsWithError / this.stats.totalSegments) * 20);
+    } else {
+      score += 20;
+    }
+
+    // 動的ルートでのnotFound()使用 (20点)
+    if (this.stats.dynamicRoutes > 0) {
+      score += Math.round((this.stats.dynamicRoutesWithNotFound / this.stats.dynamicRoutes) * 20);
+    } else {
+      score += 20;
+    }
+
+    return score;
+  }
+
+  percentage(part, total) {
+    if (total === 0) return 0;
+    return Math.round((part / total) * 100);
+  }
+
+  printIssues() {
+    console.log('\n⚠️  Issues:');
+    console.log('-'.repeat(40));
+
+    if (this.issues.length === 0) {
+      console.log('  ✅ No issues found');
+    } else {
+      const errors = this.issues.filter((i) => i.type === 'error');
+      const warnings = this.issues.filter((i) => i.type === 'warning');
+
+      for (const error of errors) {
+        console.log(`  ❌ ${error.message}`);
+      }
+      for (const warning of warnings) {
+        console.log(`  ⚠️  ${warning.message}`);
+      }
+    }
+  }
+
+  printSuggestions() {
+    console.log('\n💡 Suggestions:');
+    console.log('-'.repeat(40));
+
+    if (this.suggestions.length === 0) {
+      console.log('  ✅ No additional suggestions');
+    } else {
+      for (const suggestion of this.suggestions) {
+        console.log(`  → ${suggestion}`);
+      }
+    }
+
+    console.log('\n' + '='.repeat(60) + '\n');
+  }
+}
+
+// Main execution
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.log('Usage: node check-error-handling.mjs <app-directory>');
+  console.log('Example: node check-error-handling.mjs ./src/app');
+  process.exit(1);
+}
+
+const checker = new ErrorHandlingChecker(args[0]);
+checker.check();

--- a/.claude/skills/error-handling-pages/templates/error-page-template.md
+++ b/.claude/skills/error-handling-pages/templates/error-page-template.md
@@ -1,0 +1,401 @@
+# エラーページテンプレート
+
+## 基本エラーページ
+
+```typescript
+// app/error.tsx
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // エラーログを送信
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-gray-900">
+          エラーが発生しました
+        </h2>
+        <p className="mt-2 text-gray-600">
+          申し訳ございません。予期しないエラーが発生しました。
+        </p>
+        <button
+          onClick={() => reset()}
+          className="mt-6 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+        >
+          再試行
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+## フル機能エラーページ
+
+```typescript
+// app/error.tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+  const isDev = process.env.NODE_ENV === 'development'
+
+  useEffect(() => {
+    // 本番環境ではエラーログを送信
+    if (!isDev) {
+      logError(error)
+    }
+  }, [error, isDev])
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-gray-50">
+      <div className="max-w-md w-full text-center">
+        {/* アイコン */}
+        <div className="mx-auto w-16 h-16 flex items-center justify-center rounded-full bg-red-100 mb-6">
+          <svg
+            className="w-8 h-8 text-red-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+
+        {/* メッセージ */}
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          問題が発生しました
+        </h2>
+        <p className="text-gray-600 mb-6">
+          予期しないエラーが発生しました。
+          お手数ですが、再度お試しください。
+        </p>
+
+        {/* 開発時のみエラー詳細 */}
+        {isDev && (
+          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg text-left">
+            <p className="text-sm font-mono text-red-800">
+              {error.name}: {error.message}
+            </p>
+            {error.digest && (
+              <p className="text-xs text-red-600 mt-1">
+                Digest: {error.digest}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* アクション */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => reset()}
+            className="px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium"
+          >
+            再試行
+          </button>
+          <button
+            onClick={() => router.back()}
+            className="px-6 py-2.5 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition font-medium"
+          >
+            前のページに戻る
+          </button>
+          <button
+            onClick={() => router.push('/')}
+            className="px-6 py-2.5 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition font-medium"
+          >
+            ホームに戻る
+          </button>
+        </div>
+
+        {/* サポート */}
+        <p className="mt-8 text-sm text-gray-500">
+          問題が解決しない場合は
+          <a href="/contact" className="text-blue-600 hover:underline">
+            お問い合わせ
+          </a>
+          ください。
+        </p>
+      </div>
+    </div>
+  )
+}
+
+async function logError(error: Error & { digest?: string }) {
+  try {
+    await fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: error.name,
+        message: error.message,
+        digest: error.digest,
+        timestamp: new Date().toISOString(),
+      }),
+    })
+  } catch {
+    console.error('Failed to log error')
+  }
+}
+```
+
+## グローバルエラーページ
+
+```typescript
+// app/global-error.tsx
+'use client'
+
+import { useEffect } from 'react'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // クリティカルエラーをログ
+    reportCriticalError(error)
+  }, [error])
+
+  const handleReload = () => {
+    window.location.reload()
+  }
+
+  const handleHome = () => {
+    window.location.href = '/'
+  }
+
+  return (
+    <html lang="ja">
+      <head>
+        <title>エラーが発生しました</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <style>{`
+          * { margin: 0; padding: 0; box-sizing: border-box; }
+          body {
+            font-family: system-ui, -apple-system, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f9fafb;
+            padding: 1rem;
+          }
+          .container { text-align: center; max-width: 24rem; }
+          .icon {
+            width: 4rem;
+            height: 4rem;
+            margin: 0 auto 1.5rem;
+            color: #dc2626;
+          }
+          h1 { font-size: 1.5rem; color: #111827; margin-bottom: 0.5rem; }
+          p { color: #6b7280; margin-bottom: 1.5rem; }
+          .buttons { display: flex; flex-direction: column; gap: 0.75rem; }
+          button {
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: all 0.15s;
+          }
+          .primary {
+            background: #2563eb;
+            color: white;
+            border: none;
+          }
+          .primary:hover { background: #1d4ed8; }
+          .secondary {
+            background: white;
+            color: #374151;
+            border: 1px solid #d1d5db;
+          }
+          .secondary:hover { background: #f9fafb; }
+          @media (min-width: 640px) {
+            .buttons { flex-direction: row; justify-content: center; }
+          }
+        `}</style>
+      </head>
+      <body>
+        <div className="container">
+          <svg
+            className="icon"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <h1>深刻なエラーが発生しました</h1>
+          <p>
+            アプリケーションに問題が発生しました。
+            ご不便をおかけして申し訳ございません。
+          </p>
+          <div className="buttons">
+            <button className="primary" onClick={() => reset()}>
+              再試行
+            </button>
+            <button className="secondary" onClick={handleReload}>
+              ページを再読み込み
+            </button>
+            <button className="secondary" onClick={handleHome}>
+              ホームに戻る
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}
+
+async function reportCriticalError(error: Error & { digest?: string }) {
+  try {
+    await fetch('/api/log-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'critical',
+        name: error.name,
+        message: error.message,
+        digest: error.digest,
+        timestamp: new Date().toISOString(),
+      }),
+    })
+  } catch {
+    // ログ失敗は無視
+  }
+}
+```
+
+## エラータイプ別テンプレート
+
+```typescript
+// app/{{route}}/error.tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+// カスタムエラータイプ
+type ErrorType = 'authentication' | 'authorization' | 'validation' | 'network' | 'unknown'
+
+function getErrorType(error: Error): ErrorType {
+  if (error.name === 'AuthenticationError') return 'authentication'
+  if (error.name === 'AuthorizationError') return 'authorization'
+  if (error.name === 'ValidationError') return 'validation'
+  if (error.name === 'NetworkError' || error.message.includes('fetch')) return 'network'
+  return 'unknown'
+}
+
+const errorConfig: Record<ErrorType, { title: string; message: string; action?: string }> = {
+  authentication: {
+    title: 'ログインが必要です',
+    message: 'この機能を利用するにはログインが必要です。',
+    action: 'login',
+  },
+  authorization: {
+    title: 'アクセス権限がありません',
+    message: 'このページにアクセスする権限がありません。',
+  },
+  validation: {
+    title: '入力エラー',
+    message: '入力内容に問題があります。確認して再度お試しください。',
+  },
+  network: {
+    title: '接続エラー',
+    message: 'サーバーに接続できませんでした。インターネット接続を確認してください。',
+  },
+  unknown: {
+    title: 'エラーが発生しました',
+    message: '予期しないエラーが発生しました。',
+  },
+}
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+  const errorType = getErrorType(error)
+  const config = errorConfig[errorType]
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center p-4">
+      <div className="text-center max-w-md">
+        <h2 className="text-xl font-bold mb-2">{config.title}</h2>
+        <p className="text-gray-600 mb-6">{config.message}</p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          {config.action === 'login' ? (
+            <button
+              onClick={() => router.push('/login')}
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+            >
+              ログイン
+            </button>
+          ) : (
+            <button
+              onClick={() => reset()}
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+            >
+              再試行
+            </button>
+          )}
+          <button
+            onClick={() => router.back()}
+            className="px-4 py-2 border rounded"
+          >
+            戻る
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{route}}` | ルートパス | `dashboard`, `blog` |
+| `error.name` | エラー名 | `Error`, `AuthenticationError` |
+| `error.message` | エラーメッセージ | `Failed to fetch` |
+| `error.digest` | サーバーエラーのハッシュ | `abc123` |

--- a/.claude/skills/error-handling-pages/templates/not-found-template.md
+++ b/.claude/skills/error-handling-pages/templates/not-found-template.md
@@ -1,0 +1,341 @@
+# 404ページテンプレート
+
+## シンプルな404
+
+```typescript
+// app/not-found.tsx
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <h1 className="text-9xl font-bold text-gray-200">404</h1>
+      <h2 className="text-2xl font-bold mt-4">ページが見つかりません</h2>
+      <p className="text-gray-600 mt-2">
+        お探しのページは存在しないか、移動した可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="mt-8 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+      >
+        ホームに戻る
+      </Link>
+    </div>
+  )
+}
+```
+
+## イラスト付き404
+
+```typescript
+// app/not-found.tsx
+import Image from 'next/image'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <Image
+        src="/images/404-illustration.svg"
+        alt="ページが見つかりません"
+        width={400}
+        height={300}
+        priority
+      />
+
+      <h1 className="text-3xl font-bold mt-8 text-center">
+        お探しのページが見つかりません
+      </h1>
+
+      <p className="text-gray-600 mt-4 text-center max-w-md">
+        URLが間違っているか、ページが移動または削除された可能性があります。
+      </p>
+
+      <div className="mt-8 flex flex-col sm:flex-row gap-4">
+        <Link
+          href="/"
+          className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-center"
+        >
+          ホームに戻る
+        </Link>
+        <Link
+          href="/contact"
+          className="px-6 py-3 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-center"
+        >
+          お問い合わせ
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+## 検索機能付き404
+
+```typescript
+// app/not-found.tsx
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+export default function NotFound() {
+  const [query, setQuery] = useState('')
+  const router = useRouter()
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (query.trim()) {
+      router.push(`/search?q=${encodeURIComponent(query)}`)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="text-center max-w-xl">
+        <h1 className="text-6xl font-bold text-gray-200">404</h1>
+        <h2 className="text-2xl font-bold mt-4">ページが見つかりません</h2>
+        <p className="text-gray-600 mt-2">
+          お探しのページは存在しないか、移動した可能性があります。
+        </p>
+
+        {/* 検索フォーム */}
+        <form onSubmit={handleSearch} className="mt-8">
+          <div className="flex gap-2 max-w-md mx-auto">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="キーワードで検索..."
+              className="flex-1 px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              検索
+            </button>
+          </div>
+        </form>
+
+        {/* クイックリンク */}
+        <div className="mt-8">
+          <p className="text-sm text-gray-500 mb-4">よく見られるページ</p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/" className="text-blue-600 hover:underline">
+              ホーム
+            </Link>
+            <Link href="/products" className="text-blue-600 hover:underline">
+              商品一覧
+            </Link>
+            <Link href="/blog" className="text-blue-600 hover:underline">
+              ブログ
+            </Link>
+            <Link href="/about" className="text-blue-600 hover:underline">
+              会社概要
+            </Link>
+            <Link href="/contact" className="text-blue-600 hover:underline">
+              お問い合わせ
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## ブログ専用404
+
+```typescript
+// app/blog/not-found.tsx
+import Link from 'next/link'
+import { getRecentPosts } from '@/lib/data'
+
+export default async function BlogNotFound() {
+  const recentPosts = await getRecentPosts(3)
+
+  return (
+    <div className="max-w-4xl mx-auto py-16 px-4">
+      <div className="text-center mb-12">
+        <h1 className="text-3xl font-bold">記事が見つかりません</h1>
+        <p className="text-gray-600 mt-2">
+          この記事は存在しないか、削除された可能性があります。
+        </p>
+      </div>
+
+      {/* 最近の記事 */}
+      <div className="mt-12">
+        <h2 className="text-xl font-bold mb-6">最近の記事</h2>
+        <div className="grid gap-6">
+          {recentPosts.map((post) => (
+            <Link
+              key={post.id}
+              href={`/blog/${post.slug}`}
+              className="block p-4 border rounded-lg hover:shadow-md transition"
+            >
+              <h3 className="font-semibold">{post.title}</h3>
+              <p className="text-gray-600 text-sm mt-1">{post.excerpt}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* ナビゲーション */}
+      <div className="mt-12 flex justify-center gap-4">
+        <Link
+          href="/blog"
+          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+        >
+          記事一覧を見る
+        </Link>
+        <Link
+          href="/"
+          className="px-6 py-2 border rounded-lg hover:bg-gray-50"
+        >
+          ホームに戻る
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+## 商品専用404
+
+```typescript
+// app/products/not-found.tsx
+import Link from 'next/link'
+import Image from 'next/image'
+import { getPopularProducts } from '@/lib/data'
+
+export default async function ProductNotFound() {
+  const popularProducts = await getPopularProducts(4)
+
+  return (
+    <div className="max-w-6xl mx-auto py-16 px-4">
+      <div className="text-center mb-12">
+        <h1 className="text-3xl font-bold">商品が見つかりません</h1>
+        <p className="text-gray-600 mt-2">
+          この商品は在庫切れか、販売終了している可能性があります。
+        </p>
+      </div>
+
+      {/* 人気商品 */}
+      <div className="mt-12">
+        <h2 className="text-xl font-bold mb-6">人気の商品</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+          {popularProducts.map((product) => (
+            <Link
+              key={product.id}
+              href={`/products/${product.id}`}
+              className="group"
+            >
+              <div className="aspect-square relative overflow-hidden rounded-lg bg-gray-100">
+                <Image
+                  src={product.image}
+                  alt={product.name}
+                  fill
+                  sizes="(max-width: 768px) 50vw, 25vw"
+                  className="object-cover group-hover:scale-105 transition"
+                />
+              </div>
+              <h3 className="mt-2 font-medium group-hover:text-blue-600">
+                {product.name}
+              </h3>
+              <p className="text-gray-600">¥{product.price.toLocaleString()}</p>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* カテゴリー */}
+      <div className="mt-12">
+        <h2 className="text-xl font-bold mb-6">カテゴリーから探す</h2>
+        <div className="flex flex-wrap gap-3">
+          {['新着', 'セール', 'ランキング', 'カテゴリ1', 'カテゴリ2'].map(
+            (category) => (
+              <Link
+                key={category}
+                href={`/products?category=${category}`}
+                className="px-4 py-2 bg-gray-100 rounded-full hover:bg-gray-200 transition"
+              >
+                {category}
+              </Link>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* ナビゲーション */}
+      <div className="mt-12 flex justify-center gap-4">
+        <Link
+          href="/products"
+          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+        >
+          商品一覧を見る
+        </Link>
+        <Link
+          href="/"
+          className="px-6 py-2 border rounded-lg hover:bg-gray-50"
+        >
+          ホームに戻る
+        </Link>
+      </div>
+    </div>
+  )
+}
+```
+
+## 多言語対応404
+
+```typescript
+// app/[locale]/not-found.tsx
+import Link from 'next/link'
+import { getDictionary } from '@/lib/dictionaries'
+
+const messages = {
+  ja: {
+    title: 'ページが見つかりません',
+    description: 'お探しのページは存在しないか、移動した可能性があります。',
+    home: 'ホームに戻る',
+  },
+  en: {
+    title: 'Page Not Found',
+    description: 'The page you are looking for does not exist or has been moved.',
+    home: 'Go Home',
+  },
+}
+
+export default function NotFound({
+  params,
+}: {
+  params: { locale: string }
+}) {
+  const locale = params.locale || 'ja'
+  const t = messages[locale as keyof typeof messages] || messages.ja
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-6xl font-bold text-gray-200">404</h1>
+      <h2 className="text-2xl font-bold mt-4">{t.title}</h2>
+      <p className="text-gray-600 mt-2">{t.description}</p>
+      <Link
+        href={`/${locale}`}
+        className="mt-8 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+      >
+        {t.home}
+      </Link>
+    </div>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{locale}}` | 言語コード | `ja`, `en` |
+| `recentPosts` | 最近の投稿 | データベースから取得 |
+| `popularProducts` | 人気商品 | データベースから取得 |

--- a/.claude/skills/nextjs-app-router/SKILL.md
+++ b/.claude/skills/nextjs-app-router/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: nextjs-app-router
+description: |
+  Next.js App Routerのアーキテクチャと実装パターンを専門とするスキル。
+  Guillermo Rauchの「Server-First」「Convention over Configuration」思想に基づき、
+  高速で保守性の高いルーティング構造を設計・実装します。
+
+  専門分野:
+  - ディレクトリベースルーティング: フォルダ構造によるURL設計、特殊ファイル規約
+  - Server/Client Components: 適切なコンポーネント分離とレンダリング戦略
+  - Dynamic Routes: [slug]、[...slug]、[[...slug]]による動的ルーティング
+  - Route Groups: (folder)による論理グルーピングとレイアウト共有
+  - Parallel/Intercepting Routes: @folder、(..)による高度なルーティング
+
+  使用タイミング:
+  - Next.js App Routerのルーティング構造を設計する時
+  - Server ComponentsとClient Componentsの使い分けを判断する時
+  - 動的ルートやRoute Groupsを実装する時
+  - レンダリング戦略（Static/Dynamic/ISR）を選択する時
+
+  Use proactively when designing Next.js routing structures, implementing
+  App Router patterns, or deciding between Server and Client Components.
+version: 1.0.0
+---
+
+# Next.js App Router
+
+## 概要
+
+このスキルは、Vercel CEO / Next.js生みの親であるGuillermo Rauchの思想に基づき、
+Next.js App Routerの効果的な設計・実装パターンを提供します。
+
+**核心哲学**:
+- **Server-First**: サーバーをデフォルトとし、クライアントは例外として扱う
+- **Performance by Default**: パフォーマンスを後付けではなく、フレームワークに組み込む
+- **Convention over Configuration**: ファイルシステムがAPIとなる
+
+**主要な価値**:
+- ディレクトリベースの直感的なルーティング設計
+- 適切なServer/Client Components分離による最適なバンドルサイズ
+- レンダリング戦略の正しい選択によるパフォーマンス最適化
+
+## リソース構造
+
+```
+nextjs-app-router/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── routing-patterns.md                     # ルーティングパターン詳細
+│   ├── server-client-decision.md               # Server/Client判断フロー
+│   ├── rendering-strategies.md                 # レンダリング戦略ガイド
+│   └── layout-hierarchy.md                     # Layout階層設計
+├── scripts/
+│   └── analyze-routing-structure.mjs           # ルーティング構造分析スクリプト
+└── templates/
+    ├── page-template.md                        # Pageコンポーネントテンプレート
+    └── layout-template.md                      # Layoutコンポーネントテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# ルーティングパターン詳細
+cat .claude/skills/nextjs-app-router/resources/routing-patterns.md
+
+# Server/Client判断フロー
+cat .claude/skills/nextjs-app-router/resources/server-client-decision.md
+
+# レンダリング戦略ガイド
+cat .claude/skills/nextjs-app-router/resources/rendering-strategies.md
+
+# Layout階層設計
+cat .claude/skills/nextjs-app-router/resources/layout-hierarchy.md
+```
+
+### スクリプト実行
+
+```bash
+# ルーティング構造分析
+node .claude/skills/nextjs-app-router/scripts/analyze-routing-structure.mjs <app-directory>
+```
+
+### テンプレート参照
+
+```bash
+# Pageコンポーネントテンプレート
+cat .claude/skills/nextjs-app-router/templates/page-template.md
+
+# Layoutコンポーネントテンプレート
+cat .claude/skills/nextjs-app-router/templates/layout-template.md
+```
+
+## いつ使うか
+
+### シナリオ1: ルーティング構造設計
+**状況**: 新規プロジェクトまたは機能追加でURL構造を設計する
+
+**適用条件**:
+- [ ] 複数のページ・ルートが必要
+- [ ] URL階層の設計が求められる
+- [ ] 認証状態によるルート分離が必要
+
+**期待される成果**: 論理的で保守性の高いディレクトリ構造
+
+### シナリオ2: Server/Client判断
+**状況**: コンポーネントをServer ComponentにするかClient Componentにするか迷う
+
+**適用条件**:
+- [ ] データフェッチの要件がある
+- [ ] インタラクティブ性の要件がある
+- [ ] ブラウザAPIの使用が必要
+
+**期待される成果**: 適切なコンポーネント分類とバンドルサイズ最適化
+
+### シナリオ3: レンダリング戦略選択
+**状況**: Static Generation、Dynamic Rendering、ISRのどれを使うか迷う
+
+**適用条件**:
+- [ ] コンテンツの更新頻度が定義されている
+- [ ] パフォーマンス要件がある
+- [ ] SEO要件がある
+
+**期待される成果**: 要件に最適なレンダリング戦略の選択
+
+## 知識領域
+
+### 領域1: ディレクトリベースルーティング
+
+**特殊ファイル**:
+| ファイル | 役割 |
+|---------|------|
+| `page.tsx` | ルートのUIを定義 |
+| `layout.tsx` | 共有レイアウト（ナビゲーション時に再レンダリングされない） |
+| `template.tsx` | 共有テンプレート（ナビゲーション毎に再マウント） |
+| `loading.tsx` | 自動Suspense境界 |
+| `error.tsx` | エラー境界 |
+| `not-found.tsx` | 404エラーUI |
+
+**動的ルート構文**:
+| 構文 | 説明 | 例 |
+|------|------|-----|
+| `[slug]` | 単一動的セグメント | `/blog/[slug]` → `/blog/hello` |
+| `[...slug]` | Catch-all | `/docs/[...slug]` → `/docs/a/b/c` |
+| `[[...slug]]` | Optional Catch-all | ルート自体も含めてキャッチ |
+
+**詳細は**: `resources/routing-patterns.md` を参照
+
+### 領域2: Server/Client Components
+
+**判断基準**:
+```
+このコンポーネントは...
+├─ データフェッチが必要？
+│  └─ Yes → Server Component（async/await）
+├─ インタラクティブ性が必要？（onClick、useState等）
+│  └─ Yes → Client Component（"use client"）
+├─ ブラウザAPIが必要？（window、localStorage等）
+│  └─ Yes → Client Component
+└─ 上記すべてNo → Server Component（デフォルト）
+```
+
+**境界最適化原則**:
+- Client Componentは可能な限り下層（葉）に配置
+- Server ComponentをClient Componentのchildren propsで渡す
+- Context Providerは専用Client Componentに分離
+
+**詳細は**: `resources/server-client-decision.md` を参照
+
+### 領域3: レンダリング戦略
+
+| 戦略 | 使用ケース | 設定 |
+|------|-----------|------|
+| Static Generation | 完全静的コンテンツ | `dynamic = 'force-static'` |
+| Dynamic Rendering | リクエスト毎に変化 | `dynamic = 'force-dynamic'` |
+| ISR | 定期更新 | `revalidate = 秒数` |
+| Streaming SSR | 大量データ | `loading.tsx` + Suspense |
+
+**詳細は**: `resources/rendering-strategies.md` を参照
+
+### 領域4: Layout階層設計
+
+**Root Layout**: HTML構造、グローバル設定（フォント、メタデータ）
+**Group Layout**: 共有UI（ヘッダー、ナビ）、認証境界
+**Page Layout**: ページ固有のレイアウト
+
+**判断基準**:
+- 複数ページで共有するUI → Group Layout
+- 認証状態で分離 → `(auth)`、`(dashboard)` などのRoute Groups
+- 再レンダリングを避けたい重いロジック → Layout（1回のみ実行）
+
+**詳細は**: `resources/layout-hierarchy.md` を参照
+
+## ワークフロー
+
+### Phase 1: URL構造設計
+1. 要件からページ一覧を抽出
+2. URL階層とセグメント構造を設計
+3. 動的ルートの識別（[slug]、[id]等）
+4. Route Groupsによる論理分離を計画
+
+### Phase 2: レンダリング戦略選定
+1. 各ページのコンテンツ更新頻度を評価
+2. Static / Dynamic / ISRを選択
+3. Streaming SSRの必要性を判断
+
+### Phase 3: Layout階層設計
+1. Root Layoutの責務を定義
+2. Group Layoutsを計画
+3. 認証境界を設定
+
+### Phase 4: Server/Client分離
+1. 各コンポーネントの要件を分析
+2. Server Componentをデフォルトに
+3. Client Componentは明示的に最小限に
+
+### Phase 5: 実装と検証
+1. ディレクトリ構造を作成
+2. 特殊ファイル（page.tsx、layout.tsx等）を実装
+3. ルーティングが意図通り動作するか検証
+
+## 設計原則
+
+### Server-Firstの原則
+デフォルトはServer Component。Client Componentは明示的な"use client"で最小限に。
+
+### Convention over Configurationの原則
+ディレクトリ構造がルーティングを定義。特殊ファイル名による規約に従う。
+
+### Progressive Enhancementの原則
+サーバーレンダリングされたHTMLを基礎とし、JavaScriptは段階的な機能強化のみ。
+
+### Colocationの原則
+関連するファイル（page、layout、loading、error）は同じディレクトリに配置。
+
+## 関連スキル
+
+- `.claude/skills/server-components-patterns/SKILL.md` - データフェッチ最適化、Suspense活用
+- `.claude/skills/seo-optimization/SKILL.md` - Metadata API、動的OGP
+- `.claude/skills/web-performance/SKILL.md` - 動的インポート、画像最適化
+- `.claude/skills/error-handling-pages/SKILL.md` - error.tsx、not-found.tsx設計
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/nextjs-app-router/resources/layout-hierarchy.md
+++ b/.claude/skills/nextjs-app-router/resources/layout-hierarchy.md
@@ -1,0 +1,271 @@
+# Layout階層設計
+
+## Layout vs Template
+
+| 特性 | Layout | Template |
+|------|--------|----------|
+| 再レンダリング | ナビゲーション時に維持 | ナビゲーション毎に再マウント |
+| 状態保持 | 維持される | リセットされる |
+| Effect | 再実行されない | ナビゲーション毎に実行 |
+| 主な用途 | 共有UI、重い初期化 | ページ遷移アニメーション |
+
+## Layout階層構造
+
+```
+app/
+├── layout.tsx           # Root Layout（必須）
+│   ├── (marketing)/
+│   │   ├── layout.tsx   # マーケティング用Layout
+│   │   └── page.tsx
+│   ├── (dashboard)/
+│   │   ├── layout.tsx   # ダッシュボード用Layout
+│   │   └── settings/
+│   │       ├── layout.tsx  # 設定用Layout
+│   │       └── page.tsx
+```
+
+**レンダリング順序**:
+```
+Root Layout
+└── Group Layout
+    └── Nested Layout
+        └── Page
+```
+
+## Root Layout
+
+### 必須要件
+
+```typescript
+// app/layout.tsx
+import { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import './globals.css'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: {
+    default: 'My App',
+    template: '%s | My App',  // 子ページで上書き時のテンプレート
+  },
+  description: 'My application description',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja">
+      <body className={inter.className}>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+### Root Layoutの責務
+
+- **必須**: `<html>` と `<body>` タグ
+- グローバルCSS
+- フォント設定（next/font）
+- サイト全体のメタデータ
+- グローバルプロバイダー（Theme、Auth等）
+
+### Root Layoutに含めないもの
+
+- ページ固有のナビゲーション
+- 認証状態に依存するUI
+- 特定のRoute Groupのみで使うUI
+
+## Group Layout
+
+### 認証境界の実装
+
+```typescript
+// app/(protected)/layout.tsx
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+
+export default async function ProtectedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const session = await auth()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  return (
+    <div className="flex">
+      <Sidebar user={session.user} />
+      <main className="flex-1">{children}</main>
+    </div>
+  )
+}
+```
+
+### 共有UIの実装
+
+```typescript
+// app/(dashboard)/layout.tsx
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen">
+      <DashboardHeader />
+      <div className="flex">
+        <DashboardSidebar />
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  )
+}
+```
+
+## 並列ルートでのLayout
+
+```typescript
+// app/dashboard/layout.tsx
+export default function DashboardLayout({
+  children,
+  analytics,
+  team,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+  team: React.ReactNode
+}) {
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <main className="col-span-8">{children}</main>
+      <aside className="col-span-4 space-y-4">
+        {analytics}
+        {team}
+      </aside>
+    </div>
+  )
+}
+```
+
+## Template（特殊ケース）
+
+### ページ遷移アニメーション
+
+```typescript
+// app/template.tsx
+'use client'
+import { motion } from 'framer-motion'
+
+export default function Template({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.3 }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+```
+
+### フィードバックフォームのリセット
+
+```typescript
+// app/feedback/template.tsx
+// ナビゲーション毎にフォーム状態をリセット
+export default function FeedbackTemplate({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <div key={Date.now()}>{children}</div>
+}
+```
+
+## 設計判断フロー
+
+```
+このUIは...
+├─ 全ページで共通？
+│  └─ Yes → Root Layout
+├─ 複数ページで共有？
+│  ├─ 認証状態で分離が必要？
+│  │  └─ Yes → Route Group Layout（(public)、(protected)等）
+│  └─ 特定機能グループで共有？
+│     └─ Yes → Group Layout
+├─ ナビゲーション時に状態リセットが必要？
+│  └─ Yes → Template
+└─ ページ固有？
+   └─ Yes → Page内で実装
+```
+
+## パフォーマンス考慮
+
+### Layoutの最適化
+
+```typescript
+// ✅ 重い初期化はLayoutで（1回のみ実行）
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  const config = await fetchAppConfig() // ナビゲーション時は再実行されない
+  return (
+    <ConfigProvider config={config}>
+      {children}
+    </ConfigProvider>
+  )
+}
+
+// ❌ 重い処理をPageで（毎回実行）
+export default async function Page() {
+  const config = await fetchAppConfig() // ナビゲーション毎に実行
+  // ...
+}
+```
+
+### データフェッチの重複排除
+
+```typescript
+// LayoutとPageで同じデータをフェッチしても自動的に重複排除される
+// app/(dashboard)/layout.tsx
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  const user = await getUser() // この結果はキャッシュされる
+  return <UserNav user={user}>{children}</UserNav>
+}
+
+// app/(dashboard)/settings/page.tsx
+export default async function SettingsPage() {
+  const user = await getUser() // キャッシュからデータを取得（重複リクエストなし）
+  return <SettingsForm user={user} />
+}
+```
+
+## チェックリスト
+
+### Root Layout
+- [ ] `<html>` と `<body>` タグが含まれている
+- [ ] グローバルCSSがインポートされている
+- [ ] next/fontでフォントが設定されている
+- [ ] 基本メタデータが設定されている
+- [ ] グローバルプロバイダーが配置されている
+
+### Group Layout
+- [ ] 認証境界が適切に実装されている
+- [ ] 共有UIが正しく配置されている
+- [ ] Route Groupの命名が論理的
+- [ ] 必要なメタデータが上書きされている
+
+### 全般
+- [ ] Layoutの再レンダリング特性を理解している
+- [ ] Template と Layout の使い分けが適切
+- [ ] 重い処理がLayoutに配置されている
+- [ ] 並列ルートが適切に受け取られている

--- a/.claude/skills/nextjs-app-router/resources/rendering-strategies.md
+++ b/.claude/skills/nextjs-app-router/resources/rendering-strategies.md
@@ -1,0 +1,232 @@
+# レンダリング戦略ガイド
+
+## 戦略一覧
+
+| 戦略 | 生成タイミング | 更新方法 | 適用ケース |
+|------|--------------|---------|-----------|
+| Static Generation | ビルド時 | 再ビルド | 静的コンテンツ、ブログ |
+| ISR | ビルド時 + 再検証 | revalidate間隔 | 定期更新コンテンツ |
+| Dynamic Rendering | リクエスト時 | 毎回 | ユーザー固有データ |
+| Streaming SSR | リクエスト時（段階的） | 毎回 | 大量データ |
+
+## 判断フローチャート
+
+```
+このページは...
+├─ 完全静的コンテンツ？（全ユーザーに同じ内容）
+│  └─ Yes → Static Generation
+├─ 定期更新が必要？（1時間毎、1日毎など）
+│  └─ Yes → ISR（revalidate設定）
+├─ リクエスト毎に変化？
+│  └─ Yes → Dynamic Rendering
+├─ ユーザー固有データ？（認証、cookies）
+│  └─ Yes → Dynamic Rendering
+└─ 大量データ？（段階的表示が有効）
+   └─ Yes → Streaming SSR + Suspense
+```
+
+## Static Generation
+
+### 設定方法
+
+```typescript
+// app/about/page.tsx
+// デフォルトでStatic Generation（何も設定しない場合）
+
+// 明示的に設定
+export const dynamic = 'force-static'
+export const revalidate = false // 再検証しない
+```
+
+### 動的パラメータの静的生成
+
+```typescript
+// app/blog/[slug]/page.tsx
+export async function generateStaticParams() {
+  const posts = await getPosts()
+  return posts.map((post) => ({
+    slug: post.slug,
+  }))
+}
+
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const post = await getPost(slug)
+  return <article>{post.content}</article>
+}
+```
+
+### 適用ケース
+- マーケティングページ
+- ブログ記事（更新頻度が低い）
+- ドキュメンテーション
+- 製品カタログ（在庫変動なし）
+
+## ISR (Incremental Static Regeneration)
+
+### 設定方法
+
+```typescript
+// 時間ベースの再検証
+export const revalidate = 3600 // 1時間毎に再検証
+
+// または fetch 単位で設定
+const data = await fetch('https://api.example.com/data', {
+  next: { revalidate: 3600 }
+})
+```
+
+### On-Demand Revalidation
+
+```typescript
+// app/api/revalidate/route.ts
+import { revalidatePath, revalidateTag } from 'next/cache'
+
+export async function POST(request: Request) {
+  const { path, tag, secret } = await request.json()
+
+  // シークレットチェック
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return Response.json({ error: 'Invalid secret' }, { status: 401 })
+  }
+
+  // パスベースの再検証
+  if (path) {
+    revalidatePath(path)
+  }
+
+  // タグベースの再検証
+  if (tag) {
+    revalidateTag(tag)
+  }
+
+  return Response.json({ revalidated: true })
+}
+```
+
+### 適用ケース
+- ブログ（コメント付き）
+- ECサイト（在庫は1時間毎に更新）
+- ニュースサイト
+- CMS駆動コンテンツ
+
+## Dynamic Rendering
+
+### 設定方法
+
+```typescript
+// 明示的にDynamic Rendering
+export const dynamic = 'force-dynamic'
+
+// または動的関数の使用で自動的にDynamicになる
+import { cookies, headers } from 'next/headers'
+
+export default async function Page() {
+  const cookieStore = await cookies()
+  const headersList = await headers()
+  // この時点でDynamic Renderingになる
+}
+```
+
+### 動的関数
+
+以下を使用すると自動的にDynamic Renderingになる:
+- `cookies()`
+- `headers()`
+- `searchParams` prop
+- `unstable_noStore()`
+
+### 適用ケース
+- ダッシュボード（ユーザー固有）
+- 設定ページ
+- 検索結果（searchParams使用）
+- 認証が必要なページ
+
+## Streaming SSR
+
+### loading.tsx による自動Suspense
+
+```typescript
+// app/dashboard/loading.tsx
+export default function Loading() {
+  return <DashboardSkeleton />
+}
+
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  const data = await fetchDashboardData() // 時間がかかる
+  return <DashboardContent data={data} />
+}
+```
+
+### 手動Suspense境界
+
+```typescript
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>ダッシュボード</h1>
+
+      {/* 重要なコンテンツを先に表示 */}
+      <Suspense fallback={<StatsSkeleton />}>
+        <Stats />
+      </Suspense>
+
+      {/* 時間がかかるコンテンツは後から */}
+      <Suspense fallback={<ChartSkeleton />}>
+        <SlowChart />
+      </Suspense>
+
+      <Suspense fallback={<TableSkeleton />}>
+        <SlowTable />
+      </Suspense>
+    </div>
+  )
+}
+```
+
+### 適用ケース
+- ダッシュボード（複数のデータソース）
+- 分析ページ
+- レポートページ
+- 大量データの一覧表示
+
+## キャッシュ設定まとめ
+
+### Segment Config Options
+
+```typescript
+// 各ページ/レイアウトで設定可能
+export const dynamic = 'auto' | 'force-dynamic' | 'error' | 'force-static'
+export const revalidate = false | 0 | number
+export const fetchCache = 'auto' | 'default-cache' | 'only-cache' | 'force-cache' | 'force-no-store' | 'default-no-store' | 'only-no-store'
+export const runtime = 'nodejs' | 'edge'
+export const preferredRegion = 'auto' | 'global' | 'home' | string | string[]
+```
+
+### fetch オプション
+
+```typescript
+// キャッシュ設定
+fetch(url, { cache: 'force-cache' })  // デフォルト、キャッシュ使用
+fetch(url, { cache: 'no-store' })      // キャッシュ無効
+
+// 再検証設定
+fetch(url, { next: { revalidate: 3600 } })  // 時間ベース
+fetch(url, { next: { tags: ['posts'] } })   // タグベース
+```
+
+## パフォーマンス比較
+
+| 戦略 | TTFB | TTI | SEO | サーバー負荷 |
+|------|------|-----|-----|------------|
+| Static | 最速 | 最速 | 最良 | 最小 |
+| ISR | 速い | 速い | 良好 | 低 |
+| Dynamic | 遅い | 普通 | 良好 | 高 |
+| Streaming | 速い（部分） | 普通 | 良好 | 中 |

--- a/.claude/skills/nextjs-app-router/resources/routing-patterns.md
+++ b/.claude/skills/nextjs-app-router/resources/routing-patterns.md
@@ -1,0 +1,222 @@
+# ルーティングパターン詳細
+
+## 基本ルーティング
+
+### フォルダ構造とURL対応
+
+```
+app/
+├── page.tsx           → /
+├── about/
+│   └── page.tsx       → /about
+├── blog/
+│   ├── page.tsx       → /blog
+│   └── [slug]/
+│       └── page.tsx   → /blog/hello-world
+└── shop/
+    └── [...slug]/
+        └── page.tsx   → /shop/a/b/c
+```
+
+### 特殊ファイル優先順位
+
+```
+app/dashboard/
+├── layout.tsx     # 1. 最初にラップ
+├── template.tsx   # 2. layout内でラップ
+├── loading.tsx    # 3. Suspense境界
+├── error.tsx      # 4. ErrorBoundary
+├── not-found.tsx  # 5. 404 UI
+└── page.tsx       # 6. 実際のページコンテンツ
+```
+
+## 動的ルート
+
+### 単一動的セグメント [slug]
+
+```typescript
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <article>{/* slug を使用 */}</article>
+}
+
+// 静的パス生成（オプション）
+export async function generateStaticParams() {
+  const posts = await getPosts()
+  return posts.map((post) => ({ slug: post.slug }))
+}
+```
+
+### Catch-all セグメント [...slug]
+
+```typescript
+// app/docs/[...slug]/page.tsx
+// /docs/a → { slug: ['a'] }
+// /docs/a/b → { slug: ['a', 'b'] }
+// /docs/a/b/c → { slug: ['a', 'b', 'c'] }
+export default async function DocsPage({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return <div>{slug.join('/')}</div>
+}
+```
+
+### Optional Catch-all [[...slug]]
+
+```typescript
+// app/shop/[[...slug]]/page.tsx
+// /shop → { slug: undefined }
+// /shop/a → { slug: ['a'] }
+// /shop/a/b → { slug: ['a', 'b'] }
+```
+
+## Route Groups
+
+### 論理グルーピング（URLに影響しない）
+
+```
+app/
+├── (marketing)/
+│   ├── layout.tsx     # マーケティング用レイアウト
+│   ├── page.tsx       → /
+│   └── about/
+│       └── page.tsx   → /about
+├── (shop)/
+│   ├── layout.tsx     # ショップ用レイアウト
+│   └── products/
+│       └── page.tsx   → /products
+└── (dashboard)/
+    ├── layout.tsx     # ダッシュボード用レイアウト（認証必須）
+    └── settings/
+        └── page.tsx   → /settings
+```
+
+### 認証境界の実装例
+
+```
+app/
+├── (public)/           # 認証不要
+│   ├── layout.tsx
+│   ├── page.tsx        → /
+│   └── login/
+│       └── page.tsx    → /login
+└── (protected)/        # 認証必須
+    ├── layout.tsx      # AuthGuard を含む
+    ├── dashboard/
+    │   └── page.tsx    → /dashboard
+    └── settings/
+        └── page.tsx    → /settings
+```
+
+## 並列ルート
+
+### @folder構文
+
+```
+app/dashboard/
+├── layout.tsx          # 並列ルートを受け取る
+├── page.tsx
+├── @analytics/
+│   └── page.tsx        # 同時にレンダリング
+├── @team/
+│   └── page.tsx        # 同時にレンダリング
+└── @notifications/
+    ├── page.tsx
+    └── loading.tsx     # 独立したローディング状態
+```
+
+```typescript
+// app/dashboard/layout.tsx
+export default function DashboardLayout({
+  children,
+  analytics,
+  team,
+  notifications,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+  team: React.ReactNode
+  notifications: React.ReactNode
+}) {
+  return (
+    <div className="grid grid-cols-3">
+      <div>{children}</div>
+      <div>{analytics}</div>
+      <div>{team}</div>
+      <div>{notifications}</div>
+    </div>
+  )
+}
+```
+
+## インターセプティングルート
+
+### (..) 構文
+
+```
+app/
+├── feed/
+│   └── page.tsx            → /feed
+├── photo/
+│   └── [id]/
+│       └── page.tsx        → /photo/123（直接アクセス）
+└── @modal/
+    └── (.)photo/
+        └── [id]/
+            └── page.tsx    → モーダルでインターセプト
+```
+
+### インターセプト構文一覧
+
+| 構文 | 説明 |
+|------|------|
+| `(.)` | 同じレベルをマッチ |
+| `(..)` | 1つ上のレベルをマッチ |
+| `(..)(..)` | 2つ上のレベルをマッチ |
+| `(...)` | ルートからマッチ |
+
+## Private フォルダ
+
+### _folder（ルーティングから除外）
+
+```
+app/
+├── _components/        # ルーティングに含まれない
+│   └── Button.tsx
+├── _lib/               # ルーティングに含まれない
+│   └── utils.ts
+└── dashboard/
+    └── page.tsx
+```
+
+## プロジェクト固有構造例
+
+```
+app/
+├── api/                        # RESTful API Endpoints
+│   ├── webhook/
+│   │   └── generic/
+│   │       └── route.ts       # POST /api/webhook/generic
+│   ├── agent/
+│   │   ├── upload/
+│   │   │   └── route.ts       # POST /api/agent/upload
+│   │   └── poll/
+│   │       └── route.ts       # GET /api/agent/poll
+│   └── health/
+│       └── route.ts           # GET /api/health
+├── (public)/
+│   ├── layout.tsx
+│   └── page.tsx               # ダッシュボード（/）
+└── (dashboard)/
+    ├── layout.tsx             # 認証必須レイアウト
+    └── settings/
+        └── page.tsx           # /settings
+```

--- a/.claude/skills/nextjs-app-router/resources/server-client-decision.md
+++ b/.claude/skills/nextjs-app-router/resources/server-client-decision.md
@@ -1,0 +1,217 @@
+# Server/Client Components 判断フロー
+
+## 基本判断フローチャート
+
+```
+このコンポーネントは...
+
+1. データフェッチが必要？
+   ├─ Yes
+   │  ├─ サーバー専用リソース（DB、ファイルシステム）？
+   │  │  └─ Server Component（async/await）
+   │  └─ 外部API + クライアントインタラクション？
+   │     └─ Server Component + Client Component（子に分離）
+   └─ No → 次へ
+
+2. インタラクティブ性が必要？
+   ├─ Yes
+   │  ├─ onClick、onChange等のイベントハンドラ？
+   │  │  └─ Client Component（"use client"）
+   │  ├─ useState、useEffect等のReact Hooks？
+   │  │  └─ Client Component
+   │  └─ Context、Custom Hooks？
+   │     └─ Client Component（Providerは分離）
+   └─ No → 次へ
+
+3. ブラウザAPIが必要？
+   ├─ Yes（window、localStorage、document等）
+   │  └─ Client Component
+   └─ No → Server Component（デフォルト）
+```
+
+## Server Components
+
+### 特徴
+
+- **デフォルト**: "use client" なしのコンポーネントはすべてServer Component
+- **async/await対応**: 直接データフェッチ可能
+- **バンドルサイズ**: クライアントに送信されない
+- **アクセス**: サーバー専用リソース（DB、環境変数）に直接アクセス可能
+
+### 適用ケース
+
+```typescript
+// ✅ Server Component - データフェッチ
+async function UserProfile({ userId }: { userId: string }) {
+  const user = await db.user.findUnique({ where: { id: userId } })
+  return <div>{user.name}</div>
+}
+
+// ✅ Server Component - 静的コンテンツ
+function Footer() {
+  return <footer>© 2025 Company</footer>
+}
+
+// ✅ Server Component - 環境変数アクセス
+function ApiInfo() {
+  return <div>Version: {process.env.APP_VERSION}</div>
+}
+```
+
+### 禁止事項
+
+```typescript
+// ❌ Server Componentでは使用不可
+import { useState, useEffect } from 'react'
+
+function ServerComponent() {
+  const [count, setCount] = useState(0) // エラー
+  useEffect(() => {}, [])               // エラー
+  const handleClick = () => {}          // onClick使用不可
+}
+```
+
+## Client Components
+
+### 特徴
+
+- **明示的宣言**: ファイル先頭に `"use client"` が必要
+- **Hooks使用可能**: useState、useEffect、useContext等
+- **イベントハンドラ**: onClick、onChange等が使用可能
+- **ブラウザAPI**: window、localStorage等にアクセス可能
+
+### 適用ケース
+
+```typescript
+'use client'
+
+// ✅ Client Component - インタラクティブUI
+function Counter() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>
+}
+
+// ✅ Client Component - フォーム
+function LoginForm() {
+  const [email, setEmail] = useState('')
+  return <input value={email} onChange={(e) => setEmail(e.target.value)} />
+}
+
+// ✅ Client Component - ブラウザAPI
+function ThemeToggle() {
+  const [theme, setTheme] = useState(() =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  )
+  return <button onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>Toggle</button>
+}
+```
+
+## 境界最適化パターン
+
+### パターン1: Client Componentを葉に配置
+
+```typescript
+// ✅ 推奨: Client Componentは最下層に
+// Server Component (親)
+async function ProductPage({ id }: { id: string }) {
+  const product = await getProduct(id)
+  return (
+    <div>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+      <AddToCartButton productId={id} />  {/* Client Component */}
+    </div>
+  )
+}
+
+// Client Component (葉)
+'use client'
+function AddToCartButton({ productId }: { productId: string }) {
+  const [loading, setLoading] = useState(false)
+  const handleClick = async () => {
+    setLoading(true)
+    await addToCart(productId)
+    setLoading(false)
+  }
+  return <button onClick={handleClick} disabled={loading}>Add to Cart</button>
+}
+```
+
+### パターン2: children propsでServer Componentを渡す
+
+```typescript
+// Client Component (Provider)
+'use client'
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState('light')
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}  {/* Server Componentを含められる */}
+    </ThemeContext.Provider>
+  )
+}
+
+// Server Component (親)
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider>
+      <Header />       {/* Server Component */}
+      {children}       {/* Server Component */}
+      <Footer />       {/* Server Component */}
+    </ThemeProvider>
+  )
+}
+```
+
+### パターン3: Context Providerの分離
+
+```typescript
+// providers.tsx (Client Component)
+'use client'
+import { SessionProvider } from 'next-auth/react'
+import { ThemeProvider } from 'next-themes'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ThemeProvider>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  )
+}
+
+// layout.tsx (Server Component)
+import { Providers } from './providers'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Providers>
+          {children}
+        </Providers>
+      </body>
+    </html>
+  )
+}
+```
+
+## 判断チェックリスト
+
+### Server Component にすべきか？
+
+- [ ] データベースに直接アクセスする
+- [ ] 環境変数（シークレット）を使用する
+- [ ] ファイルシステムを読み取る
+- [ ] 大きなnpmパッケージを使用する（バンドル除外したい）
+- [ ] インタラクティブ性が不要
+
+### Client Component にすべきか？
+
+- [ ] onClick、onChange等のイベントハンドラを使用
+- [ ] useState、useReducer、useEffect を使用
+- [ ] useContext でContextを消費
+- [ ] カスタムHooksを使用
+- [ ] ブラウザAPI（window、localStorage）を使用
+- [ ] React.lazy、Suspenseを使用

--- a/.claude/skills/nextjs-app-router/scripts/analyze-routing-structure.mjs
+++ b/.claude/skills/nextjs-app-router/scripts/analyze-routing-structure.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+/**
+ * Next.js App Router ルーティング構造分析スクリプト
+ *
+ * 使用方法:
+ *   node analyze-routing-structure.mjs <app-directory>
+ *
+ * 例:
+ *   node analyze-routing-structure.mjs ./src/app
+ *   node analyze-routing-structure.mjs ./app
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const SPECIAL_FILES = [
+  'page.tsx', 'page.ts', 'page.jsx', 'page.js',
+  'layout.tsx', 'layout.ts', 'layout.jsx', 'layout.js',
+  'template.tsx', 'template.ts', 'template.jsx', 'template.js',
+  'loading.tsx', 'loading.ts', 'loading.jsx', 'loading.js',
+  'error.tsx', 'error.ts', 'error.jsx', 'error.js',
+  'not-found.tsx', 'not-found.ts', 'not-found.jsx', 'not-found.js',
+  'route.tsx', 'route.ts', 'route.jsx', 'route.js',
+];
+
+const DYNAMIC_SEGMENT_PATTERNS = {
+  single: /^\[([^\[\]\.]+)\]$/,        // [slug]
+  catchAll: /^\[\.\.\.([^\]]+)\]$/,    // [...slug]
+  optionalCatchAll: /^\[\[\.\.\.([^\]]+)\]\]$/, // [[...slug]]
+};
+
+class RoutingAnalyzer {
+  constructor(appDir) {
+    this.appDir = path.resolve(appDir);
+    this.routes = [];
+    this.layouts = [];
+    this.routeGroups = [];
+    this.parallelRoutes = [];
+    this.dynamicRoutes = [];
+    this.apiRoutes = [];
+    this.issues = [];
+  }
+
+  analyze() {
+    if (!fs.existsSync(this.appDir)) {
+      console.error(`Error: Directory not found: ${this.appDir}`);
+      process.exit(1);
+    }
+
+    console.log(`\n📂 Analyzing: ${this.appDir}\n`);
+    console.log('='.repeat(60));
+
+    this.scanDirectory(this.appDir, '');
+
+    this.printRoutes();
+    this.printLayouts();
+    this.printRouteGroups();
+    this.printParallelRoutes();
+    this.printDynamicRoutes();
+    this.printApiRoutes();
+    this.printIssues();
+    this.printSummary();
+  }
+
+  scanDirectory(dir, urlPath) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    // Check for special files
+    const specialFiles = {};
+    for (const entry of entries) {
+      if (entry.isFile() && SPECIAL_FILES.includes(entry.name)) {
+        const type = entry.name.split('.')[0];
+        specialFiles[type] = entry.name;
+      }
+    }
+
+    // Record route if page or route exists
+    if (specialFiles.page) {
+      this.routes.push({
+        path: urlPath || '/',
+        file: path.join(dir, specialFiles.page),
+        type: 'page',
+      });
+    }
+
+    if (specialFiles.route) {
+      this.apiRoutes.push({
+        path: urlPath || '/',
+        file: path.join(dir, specialFiles.route),
+      });
+    }
+
+    if (specialFiles.layout) {
+      this.layouts.push({
+        path: urlPath || '/',
+        file: path.join(dir, specialFiles.layout),
+      });
+    }
+
+    // Check for issues
+    if (specialFiles.page && specialFiles.route) {
+      this.issues.push({
+        type: 'conflict',
+        message: `page and route conflict at ${urlPath || '/'}`,
+        path: urlPath,
+      });
+    }
+
+    if (specialFiles.error && !specialFiles.error.includes('use client')) {
+      // Note: We can't actually check file contents here without reading
+      // This is a simplified check
+    }
+
+    // Scan subdirectories
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const name = entry.name;
+      const fullPath = path.join(dir, name);
+
+      // Skip private folders
+      if (name.startsWith('_')) continue;
+
+      // Route Groups (folder)
+      if (name.startsWith('(') && name.endsWith(')')) {
+        const groupName = name.slice(1, -1);
+        this.routeGroups.push({
+          name: groupName,
+          path: fullPath,
+        });
+        // Route groups don't affect URL
+        this.scanDirectory(fullPath, urlPath);
+        continue;
+      }
+
+      // Parallel Routes @folder
+      if (name.startsWith('@')) {
+        const slotName = name.slice(1);
+        this.parallelRoutes.push({
+          name: slotName,
+          path: fullPath,
+          parentPath: urlPath,
+        });
+        this.scanDirectory(fullPath, urlPath);
+        continue;
+      }
+
+      // Intercepting Routes
+      if (name.startsWith('(.)') || name.startsWith('(..)')) {
+        // Skip URL path addition for intercepting routes
+        this.scanDirectory(fullPath, urlPath);
+        continue;
+      }
+
+      // Dynamic segments
+      let segmentUrl = name;
+      if (DYNAMIC_SEGMENT_PATTERNS.optionalCatchAll.test(name)) {
+        const match = name.match(DYNAMIC_SEGMENT_PATTERNS.optionalCatchAll);
+        this.dynamicRoutes.push({
+          type: 'optionalCatchAll',
+          param: match[1],
+          path: path.join(urlPath, name),
+        });
+        segmentUrl = `[[...${match[1]}]]`;
+      } else if (DYNAMIC_SEGMENT_PATTERNS.catchAll.test(name)) {
+        const match = name.match(DYNAMIC_SEGMENT_PATTERNS.catchAll);
+        this.dynamicRoutes.push({
+          type: 'catchAll',
+          param: match[1],
+          path: path.join(urlPath, name),
+        });
+        segmentUrl = `[...${match[1]}]`;
+      } else if (DYNAMIC_SEGMENT_PATTERNS.single.test(name)) {
+        const match = name.match(DYNAMIC_SEGMENT_PATTERNS.single);
+        this.dynamicRoutes.push({
+          type: 'single',
+          param: match[1],
+          path: path.join(urlPath, name),
+        });
+        segmentUrl = `:${match[1]}`;
+      }
+
+      const newUrlPath = urlPath + '/' + segmentUrl;
+      this.scanDirectory(fullPath, newUrlPath);
+    }
+  }
+
+  printRoutes() {
+    console.log('\n📄 Pages:');
+    console.log('-'.repeat(40));
+    if (this.routes.length === 0) {
+      console.log('  (no pages found)');
+    } else {
+      for (const route of this.routes.sort((a, b) => a.path.localeCompare(b.path))) {
+        console.log(`  ${route.path}`);
+      }
+    }
+  }
+
+  printLayouts() {
+    console.log('\n🏗️  Layouts:');
+    console.log('-'.repeat(40));
+    if (this.layouts.length === 0) {
+      console.log('  (no layouts found)');
+    } else {
+      for (const layout of this.layouts.sort((a, b) => a.path.localeCompare(b.path))) {
+        console.log(`  ${layout.path || '/'} → ${path.basename(layout.file)}`);
+      }
+    }
+  }
+
+  printRouteGroups() {
+    console.log('\n📁 Route Groups:');
+    console.log('-'.repeat(40));
+    if (this.routeGroups.length === 0) {
+      console.log('  (no route groups found)');
+    } else {
+      for (const group of this.routeGroups) {
+        console.log(`  (${group.name})`);
+      }
+    }
+  }
+
+  printParallelRoutes() {
+    console.log('\n⚡ Parallel Routes:');
+    console.log('-'.repeat(40));
+    if (this.parallelRoutes.length === 0) {
+      console.log('  (no parallel routes found)');
+    } else {
+      for (const slot of this.parallelRoutes) {
+        console.log(`  @${slot.name} at ${slot.parentPath || '/'}`);
+      }
+    }
+  }
+
+  printDynamicRoutes() {
+    console.log('\n🔀 Dynamic Routes:');
+    console.log('-'.repeat(40));
+    if (this.dynamicRoutes.length === 0) {
+      console.log('  (no dynamic routes found)');
+    } else {
+      for (const route of this.dynamicRoutes) {
+        const typeLabel = {
+          single: '[param]',
+          catchAll: '[...param]',
+          optionalCatchAll: '[[...param]]',
+        }[route.type];
+        console.log(`  ${route.path} (${typeLabel}: ${route.param})`);
+      }
+    }
+  }
+
+  printApiRoutes() {
+    console.log('\n🌐 API Routes:');
+    console.log('-'.repeat(40));
+    if (this.apiRoutes.length === 0) {
+      console.log('  (no API routes found)');
+    } else {
+      for (const route of this.apiRoutes.sort((a, b) => a.path.localeCompare(b.path))) {
+        console.log(`  ${route.path}`);
+      }
+    }
+  }
+
+  printIssues() {
+    console.log('\n⚠️  Issues:');
+    console.log('-'.repeat(40));
+    if (this.issues.length === 0) {
+      console.log('  ✅ No issues found');
+    } else {
+      for (const issue of this.issues) {
+        console.log(`  ❌ ${issue.message}`);
+      }
+    }
+  }
+
+  printSummary() {
+    console.log('\n' + '='.repeat(60));
+    console.log('📊 Summary:');
+    console.log('-'.repeat(40));
+    console.log(`  Pages:          ${this.routes.length}`);
+    console.log(`  Layouts:        ${this.layouts.length}`);
+    console.log(`  Route Groups:   ${this.routeGroups.length}`);
+    console.log(`  Parallel Routes: ${this.parallelRoutes.length}`);
+    console.log(`  Dynamic Routes: ${this.dynamicRoutes.length}`);
+    console.log(`  API Routes:     ${this.apiRoutes.length}`);
+    console.log(`  Issues:         ${this.issues.length}`);
+    console.log('='.repeat(60) + '\n');
+  }
+}
+
+// Main execution
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.log('Usage: node analyze-routing-structure.mjs <app-directory>');
+  console.log('Example: node analyze-routing-structure.mjs ./src/app');
+  process.exit(1);
+}
+
+const analyzer = new RoutingAnalyzer(args[0]);
+analyzer.analyze();

--- a/.claude/skills/nextjs-app-router/templates/layout-template.md
+++ b/.claude/skills/nextjs-app-router/templates/layout-template.md
@@ -1,0 +1,285 @@
+# Layout コンポーネントテンプレート
+
+## Root Layout
+
+```typescript
+// app/layout.tsx
+import type { Metadata, Viewport } from 'next'
+import { Inter } from 'next/font/google'
+import './globals.css'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+})
+
+export const metadata: Metadata = {
+  title: {
+    default: '{{SiteName}}',
+    template: '%s | {{SiteName}}',
+  },
+  description: '{{SiteDescription}}',
+  keywords: ['{{keyword1}}', '{{keyword2}}'],
+  authors: [{ name: '{{AuthorName}}' }],
+  creator: '{{CreatorName}}',
+  openGraph: {
+    type: 'website',
+    locale: 'ja_JP',
+    url: '{{SiteUrl}}',
+    siteName: '{{SiteName}}',
+    images: [
+      {
+        url: '{{OgImageUrl}}',
+        width: 1200,
+        height: 630,
+        alt: '{{SiteName}}',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: '@{{TwitterHandle}}',
+    creator: '@{{TwitterHandle}}',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#000000' },
+  ],
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja" className={inter.variable}>
+      <body className={inter.className}>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+## Providers を含む Root Layout
+
+```typescript
+// app/layout.tsx
+import { Providers } from './providers'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja" suppressHydrationWarning>
+      <body>
+        <Providers>
+          {children}
+        </Providers>
+      </body>
+    </html>
+  )
+}
+
+// app/providers.tsx
+'use client'
+
+import { ThemeProvider } from 'next-themes'
+import { SessionProvider } from 'next-auth/react'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  )
+}
+```
+
+## 認証付き Group Layout
+
+```typescript
+// app/(protected)/layout.tsx
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { Sidebar } from '@/components/sidebar'
+import { Header } from '@/components/header'
+
+export default async function ProtectedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const session = await auth()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar user={session.user} />
+      <div className="flex flex-1 flex-col">
+        <Header user={session.user} />
+        <main className="flex-1 p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}
+```
+
+## 共有 UI を含む Group Layout
+
+```typescript
+// app/(marketing)/layout.tsx
+import { Header } from '@/components/marketing/header'
+import { Footer } from '@/components/marketing/footer'
+
+export default function MarketingLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen">
+        {children}
+      </main>
+      <Footer />
+    </>
+  )
+}
+```
+
+## 並列ルート対応 Layout
+
+```typescript
+// app/dashboard/layout.tsx
+export default function DashboardLayout({
+  children,
+  analytics,
+  team,
+  notifications,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+  team: React.ReactNode
+  notifications: React.ReactNode
+}) {
+  return (
+    <div className="grid grid-cols-12 gap-6 p-6">
+      {/* メインコンテンツ */}
+      <main className="col-span-8">
+        {children}
+      </main>
+
+      {/* サイドパネル */}
+      <aside className="col-span-4 space-y-6">
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-4 font-semibold">Analytics</h2>
+          {analytics}
+        </section>
+
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-4 font-semibold">Team</h2>
+          {team}
+        </section>
+
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-4 font-semibold">Notifications</h2>
+          {notifications}
+        </section>
+      </aside>
+    </div>
+  )
+}
+```
+
+## Metadata 継承 Layout
+
+```typescript
+// app/blog/layout.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Blog',
+    template: '%s | Blog | {{SiteName}}',
+  },
+  description: 'Latest articles and insights',
+  openGraph: {
+    type: 'website',
+    title: 'Blog',
+    description: 'Latest articles and insights',
+  },
+}
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-8">
+      {children}
+    </div>
+  )
+}
+```
+
+## Template（ページ遷移アニメーション用）
+
+```typescript
+// app/template.tsx
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function Template({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{
+        type: 'spring',
+        stiffness: 260,
+        damping: 20,
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{SiteName}}` | サイト名 | `My App` |
+| `{{SiteDescription}}` | サイト説明 | `最高のWebアプリケーション` |
+| `{{SiteUrl}}` | サイトURL | `https://example.com` |
+| `{{OgImageUrl}}` | OGP画像URL | `https://example.com/og.png` |
+| `{{TwitterHandle}}` | Twitterハンドル | `myapp` |
+| `{{AuthorName}}` | 著者名 | `John Doe` |
+| `{{CreatorName}}` | 制作者名 | `My Company` |
+| `{{keyword1}}`, `{{keyword2}}` | SEOキーワード | `web app`, `next.js` |

--- a/.claude/skills/nextjs-app-router/templates/page-template.md
+++ b/.claude/skills/nextjs-app-router/templates/page-template.md
@@ -1,0 +1,194 @@
+# Page コンポーネントテンプレート
+
+## 基本的な Server Component Page
+
+```typescript
+// app/[feature]/page.tsx
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '{{PageTitle}}',
+  description: '{{PageDescription}}',
+}
+
+export default async function {{PageName}}Page() {
+  // Server Component: データフェッチ可能
+  const data = await fetchData()
+
+  return (
+    <main>
+      <h1>{{PageTitle}}</h1>
+      {/* コンテンツ */}
+    </main>
+  )
+}
+```
+
+## 動的ルート Page
+
+```typescript
+// app/{{resource}}/[{{param}}]/page.tsx
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+type Props = {
+  params: Promise<{ {{param}}: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { {{param}} } = await params
+  const item = await getItem({{param}})
+
+  if (!item) {
+    return { title: 'Not Found' }
+  }
+
+  return {
+    title: item.title,
+    description: item.description,
+    openGraph: {
+      title: item.title,
+      description: item.description,
+      images: [item.image],
+    },
+  }
+}
+
+export async function generateStaticParams() {
+  const items = await getAllItems()
+  return items.map((item) => ({
+    {{param}}: item.{{param}},
+  }))
+}
+
+export default async function {{PageName}}Page({ params }: Props) {
+  const { {{param}} } = await params
+  const item = await getItem({{param}})
+
+  if (!item) {
+    notFound()
+  }
+
+  return (
+    <article>
+      <h1>{item.title}</h1>
+      {/* コンテンツ */}
+    </article>
+  )
+}
+```
+
+## Client Component を含む Page
+
+```typescript
+// app/{{feature}}/page.tsx
+import { Suspense } from 'react'
+import { InteractiveSection } from './interactive-section'
+import { DataSkeleton } from './data-skeleton'
+
+export default async function {{PageName}}Page() {
+  // Server側でデータ取得
+  const initialData = await fetchInitialData()
+
+  return (
+    <main>
+      <h1>{{PageTitle}}</h1>
+
+      {/* 静的コンテンツ (Server Component) */}
+      <section>
+        <StaticContent data={initialData} />
+      </section>
+
+      {/* インタラクティブ部分 (Client Component) */}
+      <Suspense fallback={<DataSkeleton />}>
+        <InteractiveSection initialData={initialData} />
+      </Suspense>
+    </main>
+  )
+}
+```
+
+## ISR 設定付き Page
+
+```typescript
+// app/{{feature}}/page.tsx
+
+// ISR: 1時間毎に再検証
+export const revalidate = 3600
+
+export default async function {{PageName}}Page() {
+  const data = await fetch('{{apiUrl}}', {
+    next: { revalidate: 3600 },
+  }).then(res => res.json())
+
+  return (
+    <main>
+      <h1>{{PageTitle}}</h1>
+      <p>Last updated: {new Date().toISOString()}</p>
+      {/* コンテンツ */}
+    </main>
+  )
+}
+```
+
+## Dynamic Rendering Page
+
+```typescript
+// app/{{feature}}/page.tsx
+import { cookies, headers } from 'next/headers'
+
+// 動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
+export default async function {{PageName}}Page() {
+  const cookieStore = await cookies()
+  const headersList = await headers()
+
+  const userPreference = cookieStore.get('preference')?.value
+  const userAgent = headersList.get('user-agent')
+
+  return (
+    <main>
+      <h1>{{PageTitle}}</h1>
+      {/* ユーザー固有のコンテンツ */}
+    </main>
+  )
+}
+```
+
+## searchParams を使用する Page
+
+```typescript
+// app/{{feature}}/page.tsx
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export default async function {{PageName}}Page({ searchParams }: Props) {
+  const params = await searchParams
+  const query = typeof params.q === 'string' ? params.q : ''
+  const page = typeof params.page === 'string' ? parseInt(params.page, 10) : 1
+
+  const results = await search(query, page)
+
+  return (
+    <main>
+      <h1>Search Results for "{query}"</h1>
+      <SearchResults results={results} />
+      <Pagination currentPage={page} />
+    </main>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{PageName}}` | Page コンポーネント名（PascalCase） | `BlogPost`, `UserProfile` |
+| `{{PageTitle}}` | ページタイトル | `ブログ記事`, `ユーザープロフィール` |
+| `{{PageDescription}}` | メタディスクリプション | `最新のブログ記事一覧` |
+| `{{feature}}` | 機能名（kebab-case） | `blog`, `user-profile` |
+| `{{resource}}` | リソース名（複数形） | `posts`, `users` |
+| `{{param}}` | 動的パラメータ名 | `slug`, `id`, `username` |
+| `{{apiUrl}}` | データフェッチURL | `https://api.example.com/data` |

--- a/.claude/skills/seo-optimization/SKILL.md
+++ b/.claude/skills/seo-optimization/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: seo-optimization
+description: |
+  Next.js Metadata APIを活用したSEO最適化を専門とするスキル。
+  検索エンジン最適化、OGP設定、構造化データによるリッチリザルトを実現します。
+
+  専門分野:
+  - Metadata API: 静的・動的メタデータの設計と実装
+  - OGP設定: Open Graph Protocol、Twitter Card設定
+  - 構造化データ: JSON-LD、Schema.org対応
+  - サイトマップ/robots: 自動生成、クロール制御
+
+  使用タイミング:
+  - ページのメタデータを設計・実装する時
+  - OGP画像やTwitter Cardを設定する時
+  - 構造化データでリッチリザルトを実装する時
+  - サイトマップやrobots.txtを設定する時
+
+  Use proactively when implementing SEO features, Metadata API,
+  or structured data for rich results.
+version: 1.0.0
+---
+
+# SEO Optimization
+
+## 概要
+
+このスキルは、Next.js App RouterのMetadata APIを活用したSEO最適化の
+ベストプラクティスを提供します。検索エンジン可視性の向上とソーシャル
+シェア時の表示最適化を実現します。
+
+**核心哲学**:
+- **Discoverable**: 検索エンジンに正しく理解されるコンテンツ
+- **Shareable**: ソーシャルメディアで魅力的に表示される
+- **Accessible**: すべてのユーザーとクローラーがアクセス可能
+
+**主要な価値**:
+- Metadata APIによる型安全なメタデータ管理
+- 動的メタデータ生成による個別ページ最適化
+- 構造化データによるリッチリザルト獲得
+
+## リソース構造
+
+```
+seo-optimization/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── metadata-api-guide.md                   # Metadata APIガイド
+│   ├── ogp-twitter-cards.md                    # OGP/Twitter Card設定
+│   ├── structured-data.md                      # 構造化データ
+│   └── sitemap-robots.md                       # サイトマップ/robots.txt
+├── scripts/
+│   └── analyze-seo.mjs                         # SEO分析スクリプト
+└── templates/
+    ├── metadata-template.md                    # メタデータテンプレート
+    └── structured-data-template.md             # 構造化データテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# Metadata APIガイド
+cat .claude/skills/seo-optimization/resources/metadata-api-guide.md
+
+# OGP/Twitter Card設定
+cat .claude/skills/seo-optimization/resources/ogp-twitter-cards.md
+
+# 構造化データ
+cat .claude/skills/seo-optimization/resources/structured-data.md
+
+# サイトマップ/robots.txt
+cat .claude/skills/seo-optimization/resources/sitemap-robots.md
+```
+
+### スクリプト実行
+
+```bash
+# SEO分析
+node .claude/skills/seo-optimization/scripts/analyze-seo.mjs <app-directory>
+```
+
+### テンプレート参照
+
+```bash
+# メタデータテンプレート
+cat .claude/skills/seo-optimization/templates/metadata-template.md
+
+# 構造化データテンプレート
+cat .claude/skills/seo-optimization/templates/structured-data-template.md
+```
+
+## いつ使うか
+
+### シナリオ1: ページメタデータ設定
+**状況**: 新しいページにSEOメタデータを設定する
+
+**適用条件**:
+- [ ] ページのtitle、descriptionが必要
+- [ ] OGP画像の設定が必要
+- [ ] 検索エンジン表示を最適化したい
+
+**期待される成果**: 検索結果とソーシャルシェアで最適な表示
+
+### シナリオ2: 動的メタデータ生成
+**状況**: 動的ルート（[slug]等）のメタデータを生成する
+
+**適用条件**:
+- [ ] 動的パラメータに基づくメタデータが必要
+- [ ] データベースやAPIからメタデータを取得
+- [ ] 各ページ固有のOGP画像が必要
+
+**期待される成果**: 動的コンテンツに対応したSEO最適化
+
+### シナリオ3: リッチリザルト実装
+**状況**: 検索結果でリッチスニペットを表示したい
+
+**適用条件**:
+- [ ] 記事、製品、FAQなどの構造化データが必要
+- [ ] パンくずリストの構造化データが必要
+- [ ] レビュー、評価の表示が必要
+
+**期待される成果**: 検索結果でのリッチリザルト表示
+
+## 知識領域
+
+### 領域1: Metadata API
+
+**静的メタデータ**:
+```typescript
+export const metadata: Metadata = {
+  title: 'Page Title',
+  description: 'Page description...',
+}
+```
+
+**動的メタデータ**:
+```typescript
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const data = await fetchData(params.id)
+  return {
+    title: data.title,
+    description: data.description,
+  }
+}
+```
+
+**詳細は**: `resources/metadata-api-guide.md` を参照
+
+### 領域2: OGP/Twitter Card
+
+**必須設定**:
+- `og:title`: ページタイトル
+- `og:description`: 説明文
+- `og:image`: 1200x630pxの画像
+- `twitter:card`: `summary_large_image`
+
+**詳細は**: `resources/ogp-twitter-cards.md` を参照
+
+### 領域3: 構造化データ
+
+**主要なスキーマ**:
+- `Article`: ブログ記事、ニュース
+- `Product`: 商品ページ
+- `BreadcrumbList`: パンくずリスト
+- `FAQPage`: よくある質問
+
+**詳細は**: `resources/structured-data.md` を参照
+
+### 領域4: サイトマップ/robots
+
+**sitemap.ts**:
+```typescript
+export default async function sitemap() {
+  const pages = await getPages()
+  return pages.map((page) => ({
+    url: `https://example.com${page.path}`,
+    lastModified: page.updatedAt,
+  }))
+}
+```
+
+**詳細は**: `resources/sitemap-robots.md` を参照
+
+## ワークフロー
+
+### Phase 1: 要件分析
+1. SEO目標を確認（検索順位、CTR等）
+2. 対象ページを特定
+3. 競合分析を実施
+
+### Phase 2: メタデータ設計
+1. タイトル戦略を決定
+2. description最適化
+3. OGP画像を準備
+
+### Phase 3: 実装
+1. Root Layoutのデフォルトメタデータ
+2. 各ページの静的/動的メタデータ
+3. 構造化データの追加
+
+### Phase 4: 検証
+1. メタデータの表示確認
+2. OGPプレビュー確認
+3. 構造化データテスト
+
+### Phase 5: 監視
+1. Search Consoleで監視
+2. CTRの改善
+3. 定期的な更新
+
+## 設計原則
+
+### ユニーク性の原則
+各ページには固有のtitleとdescriptionを設定する。
+
+### 階層的継承の原則
+Root Layoutでデフォルトを設定し、子ページで上書きする。
+
+### データ駆動の原則
+動的コンテンツには必ず動的メタデータを生成する。
+
+### 検証の原則
+実装後は必ずプレビューと構造化データテストを実行する。
+
+## 関連スキル
+
+- `.claude/skills/nextjs-app-router/SKILL.md` - ルーティング構造
+- `.claude/skills/server-components-patterns/SKILL.md` - データフェッチ
+- `.claude/skills/web-performance/SKILL.md` - パフォーマンス最適化
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/seo-optimization/resources/metadata-api-guide.md
+++ b/.claude/skills/seo-optimization/resources/metadata-api-guide.md
@@ -1,0 +1,358 @@
+# Metadata API ガイド
+
+## 概要
+
+Next.js App RouterのMetadata APIは、型安全なメタデータ管理を提供します。
+SEOとソーシャルシェアの最適化に必須の機能です。
+
+## 静的メタデータ
+
+### 基本設定
+
+```typescript
+// app/layout.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'サイトタイトル',
+  description: 'サイトの説明文（160文字以内推奨）',
+}
+```
+
+### 完全な設定例
+
+```typescript
+// app/layout.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  // 基本メタデータ
+  title: {
+    default: 'サイト名',
+    template: '%s | サイト名', // 子ページで使用されるテンプレート
+  },
+  description: 'サイトの説明文',
+  keywords: ['キーワード1', 'キーワード2'],
+  authors: [{ name: '作者名', url: 'https://example.com' }],
+  creator: '作成者',
+  publisher: '発行者',
+
+  // アイコン
+  icons: {
+    icon: '/favicon.ico',
+    shortcut: '/shortcut-icon.png',
+    apple: '/apple-touch-icon.png',
+    other: {
+      rel: 'apple-touch-icon-precomposed',
+      url: '/apple-touch-icon-precomposed.png',
+    },
+  },
+
+  // マニフェスト
+  manifest: '/manifest.json',
+
+  // Open Graph
+  openGraph: {
+    title: 'OGタイトル',
+    description: 'OG説明文',
+    url: 'https://example.com',
+    siteName: 'サイト名',
+    images: [
+      {
+        url: 'https://example.com/og.png',
+        width: 1200,
+        height: 630,
+        alt: 'OG画像の説明',
+      },
+    ],
+    locale: 'ja_JP',
+    type: 'website',
+  },
+
+  // Twitter Card
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Twitterタイトル',
+    description: 'Twitter説明文',
+    creator: '@username',
+    images: ['https://example.com/twitter.png'],
+  },
+
+  // 検索エンジン制御
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+
+  // 検証
+  verification: {
+    google: 'google-site-verification-code',
+    yandex: 'yandex-verification-code',
+    yahoo: 'yahoo-verification-code',
+  },
+
+  // 代替言語
+  alternates: {
+    canonical: 'https://example.com',
+    languages: {
+      'en-US': 'https://example.com/en-US',
+      'ja-JP': 'https://example.com/ja-JP',
+    },
+  },
+
+  // カテゴリ
+  category: 'technology',
+}
+```
+
+## 動的メタデータ
+
+### generateMetadata関数
+
+```typescript
+// app/posts/[slug]/page.tsx
+import type { Metadata, ResolvingMetadata } from 'next'
+
+type Props = {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export async function generateMetadata(
+  { params, searchParams }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const { slug } = await params
+
+  // データを取得
+  const post = await getPost(slug)
+
+  // 親のメタデータを取得（オプショナル）
+  const previousImages = (await parent).openGraph?.images || []
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      images: [post.ogImage, ...previousImages],
+    },
+  }
+}
+
+export default async function PostPage({ params }: Props) {
+  const { slug } = await params
+  const post = await getPost(slug)
+
+  return <article>{/* ... */}</article>
+}
+```
+
+### 動的OGP画像
+
+```typescript
+// app/posts/[slug]/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = '投稿のサムネイル'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OGImage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const post = await getPost(params.slug)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(to bottom, #1a1a2e, #16213e)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '40px',
+        }}
+      >
+        <h1 style={{ color: 'white', fontSize: 60, textAlign: 'center' }}>
+          {post.title}
+        </h1>
+        <p style={{ color: '#8892b0', fontSize: 30 }}>{post.author}</p>
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+## メタデータの継承
+
+### 階層構造
+
+```
+app/
+├── layout.tsx        # ベースメタデータ（title.template設定）
+├── page.tsx          # ホームページメタデータ
+└── blog/
+    ├── layout.tsx    # ブログセクションのメタデータ
+    └── [slug]/
+        └── page.tsx  # 個別記事のメタデータ（動的）
+```
+
+### titleテンプレート
+
+```typescript
+// app/layout.tsx
+export const metadata: Metadata = {
+  title: {
+    default: 'My Site',
+    template: '%s | My Site',
+  },
+}
+
+// app/blog/page.tsx
+export const metadata: Metadata = {
+  title: 'Blog', // → "Blog | My Site"
+}
+
+// app/blog/[slug]/page.tsx
+export async function generateMetadata({ params }) {
+  const post = await getPost(params.slug)
+  return {
+    title: post.title, // → "Post Title | My Site"
+  }
+}
+```
+
+### absoluteの使用
+
+```typescript
+// テンプレートを無視して絶対的なタイトルを設定
+export const metadata: Metadata = {
+  title: {
+    absolute: 'Custom Title', // → "Custom Title"（テンプレートを無視）
+  },
+}
+```
+
+## ファイルベースのメタデータ
+
+### 特殊ファイル
+
+```
+app/
+├── favicon.ico           # ファビコン
+├── icon.png              # アプリアイコン
+├── icon.svg              # SVGアイコン
+├── apple-icon.png        # Apple Touch Icon
+├── opengraph-image.png   # デフォルトOGP画像
+├── twitter-image.png     # デフォルトTwitter画像
+├── sitemap.ts            # サイトマップ
+├── robots.ts             # robots.txt
+└── manifest.ts           # Web App Manifest
+```
+
+### 動的アイコン
+
+```typescript
+// app/icon.tsx
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 32, height: 32 }
+export const contentType = 'image/png'
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 24,
+          background: 'black',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          borderRadius: '50%',
+        }}
+      >
+        A
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+## ベストプラクティス
+
+### タイトル最適化
+
+```typescript
+// ✅ 良い例
+export const metadata: Metadata = {
+  title: '記事タイトル - サイト名', // 60文字以内
+}
+
+// ❌ 避けるべき例
+export const metadata: Metadata = {
+  title: 'ホーム', // 具体性がない
+  title: 'とても長いタイトルで、検索結果では途中で切れてしまう可能性があるタイトル', // 長すぎる
+}
+```
+
+### Description最適化
+
+```typescript
+// ✅ 良い例
+export const metadata: Metadata = {
+  description:
+    'Next.js App RouterでのSEO最適化の完全ガイド。Metadata API、OGP設定、構造化データの実装方法を解説します。', // 120-160文字
+}
+
+// ❌ 避けるべき例
+export const metadata: Metadata = {
+  description: 'ブログです', // 短すぎる
+  description: 'キーワード、キーワード、キーワード...', // キーワードスタッフィング
+}
+```
+
+### 多言語対応
+
+```typescript
+export const metadata: Metadata = {
+  alternates: {
+    canonical: 'https://example.com/page',
+    languages: {
+      'en-US': 'https://example.com/en/page',
+      'ja-JP': 'https://example.com/ja/page',
+      'x-default': 'https://example.com/page',
+    },
+  },
+}
+```
+
+## チェックリスト
+
+- [ ] 各ページにユニークなtitleとdescriptionがある
+- [ ] title.templateがRoot Layoutで設定されている
+- [ ] OGP画像が1200x630pxで設定されている
+- [ ] Twitter Cardが設定されている
+- [ ] canonicalURLが設定されている
+- [ ] 多言語サイトの場合、hreflangが設定されている
+- [ ] favicon、apple-touch-iconが設定されている

--- a/.claude/skills/seo-optimization/resources/ogp-twitter-cards.md
+++ b/.claude/skills/seo-optimization/resources/ogp-twitter-cards.md
@@ -1,0 +1,358 @@
+# OGP / Twitter Card 設定
+
+## Open Graph Protocol (OGP)
+
+### 基本概念
+
+OGPは、Webページがソーシャルメディアでシェアされる際の表示を制御します。
+Facebook、LINE、Slack、Discordなど多くのプラットフォームが対応しています。
+
+### 必須プロパティ
+
+```typescript
+export const metadata: Metadata = {
+  openGraph: {
+    title: 'ページタイトル',        // og:title
+    description: '説明文',         // og:description
+    url: 'https://example.com',   // og:url
+    type: 'website',              // og:type
+    images: [
+      {
+        url: 'https://example.com/og.png',
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+}
+```
+
+### OGタイプ別設定
+
+#### website（デフォルト）
+
+```typescript
+openGraph: {
+  type: 'website',
+  siteName: 'サイト名',
+  locale: 'ja_JP',
+}
+```
+
+#### article（ブログ記事）
+
+```typescript
+openGraph: {
+  type: 'article',
+  publishedTime: '2024-01-15T00:00:00.000Z',
+  modifiedTime: '2024-01-20T00:00:00.000Z',
+  authors: ['https://example.com/authors/john'],
+  tags: ['Next.js', 'SEO', 'React'],
+}
+```
+
+#### profile（プロフィール）
+
+```typescript
+openGraph: {
+  type: 'profile',
+  firstName: '太郎',
+  lastName: '山田',
+  username: 'yamada_taro',
+}
+```
+
+#### book（書籍）
+
+```typescript
+openGraph: {
+  type: 'book',
+  isbn: '978-4-xxx-xxxxx-x',
+  authors: ['著者名'],
+  releaseDate: '2024-01-01',
+}
+```
+
+## Twitter Card
+
+### カードタイプ
+
+#### summary_large_image（推奨）
+
+```typescript
+twitter: {
+  card: 'summary_large_image',
+  title: 'タイトル',
+  description: '説明文',
+  images: ['https://example.com/twitter.png'],
+  creator: '@username',
+}
+```
+
+画像サイズ: 1200x630px（最小 300x157px）
+
+#### summary
+
+```typescript
+twitter: {
+  card: 'summary',
+  title: 'タイトル',
+  description: '説明文',
+  images: ['https://example.com/twitter-square.png'],
+}
+```
+
+画像サイズ: 144x144px〜4096x4096px（1:1推奨）
+
+#### player（動画）
+
+```typescript
+twitter: {
+  card: 'player',
+  title: '動画タイトル',
+  description: '説明文',
+  players: [
+    {
+      playerUrl: 'https://example.com/player',
+      streamUrl: 'https://example.com/video.mp4',
+      width: 1280,
+      height: 720,
+    },
+  ],
+}
+```
+
+#### app（アプリ）
+
+```typescript
+twitter: {
+  card: 'app',
+  app: {
+    id: {
+      iphone: '123456789',
+      ipad: '123456789',
+      googleplay: 'com.example.app',
+    },
+    name: 'アプリ名',
+    url: {
+      iphone: 'https://example.com/iphone',
+      ipad: 'https://example.com/ipad',
+      googleplay: 'https://example.com/android',
+    },
+  },
+}
+```
+
+## 画像最適化
+
+### 推奨仕様
+
+| プラットフォーム | サイズ | アスペクト比 | フォーマット |
+|----------------|--------|-------------|------------|
+| OGP | 1200x630px | 1.91:1 | PNG, JPG |
+| Twitter Large | 1200x630px | 1.91:1 | PNG, JPG, GIF |
+| Twitter Summary | 144x144px | 1:1 | PNG, JPG, GIF |
+| LINE | 1200x630px | 1.91:1 | PNG, JPG |
+
+### 動的OGP画像生成
+
+```typescript
+// app/blog/[slug]/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = 'ブログ記事のサムネイル'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function Image({ params }: { params: { slug: string } }) {
+  const post = await getPost(params.slug)
+
+  // カスタムフォントの読み込み（オプション）
+  const notoSansJP = await fetch(
+    new URL('./NotoSansJP-Bold.ttf', import.meta.url)
+  ).then((res) => res.arrayBuffer())
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          padding: 60,
+        }}
+      >
+        {/* カテゴリバッジ */}
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.2)',
+            padding: '8px 16px',
+            borderRadius: 20,
+            color: 'white',
+            fontSize: 20,
+          }}
+        >
+          {post.category}
+        </div>
+
+        {/* タイトル */}
+        <h1
+          style={{
+            color: 'white',
+            fontSize: 56,
+            fontWeight: 'bold',
+            lineHeight: 1.3,
+            maxWidth: '90%',
+          }}
+        >
+          {post.title}
+        </h1>
+
+        {/* フッター */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 20,
+          }}
+        >
+          <img
+            src={post.author.avatar}
+            width={48}
+            height={48}
+            style={{ borderRadius: '50%' }}
+          />
+          <span style={{ color: 'white', fontSize: 24 }}>
+            {post.author.name}
+          </span>
+          <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: 20 }}>
+            {post.date}
+          </span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Noto Sans JP',
+          data: notoSansJP,
+          style: 'normal',
+          weight: 700,
+        },
+      ],
+    }
+  )
+}
+```
+
+### Twitter画像も同時生成
+
+```typescript
+// app/blog/[slug]/twitter-image.tsx
+export { default, alt, size, contentType } from './opengraph-image'
+```
+
+## プレビュー・デバッグツール
+
+### Facebook
+
+- [Sharing Debugger](https://developers.facebook.com/tools/debug/)
+- キャッシュクリア機能あり
+
+### Twitter
+
+- [Card Validator](https://cards-dev.twitter.com/validator)
+- プレビュー確認可能
+
+### LINE
+
+- [LINE Social Plugins](https://developers.line.biz/ja/docs/line-social-plugins/)
+- シェア時の表示確認
+
+### 汎用ツール
+
+- [OGP確認ツール](https://ogp.me/)
+- [Meta Tags Analyzer](https://metatags.io/)
+
+## 完全な実装例
+
+```typescript
+// app/blog/[slug]/page.tsx
+import type { Metadata } from 'next'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPost(slug)
+
+  const ogImage = {
+    url: `https://example.com/api/og?title=${encodeURIComponent(post.title)}`,
+    width: 1200,
+    height: 630,
+    alt: post.title,
+  }
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      url: `https://example.com/blog/${slug}`,
+      siteName: 'My Blog',
+      images: [ogImage],
+      locale: 'ja_JP',
+      type: 'article',
+      publishedTime: post.publishedAt,
+      modifiedTime: post.updatedAt,
+      authors: [post.author.name],
+      tags: post.tags,
+    },
+
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+      images: [ogImage.url],
+      creator: `@${post.author.twitter}`,
+    },
+  }
+}
+```
+
+## チェックリスト
+
+### OGP
+
+- [ ] og:title が設定されている
+- [ ] og:description が設定されている
+- [ ] og:image が1200x630pxで設定されている
+- [ ] og:url が正しいURLになっている
+- [ ] og:type が適切に設定されている
+- [ ] og:site_name が設定されている
+- [ ] og:locale が設定されている
+
+### Twitter Card
+
+- [ ] twitter:card が設定されている
+- [ ] twitter:title が設定されている
+- [ ] twitter:description が設定されている
+- [ ] twitter:image が設定されている
+- [ ] twitter:creator が設定されている（オプション）
+
+### 画像
+
+- [ ] 画像サイズが推奨仕様を満たしている
+- [ ] 画像がHTTPSでアクセス可能
+- [ ] 画像の alt テキストが設定されている
+- [ ] 動的ページでは動的OGP画像を生成している

--- a/.claude/skills/seo-optimization/resources/sitemap-robots.md
+++ b/.claude/skills/seo-optimization/resources/sitemap-robots.md
@@ -1,0 +1,392 @@
+# サイトマップ / robots.txt
+
+## サイトマップ
+
+### 静的サイトマップ
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://example.com',
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: 'https://example.com/about',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://example.com/blog',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+  ]
+}
+```
+
+### 動的サイトマップ
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next'
+import { getAllPosts, getAllProducts } from '@/lib/data'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = 'https://example.com'
+
+  // 静的ページ
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+  ]
+
+  // 動的ページ（ブログ記事）
+  const posts = await getAllPosts()
+  const postPages: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt),
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }))
+
+  // 動的ページ（商品）
+  const products = await getAllProducts()
+  const productPages: MetadataRoute.Sitemap = products.map((product) => ({
+    url: `${baseUrl}/products/${product.slug}`,
+    lastModified: new Date(product.updatedAt),
+    changeFrequency: 'daily',
+    priority: 0.8,
+  }))
+
+  return [...staticPages, ...postPages, ...productPages]
+}
+```
+
+### 複数サイトマップ（大規模サイト）
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // サイトマップインデックスを返す
+  return [
+    {
+      url: 'https://example.com/sitemaps/pages.xml',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://example.com/sitemaps/posts.xml',
+      lastModified: new Date(),
+    },
+    {
+      url: 'https://example.com/sitemaps/products.xml',
+      lastModified: new Date(),
+    },
+  ]
+}
+
+// app/sitemaps/posts/sitemap.ts
+export async function generateSitemaps() {
+  const posts = await getAllPosts()
+  const postsPerSitemap = 1000
+
+  // 1000件ごとにサイトマップを分割
+  return Array.from(
+    { length: Math.ceil(posts.length / postsPerSitemap) },
+    (_, i) => ({ id: i })
+  )
+}
+
+export default async function sitemap({
+  id,
+}: {
+  id: number
+}): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPosts()
+  const start = id * 1000
+  const end = start + 1000
+
+  return posts.slice(start, end).map((post) => ({
+    url: `https://example.com/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt),
+  }))
+}
+```
+
+### 画像・動画サイトマップ
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getPostsWithMedia()
+
+  return posts.map((post) => ({
+    url: `https://example.com/blog/${post.slug}`,
+    lastModified: new Date(post.updatedAt),
+    images: post.images.map((img) => img.url),
+    videos: post.videos?.map((video) => ({
+      title: video.title,
+      thumbnail_loc: video.thumbnail,
+      description: video.description,
+      content_loc: video.url,
+      player_loc: video.playerUrl,
+      duration: video.duration,
+      publication_date: video.publishedAt,
+    })),
+  }))
+}
+```
+
+### 多言語サイトマップ
+
+```typescript
+// app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+const locales = ['ja', 'en', 'zh']
+const baseUrl = 'https://example.com'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const pages = await getAllPages()
+
+  return pages.flatMap((page) =>
+    locales.map((locale) => ({
+      url: `${baseUrl}/${locale}${page.path}`,
+      lastModified: new Date(page.updatedAt),
+      alternates: {
+        languages: Object.fromEntries(
+          locales.map((l) => [l, `${baseUrl}/${l}${page.path}`])
+        ),
+      },
+    }))
+  )
+}
+```
+
+## robots.txt
+
+### 基本設定
+
+```typescript
+// app/robots.ts
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/private/',
+    },
+    sitemap: 'https://example.com/sitemap.xml',
+  }
+}
+```
+
+### 複数ルール
+
+```typescript
+// app/robots.ts
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/', '/_next/', '/private/'],
+      },
+      {
+        userAgent: 'Googlebot',
+        allow: '/',
+        disallow: '/nogooglebot/',
+      },
+      {
+        userAgent: 'Bingbot',
+        crawlDelay: 10,
+        allow: '/',
+      },
+    ],
+    sitemap: 'https://example.com/sitemap.xml',
+    host: 'https://example.com',
+  }
+}
+```
+
+### 環境別設定
+
+```typescript
+// app/robots.ts
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  const isProduction = process.env.NODE_ENV === 'production'
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://example.com'
+
+  // 本番環境以外はクロールを禁止
+  if (!isProduction) {
+    return {
+      rules: {
+        userAgent: '*',
+        disallow: '/',
+      },
+    }
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/', '/_next/'],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}
+```
+
+## クロール最適化
+
+### メタタグによる制御
+
+```typescript
+// app/layout.tsx
+export const metadata: Metadata = {
+  robots: {
+    index: true,
+    follow: true,
+    nocache: false,
+    googleBot: {
+      index: true,
+      follow: true,
+      noimageindex: false,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+```
+
+### 特定ページのクロール禁止
+
+```typescript
+// app/admin/page.tsx
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+```
+
+### noindex設定
+
+```typescript
+// 検索結果に表示したくないページ
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: true, // リンクはフォローする
+  },
+}
+```
+
+## ベストプラクティス
+
+### サイトマップ
+
+| 項目 | 推奨 |
+|------|------|
+| URL数 | 1ファイルあたり50,000件以下 |
+| ファイルサイズ | 50MB以下（非圧縮） |
+| 更新頻度 | 内容変更時に更新 |
+| changeFrequency | 実際の更新頻度に合わせる |
+| priority | 相対的な重要度（0.0〜1.0） |
+
+### robots.txt
+
+| 項目 | 推奨 |
+|------|------|
+| 配置場所 | ルートディレクトリ |
+| サイトマップ参照 | 必ず含める |
+| APIルート | クロール禁止推奨 |
+| 管理画面 | クロール禁止 |
+| 認証ページ | クロール禁止 |
+
+### クロール最適化
+
+```typescript
+// 推奨設定
+export const metadata: Metadata = {
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+```
+
+## 検証・確認
+
+### Google Search Console
+
+1. サイトマップを送信
+2. インデックス状況を確認
+3. クロールエラーを確認
+
+### 検証ツール
+
+- [robots.txt テスター](https://www.google.com/webmasters/tools/robots-testing-tool)
+- [サイトマップ検証](https://www.xml-sitemaps.com/validate-xml-sitemap.html)
+
+## チェックリスト
+
+### サイトマップ
+
+- [ ] sitemap.tsが作成されている
+- [ ] すべての重要なページが含まれている
+- [ ] lastModifiedが適切に設定されている
+- [ ] 多言語サイトの場合、alternatesが設定されている
+- [ ] 画像がある場合、画像サイトマップが含まれている
+- [ ] Google Search Consoleに送信済み
+
+### robots.txt
+
+- [ ] robots.tsが作成されている
+- [ ] サイトマップへの参照がある
+- [ ] 不要なパス（/api/, /admin/）が禁止されている
+- [ ] 本番環境以外でクロール禁止が設定されている
+- [ ] robots.txtが正しく生成されているか確認済み

--- a/.claude/skills/seo-optimization/resources/structured-data.md
+++ b/.claude/skills/seo-optimization/resources/structured-data.md
@@ -1,0 +1,394 @@
+# 構造化データ（JSON-LD）
+
+## 概要
+
+構造化データは、検索エンジンがページの内容を理解するためのマークアップです。
+Google検索でリッチリザルト（リッチスニペット）を表示するために必要です。
+
+## 基本実装
+
+### JSON-LDコンポーネント
+
+```typescript
+// components/json-ld.tsx
+type JsonLdProps = {
+  data: Record<string, unknown>
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}
+```
+
+### 使用方法
+
+```typescript
+// app/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default function Page() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'サイト名',
+    url: 'https://example.com',
+  }
+
+  return (
+    <>
+      <JsonLd data={structuredData} />
+      <main>{/* コンテンツ */}</main>
+    </>
+  )
+}
+```
+
+## 主要なスキーマタイプ
+
+### WebSite（サイト全体）
+
+```typescript
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'サイト名',
+  url: 'https://example.com',
+  description: 'サイトの説明',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: 'https://example.com/search?q={search_term_string}',
+    },
+    'query-input': 'required name=search_term_string',
+  },
+}
+```
+
+### Organization（組織）
+
+```typescript
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: '組織名',
+  url: 'https://example.com',
+  logo: 'https://example.com/logo.png',
+  sameAs: [
+    'https://twitter.com/example',
+    'https://facebook.com/example',
+    'https://linkedin.com/company/example',
+  ],
+  contactPoint: {
+    '@type': 'ContactPoint',
+    telephone: '+81-3-xxxx-xxxx',
+    contactType: 'customer service',
+    availableLanguage: ['Japanese', 'English'],
+  },
+}
+```
+
+### Article（記事）
+
+```typescript
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: '記事のタイトル',
+  description: '記事の説明',
+  image: [
+    'https://example.com/image1.jpg',
+    'https://example.com/image2.jpg',
+  ],
+  datePublished: '2024-01-15T08:00:00+09:00',
+  dateModified: '2024-01-20T10:00:00+09:00',
+  author: {
+    '@type': 'Person',
+    name: '著者名',
+    url: 'https://example.com/author',
+  },
+  publisher: {
+    '@type': 'Organization',
+    name: '発行者名',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://example.com/logo.png',
+    },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://example.com/article/example',
+  },
+}
+```
+
+### BlogPosting（ブログ記事）
+
+```typescript
+const blogPostingSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: 'ブログ記事タイトル',
+  description: '概要',
+  image: 'https://example.com/blog-image.jpg',
+  datePublished: '2024-01-15',
+  dateModified: '2024-01-20',
+  author: {
+    '@type': 'Person',
+    name: '著者名',
+  },
+  keywords: ['Next.js', 'SEO', 'React'],
+  wordCount: 1500,
+  articleBody: '記事本文...',
+}
+```
+
+### BreadcrumbList（パンくずリスト）
+
+```typescript
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'ホーム',
+      item: 'https://example.com',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'ブログ',
+      item: 'https://example.com/blog',
+    },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: '記事タイトル',
+      item: 'https://example.com/blog/article',
+    },
+  ],
+}
+```
+
+### FAQPage（よくある質問）
+
+```typescript
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: '質問1',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: '回答1',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: '質問2',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: '回答2',
+      },
+    },
+  ],
+}
+```
+
+### Product（商品）
+
+```typescript
+const productSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Product',
+  name: '商品名',
+  description: '商品説明',
+  image: 'https://example.com/product.jpg',
+  sku: 'SKU-12345',
+  brand: {
+    '@type': 'Brand',
+    name: 'ブランド名',
+  },
+  offers: {
+    '@type': 'Offer',
+    url: 'https://example.com/product',
+    priceCurrency: 'JPY',
+    price: '9800',
+    priceValidUntil: '2024-12-31',
+    availability: 'https://schema.org/InStock',
+    seller: {
+      '@type': 'Organization',
+      name: '販売者名',
+    },
+  },
+  aggregateRating: {
+    '@type': 'AggregateRating',
+    ratingValue: '4.5',
+    reviewCount: '100',
+  },
+  review: [
+    {
+      '@type': 'Review',
+      reviewRating: {
+        '@type': 'Rating',
+        ratingValue: '5',
+      },
+      author: {
+        '@type': 'Person',
+        name: 'レビュアー名',
+      },
+      reviewBody: 'レビュー本文',
+    },
+  ],
+}
+```
+
+### LocalBusiness（店舗）
+
+```typescript
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Restaurant', // または LocalBusiness, Store など
+  name: '店舗名',
+  image: 'https://example.com/store.jpg',
+  '@id': 'https://example.com',
+  url: 'https://example.com',
+  telephone: '+81-3-xxxx-xxxx',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '渋谷区xxx 1-2-3',
+    addressLocality: '渋谷区',
+    addressRegion: '東京都',
+    postalCode: '150-0001',
+    addressCountry: 'JP',
+  },
+  geo: {
+    '@type': 'GeoCoordinates',
+    latitude: 35.6595,
+    longitude: 139.7004,
+  },
+  openingHoursSpecification: [
+    {
+      '@type': 'OpeningHoursSpecification',
+      dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+      opens: '09:00',
+      closes: '18:00',
+    },
+  ],
+  priceRange: '¥¥',
+}
+```
+
+### HowTo（ハウツー）
+
+```typescript
+const howToSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Next.jsアプリのデプロイ方法',
+  description: 'Vercelを使用したNext.jsアプリのデプロイ手順',
+  totalTime: 'PT15M',
+  step: [
+    {
+      '@type': 'HowToStep',
+      name: 'GitHubにプッシュ',
+      text: 'コードをGitHubリポジトリにプッシュします',
+      image: 'https://example.com/step1.png',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Vercelでインポート',
+      text: 'Vercelダッシュボードでリポジトリをインポートします',
+      image: 'https://example.com/step2.png',
+    },
+  ],
+}
+```
+
+## 動的生成パターン
+
+### 記事ページの完全な例
+
+```typescript
+// app/blog/[slug]/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default async function BlogPost({ params }: { params: { slug: string } }) {
+  const post = await getPost(params.slug)
+  const breadcrumbs = await getBreadcrumbs(params.slug)
+
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: post.title,
+    description: post.excerpt,
+    image: post.ogImage,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt,
+    author: {
+      '@type': 'Person',
+      name: post.author.name,
+      url: `https://example.com/authors/${post.author.slug}`,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'My Blog',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://example.com/logo.png',
+      },
+    },
+  }
+
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbs.map((crumb, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.url,
+    })),
+  }
+
+  return (
+    <>
+      <JsonLd data={articleSchema} />
+      <JsonLd data={breadcrumbSchema} />
+      <article>{/* コンテンツ */}</article>
+    </>
+  )
+}
+```
+
+## 検証ツール
+
+### Google
+
+- [リッチリザルトテスト](https://search.google.com/test/rich-results)
+- [Schema Markup Validator](https://validator.schema.org/)
+
+### その他
+
+- [JSON-LD Playground](https://json-ld.org/playground/)
+- [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data)
+
+## チェックリスト
+
+- [ ] JSON-LDが正しい形式で出力されている
+- [ ] @context が 'https://schema.org' に設定されている
+- [ ] @type が適切に設定されている
+- [ ] 必須プロパティがすべて含まれている
+- [ ] 日付形式が ISO 8601 に従っている
+- [ ] URLが正しい絶対URLになっている
+- [ ] リッチリザルトテストでエラーがない
+- [ ] 警告を可能な限り解消している

--- a/.claude/skills/seo-optimization/scripts/analyze-seo.mjs
+++ b/.claude/skills/seo-optimization/scripts/analyze-seo.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+
+/**
+ * SEO分析スクリプト
+ *
+ * 使用方法:
+ *   node analyze-seo.mjs <app-directory>
+ *
+ * 例:
+ *   node analyze-seo.mjs ./src/app
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+class SEOAnalyzer {
+  constructor(appDir) {
+    this.appDir = path.resolve(appDir);
+    this.issues = [];
+    this.suggestions = [];
+    this.stats = {
+      pages: 0,
+      pagesWithMetadata: 0,
+      pagesWithDynamicMetadata: 0,
+      pagesWithOgImage: 0,
+      pagesWithJsonLd: 0,
+      hasSitemap: false,
+      hasRobots: false,
+    };
+  }
+
+  analyze() {
+    if (!fs.existsSync(this.appDir)) {
+      console.error(`Error: Directory not found: ${this.appDir}`);
+      process.exit(1);
+    }
+
+    console.log(`\n🔍 SEO Analysis: ${this.appDir}\n`);
+    console.log('='.repeat(60));
+
+    this.checkRootFiles();
+    this.scanDirectory(this.appDir);
+    this.printStats();
+    this.printIssues();
+    this.printSuggestions();
+  }
+
+  checkRootFiles() {
+    console.log('\n📁 Root Level Files:');
+    console.log('-'.repeat(40));
+
+    // sitemap.ts チェック
+    const sitemapPath = path.join(this.appDir, 'sitemap.ts');
+    const sitemapTsxPath = path.join(this.appDir, 'sitemap.tsx');
+    this.stats.hasSitemap = fs.existsSync(sitemapPath) || fs.existsSync(sitemapTsxPath);
+    console.log(`  sitemap.ts: ${this.stats.hasSitemap ? '✅ Found' : '❌ Missing'}`);
+
+    // robots.ts チェック
+    const robotsPath = path.join(this.appDir, 'robots.ts');
+    const robotsTsxPath = path.join(this.appDir, 'robots.tsx');
+    this.stats.hasRobots = fs.existsSync(robotsPath) || fs.existsSync(robotsTsxPath);
+    console.log(`  robots.ts: ${this.stats.hasRobots ? '✅ Found' : '❌ Missing'}`);
+
+    // Root Layout チェック
+    const layoutPath = path.join(this.appDir, 'layout.tsx');
+    const hasRootLayout = fs.existsSync(layoutPath);
+    console.log(`  layout.tsx: ${hasRootLayout ? '✅ Found' : '❌ Missing'}`);
+
+    if (hasRootLayout) {
+      this.analyzeRootLayout(layoutPath);
+    }
+
+    // favicon チェック
+    const faviconPath = path.join(this.appDir, 'favicon.ico');
+    const iconPath = path.join(this.appDir, 'icon.png');
+    const iconTsxPath = path.join(this.appDir, 'icon.tsx');
+    const hasIcon = fs.existsSync(faviconPath) || fs.existsSync(iconPath) || fs.existsSync(iconTsxPath);
+    console.log(`  favicon/icon: ${hasIcon ? '✅ Found' : '⚠️  Missing'}`);
+
+    // opengraph-image チェック
+    const ogImagePath = path.join(this.appDir, 'opengraph-image.png');
+    const ogImageTsxPath = path.join(this.appDir, 'opengraph-image.tsx');
+    const hasOgImage = fs.existsSync(ogImagePath) || fs.existsSync(ogImageTsxPath);
+    console.log(`  opengraph-image: ${hasOgImage ? '✅ Found' : '⚠️  Optional'}`);
+
+    if (!this.stats.hasSitemap) {
+      this.issues.push({
+        type: 'error',
+        message: 'sitemap.ts が見つかりません',
+      });
+    }
+
+    if (!this.stats.hasRobots) {
+      this.issues.push({
+        type: 'error',
+        message: 'robots.ts が見つかりません',
+      });
+    }
+  }
+
+  analyzeRootLayout(layoutPath) {
+    const content = fs.readFileSync(layoutPath, 'utf-8');
+
+    // title.template チェック
+    const hasTitleTemplate = content.includes('template:') && content.includes('%s');
+    if (!hasTitleTemplate) {
+      this.suggestions.push('Root Layoutに title.template を設定することを推奨');
+    }
+
+    // 基本メタデータチェック
+    const hasMetadataExport = content.includes('export const metadata') ||
+                             content.includes('export async function generateMetadata');
+    if (!hasMetadataExport) {
+      this.issues.push({
+        type: 'warning',
+        message: 'Root Layoutにメタデータエクスポートがありません',
+      });
+    }
+  }
+
+  scanDirectory(dir, relativePath = '') {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relPath = path.join(relativePath, entry.name);
+
+      if (entry.isDirectory()) {
+        // Route Groups、Parallel Routes などを除外しない
+        this.scanDirectory(fullPath, relPath);
+      } else if (entry.name === 'page.tsx' || entry.name === 'page.ts') {
+        this.analyzePage(fullPath, relativePath);
+      }
+    }
+  }
+
+  analyzePage(pagePath, routePath) {
+    this.stats.pages++;
+    const content = fs.readFileSync(pagePath, 'utf-8');
+
+    console.log(`\n📄 ${routePath || '/'}`);
+    console.log('-'.repeat(40));
+
+    // 静的メタデータチェック
+    const hasStaticMetadata = content.includes('export const metadata');
+
+    // 動的メタデータチェック
+    const hasDynamicMetadata = content.includes('export async function generateMetadata');
+
+    if (hasStaticMetadata || hasDynamicMetadata) {
+      this.stats.pagesWithMetadata++;
+      console.log(`  Metadata: ${hasDynamicMetadata ? '✅ Dynamic' : '✅ Static'}`);
+
+      if (hasDynamicMetadata) {
+        this.stats.pagesWithDynamicMetadata++;
+      }
+    } else {
+      console.log(`  Metadata: ❌ Missing`);
+      this.issues.push({
+        type: 'warning',
+        message: `${routePath || '/'} にメタデータがありません`,
+      });
+    }
+
+    // OGP画像チェック
+    const pageDir = path.dirname(pagePath);
+    const hasOgImage = fs.existsSync(path.join(pageDir, 'opengraph-image.tsx')) ||
+                       fs.existsSync(path.join(pageDir, 'opengraph-image.png')) ||
+                       content.includes('openGraph:') ||
+                       content.includes('og:image');
+
+    if (hasOgImage) {
+      this.stats.pagesWithOgImage++;
+      console.log(`  OGP Image: ✅`);
+    } else {
+      console.log(`  OGP Image: ⚠️  Not configured`);
+    }
+
+    // JSON-LD チェック
+    const hasJsonLd = content.includes('application/ld+json') ||
+                      content.includes('JsonLd') ||
+                      content.includes('@context');
+
+    if (hasJsonLd) {
+      this.stats.pagesWithJsonLd++;
+      console.log(`  JSON-LD: ✅`);
+    } else {
+      console.log(`  JSON-LD: ⚠️  Not configured`);
+    }
+
+    // 動的ルートの場合の追加チェック
+    if (routePath.includes('[')) {
+      if (!hasDynamicMetadata) {
+        this.issues.push({
+          type: 'warning',
+          message: `動的ルート ${routePath} に generateMetadata がありません`,
+        });
+      }
+    }
+  }
+
+  printStats() {
+    console.log('\n' + '='.repeat(60));
+    console.log('📊 Summary:');
+    console.log('-'.repeat(40));
+    console.log(`  Total Pages: ${this.stats.pages}`);
+    console.log(`  With Metadata: ${this.stats.pagesWithMetadata} (${this.percentage(this.stats.pagesWithMetadata, this.stats.pages)}%)`);
+    console.log(`  With Dynamic Metadata: ${this.stats.pagesWithDynamicMetadata}`);
+    console.log(`  With OGP Image: ${this.stats.pagesWithOgImage} (${this.percentage(this.stats.pagesWithOgImage, this.stats.pages)}%)`);
+    console.log(`  With JSON-LD: ${this.stats.pagesWithJsonLd} (${this.percentage(this.stats.pagesWithJsonLd, this.stats.pages)}%)`);
+    console.log(`  Has Sitemap: ${this.stats.hasSitemap ? '✅' : '❌'}`);
+    console.log(`  Has Robots.txt: ${this.stats.hasRobots ? '✅' : '❌'}`);
+
+    // SEOスコア計算
+    const score = this.calculateSEOScore();
+    console.log(`\n  📈 SEO Score: ${score}/100`);
+  }
+
+  calculateSEOScore() {
+    let score = 0;
+
+    // メタデータカバレッジ (40点)
+    if (this.stats.pages > 0) {
+      score += Math.round((this.stats.pagesWithMetadata / this.stats.pages) * 40);
+    }
+
+    // OGPカバレッジ (20点)
+    if (this.stats.pages > 0) {
+      score += Math.round((this.stats.pagesWithOgImage / this.stats.pages) * 20);
+    }
+
+    // サイトマップ (15点)
+    if (this.stats.hasSitemap) score += 15;
+
+    // robots.txt (15点)
+    if (this.stats.hasRobots) score += 15;
+
+    // JSON-LD (10点)
+    if (this.stats.pages > 0) {
+      score += Math.round((this.stats.pagesWithJsonLd / this.stats.pages) * 10);
+    }
+
+    return score;
+  }
+
+  percentage(part, total) {
+    if (total === 0) return 0;
+    return Math.round((part / total) * 100);
+  }
+
+  printIssues() {
+    console.log('\n⚠️  Issues:');
+    console.log('-'.repeat(40));
+
+    if (this.issues.length === 0) {
+      console.log('  ✅ No issues found');
+    } else {
+      const errors = this.issues.filter(i => i.type === 'error');
+      const warnings = this.issues.filter(i => i.type === 'warning');
+
+      for (const error of errors) {
+        console.log(`  ❌ ${error.message}`);
+      }
+      for (const warning of warnings) {
+        console.log(`  ⚠️  ${warning.message}`);
+      }
+    }
+  }
+
+  printSuggestions() {
+    console.log('\n💡 Suggestions:');
+    console.log('-'.repeat(40));
+
+    // 自動生成の提案
+    if (this.stats.pagesWithMetadata < this.stats.pages) {
+      this.suggestions.push('すべてのページにメタデータを設定してください');
+    }
+
+    if (this.stats.pagesWithOgImage < this.stats.pages) {
+      this.suggestions.push('OGP画像の設定を検討してください（ソーシャルシェア時の表示向上）');
+    }
+
+    if (this.stats.pagesWithJsonLd === 0) {
+      this.suggestions.push('構造化データ（JSON-LD）の追加を検討してください（リッチリザルト獲得）');
+    }
+
+    if (this.suggestions.length === 0) {
+      console.log('  ✅ No additional suggestions');
+    } else {
+      for (const suggestion of this.suggestions) {
+        console.log(`  → ${suggestion}`);
+      }
+    }
+
+    console.log('\n' + '='.repeat(60) + '\n');
+  }
+}
+
+// Main execution
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.log('Usage: node analyze-seo.mjs <app-directory>');
+  console.log('Example: node analyze-seo.mjs ./src/app');
+  process.exit(1);
+}
+
+const analyzer = new SEOAnalyzer(args[0]);
+analyzer.analyze();

--- a/.claude/skills/seo-optimization/templates/metadata-template.md
+++ b/.claude/skills/seo-optimization/templates/metadata-template.md
@@ -1,0 +1,321 @@
+# メタデータテンプレート
+
+## Root Layout メタデータ
+
+```typescript
+// app/layout.tsx
+import type { Metadata, Viewport } from 'next'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#000000' },
+  ],
+}
+
+export const metadata: Metadata = {
+  // 基本設定
+  metadataBase: new URL('https://{{domain}}'),
+  title: {
+    default: '{{site_name}}',
+    template: '%s | {{site_name}}',
+  },
+  description: '{{site_description}}',
+  keywords: ['{{keyword1}}', '{{keyword2}}', '{{keyword3}}'],
+
+  // 著者情報
+  authors: [{ name: '{{author_name}}', url: 'https://{{author_url}}' }],
+  creator: '{{creator}}',
+  publisher: '{{publisher}}',
+
+  // アイコン
+  icons: {
+    icon: '/favicon.ico',
+    shortcut: '/favicon-16x16.png',
+    apple: '/apple-touch-icon.png',
+  },
+  manifest: '/site.webmanifest',
+
+  // Open Graph
+  openGraph: {
+    type: 'website',
+    locale: 'ja_JP',
+    url: 'https://{{domain}}',
+    siteName: '{{site_name}}',
+    title: '{{site_name}}',
+    description: '{{site_description}}',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: '{{site_name}}',
+      },
+    ],
+  },
+
+  // Twitter Card
+  twitter: {
+    card: 'summary_large_image',
+    title: '{{site_name}}',
+    description: '{{site_description}}',
+    creator: '@{{twitter_handle}}',
+    images: ['/twitter-image.png'],
+  },
+
+  // 検索エンジン設定
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+
+  // 検証
+  verification: {
+    google: '{{google_verification}}',
+  },
+
+  // 代替言語（多言語サイトの場合）
+  alternates: {
+    canonical: 'https://{{domain}}',
+    languages: {
+      'ja-JP': 'https://{{domain}}/ja',
+      'en-US': 'https://{{domain}}/en',
+    },
+  },
+
+  // カテゴリ
+  category: '{{category}}',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja">
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+## 静的ページメタデータ
+
+```typescript
+// app/about/page.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '{{page_title}}',
+  description: '{{page_description}}',
+  openGraph: {
+    title: '{{page_title}}',
+    description: '{{page_description}}',
+    url: '/about',
+  },
+}
+
+export default function AboutPage() {
+  return <main>{/* コンテンツ */}</main>
+}
+```
+
+## 動的ページメタデータ
+
+```typescript
+// app/blog/[slug]/page.tsx
+import type { Metadata, ResolvingMetadata } from 'next'
+import { notFound } from 'next/navigation'
+
+type Props = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const { slug } = await params
+  const {{resource}} = await get{{Resource}}(slug)
+
+  if (!{{resource}}) {
+    return { title: 'Not Found' }
+  }
+
+  // 親のOGP画像を継承（オプション）
+  const previousImages = (await parent).openGraph?.images || []
+
+  return {
+    title: {{resource}}.title,
+    description: {{resource}}.excerpt,
+    authors: [{ name: {{resource}}.author.name }],
+
+    openGraph: {
+      title: {{resource}}.title,
+      description: {{resource}}.excerpt,
+      url: `/blog/${slug}`,
+      type: 'article',
+      publishedTime: {{resource}}.publishedAt,
+      modifiedTime: {{resource}}.updatedAt,
+      authors: [{{resource}}.author.name],
+      tags: {{resource}}.tags,
+      images: [
+        {
+          url: {{resource}}.ogImage || '/og-default.png',
+          width: 1200,
+          height: 630,
+          alt: {{resource}}.title,
+        },
+        ...previousImages,
+      ],
+    },
+
+    twitter: {
+      card: 'summary_large_image',
+      title: {{resource}}.title,
+      description: {{resource}}.excerpt,
+      images: [{{resource}}.ogImage || '/twitter-default.png'],
+    },
+
+    alternates: {
+      canonical: `/blog/${slug}`,
+    },
+  }
+}
+
+export default async function {{Resource}}Page({ params }: Props) {
+  const { slug } = await params
+  const {{resource}} = await get{{Resource}}(slug)
+
+  if (!{{resource}}) {
+    notFound()
+  }
+
+  return <article>{/* コンテンツ */}</article>
+}
+```
+
+## 動的OGP画像生成
+
+```typescript
+// app/blog/[slug]/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export const runtime = 'edge'
+export const alt = '{{alt_text}}'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OGImage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const {{resource}} = await get{{Resource}}(params.slug)
+
+  if (!{{resource}}) {
+    return new ImageResponse(
+      <div style={{ background: '#f0f0f0', width: '100%', height: '100%' }}>
+        Not Found
+      </div>,
+      { ...size }
+    )
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '{{background_gradient}}',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          padding: 60,
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* カテゴリバッジ */}
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.2)',
+            padding: '8px 20px',
+            borderRadius: 24,
+            color: 'white',
+            fontSize: 18,
+          }}
+        >
+          {{{resource}}.category}
+        </div>
+
+        {/* タイトル */}
+        <h1
+          style={{
+            color: 'white',
+            fontSize: 52,
+            fontWeight: 'bold',
+            lineHeight: 1.2,
+            maxWidth: '90%',
+            margin: 0,
+          }}
+        >
+          {{{resource}}.title}
+        </h1>
+
+        {/* フッター */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16,
+          }}
+        >
+          <span style={{ color: 'white', fontSize: 20 }}>
+            {{{resource}}.author.name}
+          </span>
+          <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: 18 }}>
+            •
+          </span>
+          <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: 18 }}>
+            {new Date({{resource}}.publishedAt).toLocaleDateString('ja-JP')}
+          </span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+## Twitter画像（OGP画像を再利用）
+
+```typescript
+// app/blog/[slug]/twitter-image.tsx
+export { default, alt, size, contentType } from './opengraph-image'
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{domain}}` | サイトドメイン | `example.com` |
+| `{{site_name}}` | サイト名 | `My Blog` |
+| `{{site_description}}` | サイト説明 | `技術ブログです` |
+| `{{author_name}}` | 著者名 | `山田太郎` |
+| `{{twitter_handle}}` | Twitterハンドル | `yamada_taro` |
+| `{{resource}}` | リソース名（camelCase） | `post`, `product` |
+| `{{Resource}}` | リソース名（PascalCase） | `Post`, `Product` |
+| `{{background_gradient}}` | 背景グラデーション | `linear-gradient(135deg, #667eea 0%, #764ba2 100%)` |

--- a/.claude/skills/seo-optimization/templates/structured-data-template.md
+++ b/.claude/skills/seo-optimization/templates/structured-data-template.md
@@ -1,0 +1,414 @@
+# 構造化データテンプレート
+
+## JSON-LD コンポーネント
+
+```typescript
+// components/json-ld.tsx
+type JsonLdProps = {
+  data: Record<string, unknown>
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}
+```
+
+## WebSite スキーマ（トップページ）
+
+```typescript
+// app/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default function HomePage() {
+  const websiteSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: '{{site_name}}',
+    url: 'https://{{domain}}',
+    description: '{{site_description}}',
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: 'https://{{domain}}/search?q={search_term_string}',
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  }
+
+  const organizationSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: '{{organization_name}}',
+    url: 'https://{{domain}}',
+    logo: 'https://{{domain}}/logo.png',
+    sameAs: [
+      'https://twitter.com/{{twitter_handle}}',
+      'https://github.com/{{github_handle}}',
+    ],
+  }
+
+  return (
+    <>
+      <JsonLd data={websiteSchema} />
+      <JsonLd data={organizationSchema} />
+      <main>{/* コンテンツ */}</main>
+    </>
+  )
+}
+```
+
+## Article スキーマ（ブログ記事）
+
+```typescript
+// app/blog/[slug]/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const post = await getPost(params.slug)
+
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: post.title,
+    description: post.excerpt,
+    image: [post.ogImage],
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt,
+    author: {
+      '@type': 'Person',
+      name: post.author.name,
+      url: `https://{{domain}}/authors/${post.author.slug}`,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: '{{site_name}}',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://{{domain}}/logo.png',
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `https://{{domain}}/blog/${params.slug}`,
+    },
+  }
+
+  return (
+    <>
+      <JsonLd data={articleSchema} />
+      <article>{/* コンテンツ */}</article>
+    </>
+  )
+}
+```
+
+## BreadcrumbList スキーマ（パンくずリスト）
+
+```typescript
+// components/breadcrumb-json-ld.tsx
+import { JsonLd } from '@/components/json-ld'
+
+type Breadcrumb = {
+  name: string
+  url: string
+}
+
+export function BreadcrumbJsonLd({ items }: { items: Breadcrumb[] }) {
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  }
+
+  return <JsonLd data={breadcrumbSchema} />
+}
+
+// 使用例
+// app/blog/[slug]/page.tsx
+<BreadcrumbJsonLd
+  items={[
+    { name: 'ホーム', url: 'https://{{domain}}' },
+    { name: 'ブログ', url: 'https://{{domain}}/blog' },
+    { name: post.title, url: `https://{{domain}}/blog/${post.slug}` },
+  ]}
+/>
+```
+
+## FAQPage スキーマ（よくある質問）
+
+```typescript
+// app/faq/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+type FAQ = {
+  question: string
+  answer: string
+}
+
+const faqs: FAQ[] = [
+  {
+    question: '{{question_1}}',
+    answer: '{{answer_1}}',
+  },
+  {
+    question: '{{question_2}}',
+    answer: '{{answer_2}}',
+  },
+]
+
+export default function FAQPage() {
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  }
+
+  return (
+    <>
+      <JsonLd data={faqSchema} />
+      <main>
+        {faqs.map((faq, index) => (
+          <div key={index}>
+            <h3>{faq.question}</h3>
+            <p>{faq.answer}</p>
+          </div>
+        ))}
+      </main>
+    </>
+  )
+}
+```
+
+## Product スキーマ（商品ページ）
+
+```typescript
+// app/products/[slug]/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const product = await getProduct(params.slug)
+
+  const productSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: product.name,
+    description: product.description,
+    image: product.images,
+    sku: product.sku,
+    brand: {
+      '@type': 'Brand',
+      name: product.brand,
+    },
+    offers: {
+      '@type': 'Offer',
+      url: `https://{{domain}}/products/${product.slug}`,
+      priceCurrency: 'JPY',
+      price: product.price,
+      priceValidUntil: product.priceValidUntil,
+      availability: product.inStock
+        ? 'https://schema.org/InStock'
+        : 'https://schema.org/OutOfStock',
+      seller: {
+        '@type': 'Organization',
+        name: '{{organization_name}}',
+      },
+    },
+    aggregateRating: product.rating
+      ? {
+          '@type': 'AggregateRating',
+          ratingValue: product.rating.average,
+          reviewCount: product.rating.count,
+        }
+      : undefined,
+  }
+
+  return (
+    <>
+      <JsonLd data={productSchema} />
+      <main>{/* 商品詳細 */}</main>
+    </>
+  )
+}
+```
+
+## LocalBusiness スキーマ（店舗情報）
+
+```typescript
+// app/store/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default function StorePage() {
+  const localBusinessSchema = {
+    '@context': 'https://schema.org',
+    '@type': '{{business_type}}', // Restaurant, Store, LocalBusiness など
+    name: '{{store_name}}',
+    image: 'https://{{domain}}/store-image.jpg',
+    '@id': 'https://{{domain}}',
+    url: 'https://{{domain}}',
+    telephone: '{{phone_number}}',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: '{{street_address}}',
+      addressLocality: '{{city}}',
+      addressRegion: '{{prefecture}}',
+      postalCode: '{{postal_code}}',
+      addressCountry: 'JP',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: {{latitude}},
+      longitude: {{longitude}},
+    },
+    openingHoursSpecification: [
+      {
+        '@type': 'OpeningHoursSpecification',
+        dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        opens: '{{weekday_open}}',
+        closes: '{{weekday_close}}',
+      },
+      {
+        '@type': 'OpeningHoursSpecification',
+        dayOfWeek: ['Saturday', 'Sunday'],
+        opens: '{{weekend_open}}',
+        closes: '{{weekend_close}}',
+      },
+    ],
+    priceRange: '{{price_range}}', // ¥, ¥¥, ¥¥¥, ¥¥¥¥
+  }
+
+  return (
+    <>
+      <JsonLd data={localBusinessSchema} />
+      <main>{/* 店舗情報 */}</main>
+    </>
+  )
+}
+```
+
+## HowTo スキーマ（ハウツー記事）
+
+```typescript
+// app/tutorials/[slug]/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default async function TutorialPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const tutorial = await getTutorial(params.slug)
+
+  const howToSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: tutorial.title,
+    description: tutorial.description,
+    totalTime: tutorial.duration, // ISO 8601形式: PT15M
+    estimatedCost: tutorial.cost
+      ? {
+          '@type': 'MonetaryAmount',
+          currency: 'JPY',
+          value: tutorial.cost,
+        }
+      : undefined,
+    tool: tutorial.tools?.map((tool) => ({
+      '@type': 'HowToTool',
+      name: tool,
+    })),
+    step: tutorial.steps.map((step, index) => ({
+      '@type': 'HowToStep',
+      position: index + 1,
+      name: step.title,
+      text: step.description,
+      image: step.image,
+      url: `https://{{domain}}/tutorials/${tutorial.slug}#step-${index + 1}`,
+    })),
+  }
+
+  return (
+    <>
+      <JsonLd data={howToSchema} />
+      <article>{/* チュートリアル内容 */}</article>
+    </>
+  )
+}
+```
+
+## 複合スキーマ（記事 + パンくず）
+
+```typescript
+// app/blog/[slug]/page.tsx
+import { JsonLd } from '@/components/json-ld'
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const post = await getPost(params.slug)
+
+  // 複数のスキーマを @graph で結合
+  const combinedSchema = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        headline: post.title,
+        // ... Article スキーマ
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          // ... パンくずリスト
+        ],
+      },
+    ],
+  }
+
+  return (
+    <>
+      <JsonLd data={combinedSchema} />
+      <article>{/* コンテンツ */}</article>
+    </>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{domain}}` | サイトドメイン | `example.com` |
+| `{{site_name}}` | サイト名 | `My Site` |
+| `{{organization_name}}` | 組織名 | `株式会社サンプル` |
+| `{{twitter_handle}}` | Twitterハンドル | `example` |
+| `{{business_type}}` | 事業タイプ | `Restaurant`, `Store` |
+| `{{latitude}}` | 緯度 | `35.6895` |
+| `{{longitude}}` | 経度 | `139.6917` |
+| `{{price_range}}` | 価格帯 | `¥¥` |

--- a/.claude/skills/server-components-patterns/SKILL.md
+++ b/.claude/skills/server-components-patterns/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: server-components-patterns
+description: |
+  React Server Componentsのデータフェッチ最適化とSuspense活用を専門とするスキル。
+  Server Componentsファーストのアプローチで、効率的なデータフェッチとストリーミング
+  レンダリングを実現します。
+
+  専門分野:
+  - データフェッチ最適化: async/await、並列フェッチ、重複排除
+  - Suspense活用: 段階的レンダリング、loading.tsx、フォールバックUI
+  - キャッシュ戦略: fetch options、revalidate、タグベース無効化
+  - Server Actions: フォーム処理、ミューテーション、楽観的更新
+
+  使用タイミング:
+  - Server Componentでデータフェッチを実装する時
+  - Suspenseによる段階的レンダリングを設計する時
+  - キャッシュ戦略を最適化する時
+  - Server Actionsでフォーム処理を実装する時
+
+  Use proactively when implementing data fetching in Server Components,
+  designing streaming patterns, or optimizing cache strategies.
+version: 1.0.0
+---
+
+# Server Components Patterns
+
+## 概要
+
+このスキルは、React Server Componentsにおけるデータフェッチ最適化と
+Suspenseを活用したストリーミングレンダリングのベストプラクティスを提供します。
+
+**核心哲学**:
+- **Server-First**: データはサーバーで取得し、クライアントへの転送を最小化
+- **Streaming**: コンテンツを段階的に配信し、ユーザー体験を向上
+- **Cache-Aware**: 適切なキャッシュ戦略で効率とフレッシュネスを両立
+
+**主要な価値**:
+- サーバーサイドでの効率的なデータフェッチによるパフォーマンス向上
+- Suspenseによる知覚パフォーマンスの改善
+- 適切なキャッシュ戦略によるリソース効率化
+
+## リソース構造
+
+```
+server-components-patterns/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── data-fetching-patterns.md               # データフェッチパターン
+│   ├── suspense-streaming.md                   # Suspense/Streamingガイド
+│   ├── caching-strategies.md                   # キャッシュ戦略
+│   └── server-actions.md                       # Server Actions
+├── scripts/
+│   └── analyze-data-fetching.mjs               # データフェッチ分析
+└── templates/
+    ├── data-fetch-template.md                  # データフェッチテンプレート
+    └── server-action-template.md               # Server Actionテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# データフェッチパターン
+cat .claude/skills/server-components-patterns/resources/data-fetching-patterns.md
+
+# Suspense/Streamingガイド
+cat .claude/skills/server-components-patterns/resources/suspense-streaming.md
+
+# キャッシュ戦略
+cat .claude/skills/server-components-patterns/resources/caching-strategies.md
+
+# Server Actions
+cat .claude/skills/server-components-patterns/resources/server-actions.md
+```
+
+### スクリプト実行
+
+```bash
+# データフェッチ分析
+node .claude/skills/server-components-patterns/scripts/analyze-data-fetching.mjs <file.tsx>
+```
+
+### テンプレート参照
+
+```bash
+# データフェッチテンプレート
+cat .claude/skills/server-components-patterns/templates/data-fetch-template.md
+
+# Server Actionテンプレート
+cat .claude/skills/server-components-patterns/templates/server-action-template.md
+```
+
+## いつ使うか
+
+### シナリオ1: データフェッチ実装
+**状況**: Server Componentでデータを取得する必要がある
+
+**適用条件**:
+- [ ] データベースまたはAPIからデータ取得
+- [ ] 複数のデータソースを並列で取得
+- [ ] キャッシュ戦略の設計が必要
+
+**期待される成果**: 効率的で保守しやすいデータフェッチ実装
+
+### シナリオ2: Suspense設計
+**状況**: ページの段階的レンダリングを実装したい
+
+**適用条件**:
+- [ ] 非同期コンポーネントが複数ある
+- [ ] 重要度の異なるコンテンツがある
+- [ ] ローディングUIの設計が必要
+
+**期待される成果**: 最適なSuspense境界の配置とフォールバックUI
+
+### シナリオ3: キャッシュ最適化
+**状況**: データの鮮度とパフォーマンスのバランスを取りたい
+
+**適用条件**:
+- [ ] データの更新頻度が定義されている
+- [ ] キャッシュ無効化のタイミングが明確
+- [ ] On-demand再検証が必要
+
+**期待される成果**: 要件に最適なキャッシュ設定
+
+## 知識領域
+
+### 領域1: データフェッチパターン
+
+**基本パターン**:
+```typescript
+// Server Componentでの直接フェッチ
+async function UserProfile({ userId }: { userId: string }) {
+  const user = await getUser(userId)
+  return <div>{user.name}</div>
+}
+```
+
+**並列フェッチ**:
+```typescript
+async function Dashboard() {
+  // 並列実行
+  const [user, posts, stats] = await Promise.all([
+    getUser(),
+    getPosts(),
+    getStats(),
+  ])
+  return <DashboardContent user={user} posts={posts} stats={stats} />
+}
+```
+
+**詳細は**: `resources/data-fetching-patterns.md` を参照
+
+### 領域2: Suspense/Streaming
+
+**自動Suspense（loading.tsx）**:
+```
+app/dashboard/
+├── loading.tsx  → 自動的にSuspense境界を作成
+└── page.tsx
+```
+
+**手動Suspense**:
+```typescript
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <>
+      <Header /> {/* 即座にレンダリング */}
+      <Suspense fallback={<PostsSkeleton />}>
+        <Posts /> {/* ストリーミング */}
+      </Suspense>
+    </>
+  )
+}
+```
+
+**詳細は**: `resources/suspense-streaming.md` を参照
+
+### 領域3: キャッシュ戦略
+
+| 戦略 | 設定 | 用途 |
+|------|------|------|
+| 静的キャッシュ | `cache: 'force-cache'` | 変更されないデータ |
+| 時間ベース | `next: { revalidate: 3600 }` | 定期更新データ |
+| 動的 | `cache: 'no-store'` | 常に最新が必要 |
+| タグベース | `next: { tags: ['posts'] }` | 選択的無効化 |
+
+**詳細は**: `resources/caching-strategies.md` を参照
+
+### 領域4: Server Actions
+
+**フォーム処理**:
+```typescript
+'use server'
+
+export async function createPost(formData: FormData) {
+  const title = formData.get('title')
+  await db.post.create({ data: { title } })
+  revalidatePath('/posts')
+}
+```
+
+**楽観的更新**:
+```typescript
+'use client'
+import { useOptimistic } from 'react'
+
+function PostList({ posts }) {
+  const [optimisticPosts, addOptimisticPost] = useOptimistic(
+    posts,
+    (state, newPost) => [...state, newPost]
+  )
+  // ...
+}
+```
+
+**詳細は**: `resources/server-actions.md` を参照
+
+## ワークフロー
+
+### Phase 1: データ要件分析
+1. 必要なデータソースを特定
+2. データの依存関係を分析
+3. 更新頻度を確認
+
+### Phase 2: フェッチ戦略設計
+1. 並列/逐次フェッチを決定
+2. キャッシュ戦略を選択
+3. エラーハンドリングを計画
+
+### Phase 3: Suspense境界設計
+1. コンテンツの優先度を分析
+2. Suspense境界を配置
+3. フォールバックUIを設計
+
+### Phase 4: 実装
+1. データフェッチ関数を実装
+2. Server Componentを実装
+3. loading.tsx/Suspenseを実装
+
+### Phase 5: 検証
+1. パフォーマンスを測定
+2. キャッシュ動作を確認
+3. エラーケースをテスト
+
+## 設計原則
+
+### コロケーションの原則
+データフェッチはそれを使用するコンポーネントに近接して配置する。
+
+### 並列化の原則
+独立したデータフェッチはPromise.allで並列実行する。
+
+### 段階的開示の原則
+重要なコンテンツを優先し、二次的なコンテンツはストリーミングする。
+
+### フォールバック優先の原則
+適切なスケルトンUIでユーザーに進行状況を伝える。
+
+## 関連スキル
+
+- `.claude/skills/nextjs-app-router/SKILL.md` - ルーティング構造
+- `.claude/skills/seo-optimization/SKILL.md` - Metadata API
+- `.claude/skills/web-performance/SKILL.md` - パフォーマンス最適化
+- `.claude/skills/error-handling-pages/SKILL.md` - エラーハンドリング
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/server-components-patterns/resources/caching-strategies.md
+++ b/.claude/skills/server-components-patterns/resources/caching-strategies.md
@@ -1,0 +1,297 @@
+# キャッシュ戦略
+
+## Next.js のキャッシュレイヤー
+
+```
+1. Request Memoization (React)
+   └── 同一リクエスト内でのfetch重複排除
+
+2. Data Cache (Next.js)
+   └── fetchの結果をサーバーで永続化
+
+3. Full Route Cache (Next.js)
+   └── ビルド時にレンダリング結果をキャッシュ
+
+4. Router Cache (Client)
+   └── クライアントでのRoute Segmentキャッシュ
+```
+
+## fetch オプション
+
+### キャッシュモード
+
+```typescript
+// 1. 静的キャッシュ（デフォルト）
+fetch('https://api.example.com/data')
+// または明示的に
+fetch('https://api.example.com/data', { cache: 'force-cache' })
+
+// 2. キャッシュなし（常に最新）
+fetch('https://api.example.com/data', { cache: 'no-store' })
+
+// 3. 時間ベースの再検証
+fetch('https://api.example.com/data', {
+  next: { revalidate: 3600 }, // 1時間
+})
+
+// 4. タグベースの再検証
+fetch('https://api.example.com/data', {
+  next: { tags: ['posts'] },
+})
+```
+
+### 設定の優先順位
+
+```
+fetch オプション > Route Segment Config > 動的関数の使用
+
+例:
+- fetch({ cache: 'no-store' }) → 常に動的
+- cookies() の使用 → 常に動的
+- export const revalidate = 3600 → ISR
+- export const dynamic = 'force-static' → 常に静的
+```
+
+## Route Segment Config
+
+### ページ/レイアウトレベルの設定
+
+```typescript
+// app/blog/page.tsx
+
+// 動的レンダリングを強制
+export const dynamic = 'force-dynamic'
+
+// 静的レンダリングを強制
+export const dynamic = 'force-static'
+
+// 再検証間隔（ISR）
+export const revalidate = 3600 // 1時間
+
+// フェッチキャッシュの制御
+export const fetchCache = 'force-cache'
+```
+
+### 設定オプション一覧
+
+| オプション | 値 | 説明 |
+|-----------|-----|------|
+| `dynamic` | `'auto'` | Next.jsが自動判断（デフォルト） |
+| | `'force-dynamic'` | 常に動的レンダリング |
+| | `'error'` | 動的になるとエラー |
+| | `'force-static'` | 常に静的レンダリング |
+| `revalidate` | `false` | 再検証しない |
+| | `0` | 常にリクエスト時にレンダリング |
+| | `number` | 秒数で再検証間隔を指定 |
+
+## 再検証（Revalidation）
+
+### 時間ベースの再検証
+
+```typescript
+// ページ全体の再検証間隔
+export const revalidate = 3600 // 1時間
+
+// 個別fetchの再検証
+const posts = await fetch('https://api.example.com/posts', {
+  next: { revalidate: 3600 },
+})
+```
+
+### On-Demand 再検証
+
+```typescript
+// app/api/revalidate/route.ts
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { NextRequest } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const { secret, path, tag } = await request.json()
+
+  // シークレットの検証
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return Response.json({ error: 'Invalid secret' }, { status: 401 })
+  }
+
+  // パスベースの再検証
+  if (path) {
+    revalidatePath(path)
+    return Response.json({ revalidated: true, path })
+  }
+
+  // タグベースの再検証
+  if (tag) {
+    revalidateTag(tag)
+    return Response.json({ revalidated: true, tag })
+  }
+
+  return Response.json({ error: 'Missing path or tag' }, { status: 400 })
+}
+```
+
+### Server Actions での再検証
+
+```typescript
+'use server'
+
+import { revalidatePath, revalidateTag } from 'next/cache'
+
+export async function createPost(formData: FormData) {
+  const title = formData.get('title') as string
+
+  await db.post.create({
+    data: { title },
+  })
+
+  // 作成後にパスを再検証
+  revalidatePath('/posts')
+
+  // または特定のタグを再検証
+  revalidateTag('posts')
+}
+```
+
+## タグベースのキャッシュ
+
+### タグの設定
+
+```typescript
+// lib/data.ts
+export async function getPosts() {
+  const res = await fetch('https://api.example.com/posts', {
+    next: { tags: ['posts'] },
+  })
+  return res.json()
+}
+
+export async function getPost(slug: string) {
+  const res = await fetch(`https://api.example.com/posts/${slug}`, {
+    next: { tags: ['posts', `post-${slug}`] },
+  })
+  return res.json()
+}
+
+export async function getUser(id: string) {
+  const res = await fetch(`https://api.example.com/users/${id}`, {
+    next: { tags: ['users', `user-${id}`] },
+  })
+  return res.json()
+}
+```
+
+### タグの再検証
+
+```typescript
+'use server'
+
+import { revalidateTag } from 'next/cache'
+
+// すべての投稿を再検証
+export async function revalidateAllPosts() {
+  revalidateTag('posts')
+}
+
+// 特定の投稿のみ再検証
+export async function revalidatePost(slug: string) {
+  revalidateTag(`post-${slug}`)
+}
+```
+
+## キャッシュ戦略の選択
+
+### 判断フロー
+
+```
+このデータは...
+├─ 変更されない（静的アセット、設定等）
+│  └─ cache: 'force-cache' + 再検証なし
+├─ 定期的に変更（ブログ投稿、製品情報）
+│  └─ next: { revalidate: 適切な秒数 }
+├─ イベント駆動で変更（ユーザー操作後）
+│  └─ next: { tags: ['tag'] } + revalidateTag()
+├─ ユーザー固有（ダッシュボード、設定）
+│  └─ cache: 'no-store'
+└─ リアルタイム必須（チャット、通知）
+   └─ cache: 'no-store' + クライアントポーリング/WebSocket
+```
+
+### ユースケース別設定例
+
+```typescript
+// 1. 静的コンテンツ（ドキュメント、About）
+export const dynamic = 'force-static'
+
+// 2. ブログ投稿（1時間毎に更新）
+export const revalidate = 3600
+
+// 3. ECサイト商品（CMSから即時更新）
+const product = await fetch(`/api/products/${id}`, {
+  next: { tags: [`product-${id}`] },
+})
+
+// 4. ユーザーダッシュボード（常に最新）
+export const dynamic = 'force-dynamic'
+
+// 5. 検索結果（キャッシュしない）
+const results = await fetch(`/api/search?q=${query}`, {
+  cache: 'no-store',
+})
+```
+
+## ORM/データベースのキャッシュ
+
+### unstable_cache の使用
+
+```typescript
+import { unstable_cache } from 'next/cache'
+
+const getCachedUser = unstable_cache(
+  async (id: string) => {
+    return db.user.findUnique({ where: { id } })
+  },
+  ['user'],
+  {
+    tags: ['users'],
+    revalidate: 3600,
+  }
+)
+
+// 使用
+const user = await getCachedUser(userId)
+
+// 再検証
+revalidateTag('users')
+```
+
+### Reactのcacheとの併用
+
+```typescript
+import { cache } from 'react'
+import { unstable_cache } from 'next/cache'
+
+// リクエスト間でキャッシュ（Next.js）
+const getCachedUser = unstable_cache(
+  async (id: string) => db.user.findUnique({ where: { id } }),
+  ['user'],
+  { tags: ['users'] }
+)
+
+// 同一リクエスト内で重複排除（React）
+export const getUser = cache(getCachedUser)
+```
+
+## チェックリスト
+
+### キャッシュ設計時
+
+- [ ] 各データソースの更新頻度を把握している
+- [ ] 適切なキャッシュモードを選択している
+- [ ] タグが論理的に設計されている
+- [ ] On-demand再検証のエンドポイントがセキュア
+
+### パフォーマンス
+
+- [ ] 不必要な動的レンダリングを避けている
+- [ ] ISRで適切な再検証間隔を設定している
+- [ ] タグの粒度が適切（細かすぎず粗すぎず）
+- [ ] キャッシュヒット率を監視している

--- a/.claude/skills/server-components-patterns/resources/data-fetching-patterns.md
+++ b/.claude/skills/server-components-patterns/resources/data-fetching-patterns.md
@@ -1,0 +1,336 @@
+# データフェッチパターン
+
+## 基本パターン
+
+### Server Componentでの直接フェッチ
+
+```typescript
+// app/users/[id]/page.tsx
+async function UserProfile({ userId }: { userId: string }) {
+  // Server Componentでは直接awaitが使用可能
+  const user = await db.user.findUnique({
+    where: { id: userId },
+  })
+
+  if (!user) {
+    notFound()
+  }
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+### fetch APIの使用
+
+```typescript
+async function getPosts() {
+  const res = await fetch('https://api.example.com/posts', {
+    // キャッシュオプション
+    cache: 'force-cache', // デフォルト
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch posts')
+  }
+
+  return res.json()
+}
+
+async function PostList() {
+  const posts = await getPosts()
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## 並列フェッチ
+
+### Promise.allによる並列実行
+
+```typescript
+// ✅ 推奨: 並列フェッチ
+async function Dashboard() {
+  // 3つのリクエストが同時に実行される
+  const [user, posts, analytics] = await Promise.all([
+    getUser(),
+    getPosts(),
+    getAnalytics(),
+  ])
+
+  return (
+    <div>
+      <UserCard user={user} />
+      <PostList posts={posts} />
+      <AnalyticsChart data={analytics} />
+    </div>
+  )
+}
+
+// ❌ 避けるべき: 逐次フェッチ（ウォーターフォール）
+async function Dashboard() {
+  const user = await getUser()      // 1秒
+  const posts = await getPosts()    // 1秒
+  const analytics = await getAnalytics() // 1秒
+  // 合計: 3秒
+
+  return <div>...</div>
+}
+```
+
+### 依存関係がある場合
+
+```typescript
+async function UserPosts({ userId }: { userId: string }) {
+  // userを取得してから、そのIDでpostsを取得
+  const user = await getUser(userId)
+
+  // 依存するフェッチは逐次で OK
+  const posts = await getPostsByAuthor(user.id)
+
+  return (
+    <div>
+      <h1>{user.name}'s Posts</h1>
+      <PostList posts={posts} />
+    </div>
+  )
+}
+```
+
+## プリロード/プリフェッチ
+
+### プリロードパターン
+
+```typescript
+// lib/data.ts
+import { cache } from 'react'
+
+// cacheで同一リクエスト内の重複を排除
+export const getUser = cache(async (id: string) => {
+  const res = await fetch(`/api/users/${id}`)
+  return res.json()
+})
+
+// プリロード関数
+export const preloadUser = (id: string) => {
+  void getUser(id)
+}
+```
+
+```typescript
+// app/users/[id]/page.tsx
+import { preloadUser, getUser } from '@/lib/data'
+
+export default async function UserPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  // 早期にプリロードを開始
+  preloadUser(id)
+
+  // 他の処理...
+
+  // 後でデータを使用（既にキャッシュされている可能性）
+  const user = await getUser(id)
+  return <UserProfile user={user} />
+}
+```
+
+## リクエスト重複排除
+
+### Reactのcache関数
+
+```typescript
+import { cache } from 'react'
+
+// 同一リクエスト内で複数回呼び出しても1回のみ実行
+export const getUser = cache(async (id: string) => {
+  console.log('Fetching user:', id) // 1回のみログ出力
+  const res = await fetch(`/api/users/${id}`)
+  return res.json()
+})
+```
+
+```typescript
+// Layout と Page で同じ関数を呼んでも重複しない
+// app/users/[id]/layout.tsx
+export default async function Layout({ children, params }) {
+  const { id } = await params
+  const user = await getUser(id) // フェッチ実行
+  return <UserNav user={user}>{children}</UserNav>
+}
+
+// app/users/[id]/page.tsx
+export default async function Page({ params }) {
+  const { id } = await params
+  const user = await getUser(id) // キャッシュから取得（重複なし）
+  return <UserProfile user={user} />
+}
+```
+
+### fetchの自動重複排除
+
+```typescript
+// Next.jsはfetchを自動的に重複排除
+// 同じURLとオプションのfetchは1回のみ実行される
+
+async function ComponentA() {
+  const data = await fetch('https://api.example.com/data')
+  return <div>{/* ... */}</div>
+}
+
+async function ComponentB() {
+  // 同じURL → ComponentAと同じリクエスト、重複排除
+  const data = await fetch('https://api.example.com/data')
+  return <div>{/* ... */}</div>
+}
+```
+
+## データ取得関数の構造化
+
+### 推奨構造
+
+```typescript
+// lib/db/users.ts
+import { db } from '@/lib/db'
+import { cache } from 'react'
+
+export const getUser = cache(async (id: string) => {
+  return db.user.findUnique({
+    where: { id },
+    include: { profile: true },
+  })
+})
+
+export const getUsers = cache(async () => {
+  return db.user.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+})
+
+export const getUserWithPosts = cache(async (id: string) => {
+  return db.user.findUnique({
+    where: { id },
+    include: {
+      posts: {
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+      },
+    },
+  })
+})
+```
+
+```typescript
+// lib/api/posts.ts
+import { cache } from 'react'
+
+const API_URL = process.env.API_URL
+
+export const getPosts = cache(async () => {
+  const res = await fetch(`${API_URL}/posts`, {
+    next: { revalidate: 3600 },
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch posts')
+  }
+
+  return res.json()
+})
+
+export const getPost = cache(async (slug: string) => {
+  const res = await fetch(`${API_URL}/posts/${slug}`, {
+    next: { tags: [`post-${slug}`] },
+  })
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      return null
+    }
+    throw new Error('Failed to fetch post')
+  }
+
+  return res.json()
+})
+```
+
+## エラーハンドリング
+
+### try-catchパターン
+
+```typescript
+async function UserProfile({ userId }: { userId: string }) {
+  try {
+    const user = await getUser(userId)
+
+    if (!user) {
+      notFound()
+    }
+
+    return <div>{user.name}</div>
+  } catch (error) {
+    // エラーはerror.tsxで捕捉される
+    throw error
+  }
+}
+```
+
+### Result型パターン
+
+```typescript
+type Result<T> =
+  | { success: true; data: T }
+  | { success: false; error: string }
+
+async function getUser(id: string): Promise<Result<User>> {
+  try {
+    const user = await db.user.findUnique({ where: { id } })
+    if (!user) {
+      return { success: false, error: 'User not found' }
+    }
+    return { success: true, data: user }
+  } catch (error) {
+    return { success: false, error: 'Failed to fetch user' }
+  }
+}
+
+async function UserProfile({ userId }: { userId: string }) {
+  const result = await getUser(userId)
+
+  if (!result.success) {
+    return <ErrorMessage message={result.error} />
+  }
+
+  return <div>{result.data.name}</div>
+}
+```
+
+## チェックリスト
+
+### データフェッチ実装時
+
+- [ ] Server Componentでデータを取得している
+- [ ] 独立したフェッチはPromise.allで並列化している
+- [ ] cache関数で重複排除している
+- [ ] エラーハンドリングが適切
+- [ ] キャッシュオプションが設定されている
+
+### パフォーマンス最適化
+
+- [ ] N+1問題を避けている
+- [ ] 必要なフィールドのみ取得している
+- [ ] プリロードを活用している
+- [ ] 不要な再フェッチを避けている

--- a/.claude/skills/server-components-patterns/resources/server-actions.md
+++ b/.claude/skills/server-components-patterns/resources/server-actions.md
@@ -1,0 +1,392 @@
+# Server Actions
+
+## 基本概念
+
+Server Actionsは、サーバーで実行される非同期関数です。フォーム送信やミューテーションを
+クライアントコードを書かずに処理できます。
+
+## 基本的な使い方
+
+### 単独ファイルでの定義
+
+```typescript
+// app/actions.ts
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+export async function createPost(formData: FormData) {
+  const title = formData.get('title') as string
+  const content = formData.get('content') as string
+
+  await db.post.create({
+    data: { title, content },
+  })
+
+  revalidatePath('/posts')
+  redirect('/posts')
+}
+```
+
+### インラインでの定義
+
+```typescript
+// app/posts/new/page.tsx
+export default function NewPostPage() {
+  async function createPost(formData: FormData) {
+    'use server'
+
+    const title = formData.get('title') as string
+    await db.post.create({ data: { title } })
+    revalidatePath('/posts')
+  }
+
+  return (
+    <form action={createPost}>
+      <input name="title" required />
+      <button type="submit">Create</button>
+    </form>
+  )
+}
+```
+
+## フォーム処理
+
+### 基本フォーム
+
+```typescript
+// components/create-post-form.tsx
+import { createPost } from '@/app/actions'
+
+export function CreatePostForm() {
+  return (
+    <form action={createPost}>
+      <label htmlFor="title">Title</label>
+      <input id="title" name="title" required />
+
+      <label htmlFor="content">Content</label>
+      <textarea id="content" name="content" required />
+
+      <button type="submit">Create Post</button>
+    </form>
+  )
+}
+```
+
+### useFormState によるステート管理
+
+```typescript
+// app/actions.ts
+'use server'
+
+type State = {
+  message: string
+  errors?: {
+    title?: string[]
+    content?: string[]
+  }
+}
+
+export async function createPost(
+  prevState: State,
+  formData: FormData
+): Promise<State> {
+  const title = formData.get('title') as string
+  const content = formData.get('content') as string
+
+  // バリデーション
+  const errors: State['errors'] = {}
+  if (!title || title.length < 3) {
+    errors.title = ['Title must be at least 3 characters']
+  }
+  if (!content || content.length < 10) {
+    errors.content = ['Content must be at least 10 characters']
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { message: 'Validation failed', errors }
+  }
+
+  await db.post.create({ data: { title, content } })
+  revalidatePath('/posts')
+
+  return { message: 'Post created successfully' }
+}
+```
+
+```typescript
+// components/create-post-form.tsx
+'use client'
+
+import { useFormState } from 'react-dom'
+import { createPost } from '@/app/actions'
+
+const initialState = { message: '', errors: {} }
+
+export function CreatePostForm() {
+  const [state, formAction] = useFormState(createPost, initialState)
+
+  return (
+    <form action={formAction}>
+      <div>
+        <input name="title" />
+        {state.errors?.title && (
+          <p className="text-red-500">{state.errors.title[0]}</p>
+        )}
+      </div>
+
+      <div>
+        <textarea name="content" />
+        {state.errors?.content && (
+          <p className="text-red-500">{state.errors.content[0]}</p>
+        )}
+      </div>
+
+      <SubmitButton />
+
+      {state.message && <p>{state.message}</p>}
+    </form>
+  )
+}
+```
+
+### useFormStatus によるローディング状態
+
+```typescript
+// components/submit-button.tsx
+'use client'
+
+import { useFormStatus } from 'react-dom'
+
+export function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? 'Creating...' : 'Create Post'}
+    </button>
+  )
+}
+```
+
+## 楽観的更新
+
+### useOptimistic の使用
+
+```typescript
+// components/like-button.tsx
+'use client'
+
+import { useOptimistic } from 'react'
+import { likePost } from '@/app/actions'
+
+export function LikeButton({ postId, likes }: { postId: string; likes: number }) {
+  const [optimisticLikes, addOptimisticLike] = useOptimistic(
+    likes,
+    (state, _) => state + 1
+  )
+
+  async function handleLike() {
+    addOptimisticLike(null) // 即座にUIを更新
+    await likePost(postId)  // サーバーで処理
+  }
+
+  return (
+    <form action={handleLike}>
+      <button type="submit">
+        ❤️ {optimisticLikes}
+      </button>
+    </form>
+  )
+}
+```
+
+### リストの楽観的更新
+
+```typescript
+// components/todo-list.tsx
+'use client'
+
+import { useOptimistic } from 'react'
+import { addTodo, deleteTodo } from '@/app/actions'
+
+type Todo = { id: string; text: string; pending?: boolean }
+
+export function TodoList({ todos }: { todos: Todo[] }) {
+  const [optimisticTodos, addOptimisticTodo] = useOptimistic(
+    todos,
+    (state, action: { type: 'add' | 'delete'; todo?: Todo; id?: string }) => {
+      switch (action.type) {
+        case 'add':
+          return [...state, { ...action.todo!, pending: true }]
+        case 'delete':
+          return state.filter((t) => t.id !== action.id)
+        default:
+          return state
+      }
+    }
+  )
+
+  async function handleAdd(formData: FormData) {
+    const text = formData.get('text') as string
+    const tempId = `temp-${Date.now()}`
+
+    addOptimisticTodo({ type: 'add', todo: { id: tempId, text } })
+    await addTodo(text)
+  }
+
+  async function handleDelete(id: string) {
+    addOptimisticTodo({ type: 'delete', id })
+    await deleteTodo(id)
+  }
+
+  return (
+    <div>
+      <form action={handleAdd}>
+        <input name="text" required />
+        <button type="submit">Add</button>
+      </form>
+
+      <ul>
+        {optimisticTodos.map((todo) => (
+          <li key={todo.id} className={todo.pending ? 'opacity-50' : ''}>
+            {todo.text}
+            <button onClick={() => handleDelete(todo.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## エラーハンドリング
+
+### try-catch パターン
+
+```typescript
+// app/actions.ts
+'use server'
+
+export async function createPost(formData: FormData) {
+  try {
+    const title = formData.get('title') as string
+
+    await db.post.create({ data: { title } })
+    revalidatePath('/posts')
+
+    return { success: true }
+  } catch (error) {
+    console.error('Failed to create post:', error)
+    return { success: false, error: 'Failed to create post' }
+  }
+}
+```
+
+### バリデーション with Zod
+
+```typescript
+// app/actions.ts
+'use server'
+
+import { z } from 'zod'
+
+const PostSchema = z.object({
+  title: z.string().min(3, 'Title must be at least 3 characters'),
+  content: z.string().min(10, 'Content must be at least 10 characters'),
+})
+
+export async function createPost(formData: FormData) {
+  const validatedFields = PostSchema.safeParse({
+    title: formData.get('title'),
+    content: formData.get('content'),
+  })
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: validatedFields.error.flatten().fieldErrors,
+    }
+  }
+
+  const { title, content } = validatedFields.data
+
+  await db.post.create({ data: { title, content } })
+  revalidatePath('/posts')
+
+  return { success: true }
+}
+```
+
+## セキュリティ考慮事項
+
+### 認証チェック
+
+```typescript
+'use server'
+
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+
+export async function createPost(formData: FormData) {
+  const session = await auth()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  // 認証済みユーザーのみ実行可能
+  const title = formData.get('title') as string
+
+  await db.post.create({
+    data: {
+      title,
+      authorId: session.user.id,
+    },
+  })
+
+  revalidatePath('/posts')
+}
+```
+
+### 認可チェック
+
+```typescript
+'use server'
+
+export async function deletePost(postId: string) {
+  const session = await auth()
+
+  if (!session) {
+    throw new Error('Unauthorized')
+  }
+
+  const post = await db.post.findUnique({ where: { id: postId } })
+
+  // 投稿の所有者のみ削除可能
+  if (post?.authorId !== session.user.id) {
+    throw new Error('Forbidden')
+  }
+
+  await db.post.delete({ where: { id: postId } })
+  revalidatePath('/posts')
+}
+```
+
+## チェックリスト
+
+### Server Action 実装時
+
+- [ ] 'use server' ディレクティブが設定されている
+- [ ] 入力値のバリデーションを行っている
+- [ ] 適切なエラーハンドリングがある
+- [ ] 認証・認可チェックを行っている
+- [ ] revalidatePath/revalidateTagで適切に再検証している
+
+### フォーム実装時
+
+- [ ] useFormStateでステート管理している
+- [ ] useFormStatusでローディング状態を表示
+- [ ] エラーメッセージをユーザーに表示
+- [ ] 楽観的更新が必要な場合はuseOptimisticを使用

--- a/.claude/skills/server-components-patterns/resources/suspense-streaming.md
+++ b/.claude/skills/server-components-patterns/resources/suspense-streaming.md
@@ -1,0 +1,314 @@
+# Suspense/Streaming ガイド
+
+## Streaming SSR の仕組み
+
+```
+1. サーバーがHTMLの生成を開始
+2. 準備できた部分から順次クライアントに送信
+3. クライアントは受信したHTMLを即座に表示
+4. 非同期部分は後からストリーミングで到着
+
+[Header: 即座に表示] → [Main: 即座に表示] → [Posts: 後からストリーミング]
+```
+
+## loading.tsx による自動Suspense
+
+### 基本的な使い方
+
+```
+app/dashboard/
+├── loading.tsx   # 自動的にSuspense境界を作成
+├── page.tsx      # 非同期コンポーネント
+└── layout.tsx
+```
+
+```typescript
+// app/dashboard/loading.tsx
+export default function Loading() {
+  return <DashboardSkeleton />
+}
+
+// app/dashboard/page.tsx
+export default async function DashboardPage() {
+  const data = await fetchDashboardData() // 時間がかかる処理
+  return <Dashboard data={data} />
+}
+```
+
+### loading.tsxの特徴
+
+- 自動的にSuspense境界を作成
+- page.tsxと同じディレクトリに配置
+- ナビゲーション中も表示される（インスタントナビゲーション）
+
+## 手動Suspense境界
+
+### 基本パターン
+
+```typescript
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <div>
+      {/* 即座にレンダリング */}
+      <Header />
+
+      {/* 非同期コンポーネントをSuspenseでラップ */}
+      <Suspense fallback={<PostsSkeleton />}>
+        <Posts />
+      </Suspense>
+
+      {/* 即座にレンダリング */}
+      <Footer />
+    </div>
+  )
+}
+```
+
+### 複数のSuspense境界
+
+```typescript
+export default function DashboardPage() {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {/* 各セクションが独立してストリーミング */}
+      <Suspense fallback={<StatsSkeleton />}>
+        <Stats />
+      </Suspense>
+
+      <Suspense fallback={<ChartSkeleton />}>
+        <Chart />
+      </Suspense>
+
+      <Suspense fallback={<RecentActivitySkeleton />}>
+        <RecentActivity />
+      </Suspense>
+
+      <Suspense fallback={<NotificationsSkeleton />}>
+        <Notifications />
+      </Suspense>
+    </div>
+  )
+}
+```
+
+### ネストされたSuspense
+
+```typescript
+export default function Page() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <Header />
+      <main>
+        {/* 外側のSuspenseが解決された後、内側が表示 */}
+        <Suspense fallback={<ContentSkeleton />}>
+          <Content />
+        </Suspense>
+      </main>
+    </Suspense>
+  )
+}
+```
+
+## Skeleton UI 設計
+
+### 効果的なスケルトンの原則
+
+1. **構造を反映**: 実際のコンテンツのレイアウトを模倣
+2. **アニメーション**: パルスまたはシマーでロード中を明示
+3. **サイズ一致**: CLSを防ぐため実際のサイズに近づける
+
+### Skeleton コンポーネント例
+
+```typescript
+// components/skeletons/post-skeleton.tsx
+export function PostSkeleton() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-48 bg-gray-200 rounded-lg mb-4" />
+      <div className="h-6 bg-gray-200 rounded w-3/4 mb-2" />
+      <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+      <div className="space-y-2">
+        <div className="h-4 bg-gray-200 rounded" />
+        <div className="h-4 bg-gray-200 rounded w-5/6" />
+      </div>
+    </div>
+  )
+}
+
+export function PostListSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: count }).map((_, i) => (
+        <PostSkeleton key={i} />
+      ))}
+    </div>
+  )
+}
+```
+
+### Tailwind CSSスケルトン
+
+```typescript
+// シマーエフェクト
+function ShimmerSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={`
+        relative overflow-hidden bg-gray-200 rounded
+        before:absolute before:inset-0
+        before:-translate-x-full
+        before:animate-[shimmer_1.5s_infinite]
+        before:bg-gradient-to-r
+        before:from-transparent before:via-white/60 before:to-transparent
+        ${className}
+      `}
+    />
+  )
+}
+```
+
+## Streaming の最適化
+
+### 優先度ベースのストリーミング
+
+```typescript
+export default function ProductPage({ productId }: { productId: string }) {
+  return (
+    <div>
+      {/* 高優先度: 商品情報は即座に必要 */}
+      <Suspense fallback={<ProductInfoSkeleton />}>
+        <ProductInfo id={productId} />
+      </Suspense>
+
+      {/* 中優先度: レビューは少し待てる */}
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Reviews productId={productId} />
+      </Suspense>
+
+      {/* 低優先度: 関連商品は最後でOK */}
+      <Suspense fallback={<RelatedProductsSkeleton />}>
+        <RelatedProducts productId={productId} />
+      </Suspense>
+    </div>
+  )
+}
+```
+
+### 条件付きSuspense
+
+```typescript
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ view?: string }>
+}) {
+  const params = await searchParams
+
+  return (
+    <div>
+      <Header />
+
+      {/* 条件に応じてSuspenseを切り替え */}
+      {params.view === 'detailed' ? (
+        <Suspense fallback={<DetailedViewSkeleton />}>
+          <DetailedView />
+        </Suspense>
+      ) : (
+        <Suspense fallback={<SimpleViewSkeleton />}>
+          <SimpleView />
+        </Suspense>
+      )}
+    </div>
+  )
+}
+```
+
+## エラーハンドリングとの統合
+
+### error.tsx と loading.tsx の組み合わせ
+
+```
+app/dashboard/
+├── layout.tsx
+├── loading.tsx    # ローディング状態
+├── error.tsx      # エラー状態
+├── not-found.tsx  # 404状態
+└── page.tsx
+```
+
+### Suspenseとエラー境界の順序
+
+```typescript
+// Suspenseはエラー境界の内側に配置
+export default function Page() {
+  return (
+    <ErrorBoundary fallback={<ErrorUI />}>
+      <Suspense fallback={<Loading />}>
+        <AsyncComponent />
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+## パフォーマンス考慮事項
+
+### Suspense境界の粒度
+
+```typescript
+// ❌ 避けるべき: 粒度が粗すぎる
+<Suspense fallback={<PageSkeleton />}>
+  <EntirePage /> {/* 全体が遅い */}
+</Suspense>
+
+// ✅ 推奨: 適切な粒度
+<>
+  <Header /> {/* 即座に表示 */}
+  <Suspense fallback={<MainSkeleton />}>
+    <Main /> {/* ストリーミング */}
+  </Suspense>
+  <Suspense fallback={<SidebarSkeleton />}>
+    <Sidebar /> {/* 独立してストリーミング */}
+  </Suspense>
+</>
+```
+
+### 並列Suspense vs 逐次Suspense
+
+```typescript
+// 並列: 独立して解決
+<div className="flex">
+  <Suspense fallback={<A_Skeleton />}>
+    <ComponentA /> {/* 先に解決されれば先に表示 */}
+  </Suspense>
+  <Suspense fallback={<B_Skeleton />}>
+    <ComponentB /> {/* 独立して解決 */}
+  </Suspense>
+</div>
+
+// 逐次: 順番に解決
+<Suspense fallback={<A_Skeleton />}>
+  <ComponentA />
+  <Suspense fallback={<B_Skeleton />}>
+    <ComponentB /> {/* Aの後に表示 */}
+  </Suspense>
+</Suspense>
+```
+
+## チェックリスト
+
+### Suspense設計時
+
+- [ ] 重要なコンテンツは早くストリーミングされるか
+- [ ] Suspense境界の粒度は適切か
+- [ ] スケルトンUIが実際のコンテンツ構造を反映しているか
+- [ ] CLSが発生しないサイズになっているか
+
+### パフォーマンス
+
+- [ ] 不要なSuspense境界がないか
+- [ ] 並列化できるものは並列になっているか
+- [ ] loading.tsxが適切に配置されているか
+- [ ] エラー境界との統合が適切か

--- a/.claude/skills/server-components-patterns/scripts/analyze-data-fetching.mjs
+++ b/.claude/skills/server-components-patterns/scripts/analyze-data-fetching.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+/**
+ * Server Components データフェッチ分析スクリプト
+ *
+ * 使用方法:
+ *   node analyze-data-fetching.mjs <file.tsx>
+ *
+ * 例:
+ *   node analyze-data-fetching.mjs ./src/app/page.tsx
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+class DataFetchingAnalyzer {
+  constructor(filePath) {
+    this.filePath = path.resolve(filePath);
+    this.content = '';
+    this.issues = [];
+    this.suggestions = [];
+    this.stats = {
+      fetches: 0,
+      parallelFetches: 0,
+      sequentialFetches: 0,
+      cachedFetches: 0,
+      uncachedFetches: 0,
+      serverActions: 0,
+      suspenseBoundaries: 0,
+    };
+  }
+
+  analyze() {
+    if (!fs.existsSync(this.filePath)) {
+      console.error(`Error: File not found: ${this.filePath}`);
+      process.exit(1);
+    }
+
+    this.content = fs.readFileSync(this.filePath, 'utf-8');
+
+    console.log(`\n📊 Analyzing: ${this.filePath}\n`);
+    console.log('='.repeat(60));
+
+    this.checkComponentType();
+    this.analyzeDataFetching();
+    this.analyzeCaching();
+    this.analyzeSuspense();
+    this.analyzeServerActions();
+    this.checkPatterns();
+
+    this.printStats();
+    this.printIssues();
+    this.printSuggestions();
+  }
+
+  checkComponentType() {
+    const hasUseClient = this.content.includes("'use client'") || this.content.includes('"use client"');
+    const hasUseServer = this.content.includes("'use server'") || this.content.includes('"use server"');
+
+    console.log('\n🔍 Component Type:');
+    console.log('-'.repeat(40));
+
+    if (hasUseClient) {
+      console.log('  Type: Client Component');
+      this.suggestions.push('Client Componentではデータフェッチを避け、Server Componentから props で渡すことを検討');
+    } else if (hasUseServer) {
+      console.log('  Type: Server Action file');
+    } else {
+      console.log('  Type: Server Component (default)');
+    }
+  }
+
+  analyzeDataFetching() {
+    console.log('\n📥 Data Fetching Analysis:');
+    console.log('-'.repeat(40));
+
+    // fetch呼び出しを検出
+    const fetchMatches = this.content.match(/await\s+fetch\s*\(/g) || [];
+    this.stats.fetches = fetchMatches.length;
+
+    // Promise.allの検出
+    const promiseAllMatches = this.content.match(/Promise\.all\s*\(\s*\[/g) || [];
+    this.stats.parallelFetches = promiseAllMatches.length;
+
+    // 連続したawaitを検出（ウォーターフォール）
+    const sequentialPattern = /await\s+\w+\([^)]*\)\s*;?\s*\n\s*await\s+\w+\(/g;
+    const sequentialMatches = this.content.match(sequentialPattern) || [];
+
+    if (sequentialMatches.length > 0) {
+      this.stats.sequentialFetches = sequentialMatches.length;
+      this.issues.push({
+        type: 'warning',
+        message: `連続した await が ${sequentialMatches.length} 箇所あります（ウォーターフォール）`,
+      });
+    }
+
+    // DB直接アクセスを検出
+    const dbPatterns = ['db.', 'prisma.', 'drizzle.'];
+    const hasDbAccess = dbPatterns.some(p => this.content.includes(p));
+
+    console.log(`  fetch calls: ${this.stats.fetches}`);
+    console.log(`  Promise.all usage: ${this.stats.parallelFetches}`);
+    console.log(`  Sequential awaits: ${this.stats.sequentialFetches}`);
+    console.log(`  Database access: ${hasDbAccess ? 'Yes' : 'No'}`);
+
+    if (this.stats.fetches > 1 && this.stats.parallelFetches === 0) {
+      this.suggestions.push('複数のfetchがあります。独立している場合はPromise.allで並列化を検討');
+    }
+  }
+
+  analyzeCaching() {
+    console.log('\n💾 Caching Analysis:');
+    console.log('-'.repeat(40));
+
+    // キャッシュオプションの検出
+    const forceCache = (this.content.match(/cache:\s*['"]force-cache['"]/g) || []).length;
+    const noStore = (this.content.match(/cache:\s*['"]no-store['"]/g) || []).length;
+    const revalidate = (this.content.match(/next:\s*\{\s*revalidate:/g) || []).length;
+    const tags = (this.content.match(/next:\s*\{\s*tags:/g) || []).length;
+
+    // Segment config
+    const dynamicExport = this.content.match(/export\s+const\s+dynamic\s*=\s*['"]([^'"]+)['"]/);
+    const revalidateExport = this.content.match(/export\s+const\s+revalidate\s*=\s*(\d+|false)/);
+
+    this.stats.cachedFetches = forceCache + revalidate;
+    this.stats.uncachedFetches = noStore;
+
+    console.log(`  force-cache: ${forceCache}`);
+    console.log(`  no-store: ${noStore}`);
+    console.log(`  revalidate: ${revalidate}`);
+    console.log(`  tags: ${tags}`);
+    console.log(`  dynamic export: ${dynamicExport ? dynamicExport[1] : 'none'}`);
+    console.log(`  revalidate export: ${revalidateExport ? revalidateExport[1] : 'none'}`);
+
+    if (this.stats.fetches > 0 && this.stats.cachedFetches === 0 && this.stats.uncachedFetches === 0) {
+      this.suggestions.push('fetchにキャッシュオプションが設定されていません。明示的な設定を検討');
+    }
+  }
+
+  analyzeSuspense() {
+    console.log('\n⏳ Suspense Analysis:');
+    console.log('-'.repeat(40));
+
+    // Suspense使用の検出
+    const suspenseMatches = this.content.match(/<Suspense/g) || [];
+    this.stats.suspenseBoundaries = suspenseMatches.length;
+
+    // loading.tsxの存在チェック（同じディレクトリ）
+    const dir = path.dirname(this.filePath);
+    const hasLoading = fs.existsSync(path.join(dir, 'loading.tsx')) ||
+                       fs.existsSync(path.join(dir, 'loading.ts'));
+
+    console.log(`  Suspense boundaries: ${this.stats.suspenseBoundaries}`);
+    console.log(`  loading.tsx exists: ${hasLoading ? 'Yes' : 'No'}`);
+
+    if (this.stats.fetches > 0 && this.stats.suspenseBoundaries === 0 && !hasLoading) {
+      this.suggestions.push('非同期処理がありますが、Suspense境界がありません。loading.tsxまたは<Suspense>の追加を検討');
+    }
+  }
+
+  analyzeServerActions() {
+    console.log('\n🚀 Server Actions Analysis:');
+    console.log('-'.repeat(40));
+
+    // Server Actions の検出
+    const actionMatches = this.content.match(/async\s+function\s+\w+\s*\([^)]*FormData/g) || [];
+    const useServerInline = this.content.match(/'use server'\s*\n/g) || [];
+
+    this.stats.serverActions = actionMatches.length;
+
+    // revalidatePath/revalidateTag の使用
+    const hasRevalidatePath = this.content.includes('revalidatePath');
+    const hasRevalidateTag = this.content.includes('revalidateTag');
+
+    console.log(`  Server Actions: ${this.stats.serverActions}`);
+    console.log(`  revalidatePath usage: ${hasRevalidatePath ? 'Yes' : 'No'}`);
+    console.log(`  revalidateTag usage: ${hasRevalidateTag ? 'Yes' : 'No'}`);
+
+    if (this.stats.serverActions > 0 && !hasRevalidatePath && !hasRevalidateTag) {
+      this.suggestions.push('Server Actionsがありますが、再検証処理がありません。revalidatePath/revalidateTagの追加を検討');
+    }
+  }
+
+  checkPatterns() {
+    // cache関数の使用
+    const hasCacheImport = this.content.includes("from 'react'") && this.content.includes('cache');
+
+    // unstable_cacheの使用
+    const hasUnstableCache = this.content.includes('unstable_cache');
+
+    if (!hasCacheImport && !hasUnstableCache && this.stats.fetches > 1) {
+      this.suggestions.push('複数のデータ取得がある場合、Reactのcache()関数で重複排除を検討');
+    }
+  }
+
+  printStats() {
+    console.log('\n' + '='.repeat(60));
+    console.log('📈 Summary:');
+    console.log('-'.repeat(40));
+    console.log(`  Total fetches: ${this.stats.fetches}`);
+    console.log(`  Parallel patterns: ${this.stats.parallelFetches}`);
+    console.log(`  Sequential patterns: ${this.stats.sequentialFetches}`);
+    console.log(`  Suspense boundaries: ${this.stats.suspenseBoundaries}`);
+    console.log(`  Server Actions: ${this.stats.serverActions}`);
+  }
+
+  printIssues() {
+    console.log('\n⚠️  Issues:');
+    console.log('-'.repeat(40));
+
+    if (this.issues.length === 0) {
+      console.log('  ✅ No issues found');
+    } else {
+      for (const issue of this.issues) {
+        const icon = issue.type === 'error' ? '❌' : '⚠️';
+        console.log(`  ${icon} ${issue.message}`);
+      }
+    }
+  }
+
+  printSuggestions() {
+    console.log('\n💡 Suggestions:');
+    console.log('-'.repeat(40));
+
+    if (this.suggestions.length === 0) {
+      console.log('  ✅ No suggestions');
+    } else {
+      for (const suggestion of this.suggestions) {
+        console.log(`  → ${suggestion}`);
+      }
+    }
+
+    console.log('\n' + '='.repeat(60) + '\n');
+  }
+}
+
+// Main execution
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.log('Usage: node analyze-data-fetching.mjs <file.tsx>');
+  console.log('Example: node analyze-data-fetching.mjs ./src/app/page.tsx');
+  process.exit(1);
+}
+
+const analyzer = new DataFetchingAnalyzer(args[0]);
+analyzer.analyze();

--- a/.claude/skills/server-components-patterns/templates/data-fetch-template.md
+++ b/.claude/skills/server-components-patterns/templates/data-fetch-template.md
@@ -1,0 +1,186 @@
+# データフェッチテンプレート
+
+## 基本データフェッチ関数
+
+```typescript
+// lib/data/{{resource}}.ts
+import { cache } from 'react'
+import { db } from '@/lib/db'
+
+// 単一アイテム取得（重複排除付き）
+export const get{{Resource}} = cache(async (id: string) => {
+  return db.{{resource}}.findUnique({
+    where: { id },
+    include: {
+      // 必要なリレーション
+    },
+  })
+})
+
+// リスト取得
+export const get{{Resources}} = cache(async () => {
+  return db.{{resource}}.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 10,
+  })
+})
+
+// プリロード関数
+export const preload{{Resource}} = (id: string) => {
+  void get{{Resource}}(id)
+}
+```
+
+## fetch API を使用したデータ取得
+
+```typescript
+// lib/api/{{resource}}.ts
+import { cache } from 'react'
+
+const API_URL = process.env.API_URL
+
+export const get{{Resource}} = cache(async (id: string) => {
+  const res = await fetch(`${API_URL}/{{resources}}/${id}`, {
+    next: {
+      revalidate: 3600, // 1時間キャッシュ
+      tags: ['{{resources}}', `{{resource}}-${id}`],
+    },
+  })
+
+  if (!res.ok) {
+    if (res.status === 404) return null
+    throw new Error('Failed to fetch {{resource}}')
+  }
+
+  return res.json()
+})
+
+export const get{{Resources}} = cache(async () => {
+  const res = await fetch(`${API_URL}/{{resources}}`, {
+    next: {
+      revalidate: 3600,
+      tags: ['{{resources}}'],
+    },
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch {{resources}}')
+  }
+
+  return res.json()
+})
+```
+
+## 並列フェッチパターン
+
+```typescript
+// app/{{feature}}/page.tsx
+import { get{{ResourceA}}, get{{ResourceB}}, get{{ResourceC}} } from '@/lib/data'
+
+export default async function {{PageName}}Page() {
+  // 並列でデータ取得
+  const [{{resourceA}}, {{resourceB}}, {{resourceC}}] = await Promise.all([
+    get{{ResourceA}}(),
+    get{{ResourceB}}(),
+    get{{ResourceC}}(),
+  ])
+
+  return (
+    <div>
+      <{{SectionA}} data={{{resourceA}}} />
+      <{{SectionB}} data={{{resourceB}}} />
+      <{{SectionC}} data={{{resourceC}}} />
+    </div>
+  )
+}
+```
+
+## Suspense を使用した段階的レンダリング
+
+```typescript
+// app/{{feature}}/page.tsx
+import { Suspense } from 'react'
+import { {{SectionA}}, {{SectionB}} } from './components'
+import { {{SectionA}}Skeleton, {{SectionB}}Skeleton } from './skeletons'
+
+export default function {{PageName}}Page() {
+  return (
+    <div>
+      {/* 高優先度コンテンツ */}
+      <Suspense fallback={<{{SectionA}}Skeleton />}>
+        <{{SectionA}} />
+      </Suspense>
+
+      {/* 低優先度コンテンツ */}
+      <Suspense fallback={<{{SectionB}}Skeleton />}>
+        <{{SectionB}} />
+      </Suspense>
+    </div>
+  )
+}
+
+// components/{{section-a}}.tsx
+async function {{SectionA}}() {
+  const data = await get{{SectionA}}Data()
+  return <div>{/* ... */}</div>
+}
+```
+
+## 動的メタデータ付きページ
+
+```typescript
+// app/{{resource}}/[id]/page.tsx
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { get{{Resource}}, preload{{Resource}} } from '@/lib/data'
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params
+  const {{resource}} = await get{{Resource}}(id)
+
+  if (!{{resource}}) {
+    return { title: 'Not Found' }
+  }
+
+  return {
+    title: {{resource}}.title,
+    description: {{resource}}.description,
+  }
+}
+
+export default async function {{Resource}}Page({ params }: Props) {
+  const { id } = await params
+
+  // プリロード
+  preload{{Resource}}(id)
+
+  const {{resource}} = await get{{Resource}}(id)
+
+  if (!{{resource}}) {
+    notFound()
+  }
+
+  return (
+    <article>
+      <h1>{{{resource}}.title}</h1>
+      {/* ... */}
+    </article>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{resource}}` | リソース名（単数、camelCase） | `user`, `post`, `product` |
+| `{{Resource}}` | リソース名（単数、PascalCase） | `User`, `Post`, `Product` |
+| `{{resources}}` | リソース名（複数、camelCase） | `users`, `posts`, `products` |
+| `{{Resources}}` | リソース名（複数、PascalCase） | `Users`, `Posts`, `Products` |
+| `{{feature}}` | 機能名 | `dashboard`, `blog`, `shop` |
+| `{{PageName}}` | ページコンポーネント名 | `Dashboard`, `UserProfile` |
+| `{{SectionA}}` | セクションコンポーネント名 | `Stats`, `Posts`, `Activity` |

--- a/.claude/skills/server-components-patterns/templates/server-action-template.md
+++ b/.claude/skills/server-components-patterns/templates/server-action-template.md
@@ -1,0 +1,278 @@
+# Server Action テンプレート
+
+## 基本的な Server Action
+
+```typescript
+// app/actions/{{resource}}.ts
+'use server'
+
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { auth } from '@/lib/auth'
+
+// バリデーションスキーマ
+const Create{{Resource}}Schema = z.object({
+  title: z.string().min(1, 'Title is required').max(100),
+  content: z.string().min(10, 'Content must be at least 10 characters'),
+})
+
+const Update{{Resource}}Schema = Create{{Resource}}Schema.partial()
+
+// 型定義
+type ActionState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+// 作成アクション
+export async function create{{Resource}}(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 認証チェック
+  const session = await auth()
+  if (!session) {
+    return { success: false, message: 'Unauthorized' }
+  }
+
+  // バリデーション
+  const validatedFields = Create{{Resource}}Schema.safeParse({
+    title: formData.get('title'),
+    content: formData.get('content'),
+  })
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: validatedFields.error.flatten().fieldErrors,
+    }
+  }
+
+  try {
+    await db.{{resource}}.create({
+      data: {
+        ...validatedFields.data,
+        authorId: session.user.id,
+      },
+    })
+
+    revalidatePath('/{{resources}}')
+    revalidateTag('{{resources}}')
+
+    return { success: true, message: '{{Resource}} created successfully' }
+  } catch (error) {
+    console.error('Failed to create {{resource}}:', error)
+    return { success: false, message: 'Failed to create {{resource}}' }
+  }
+}
+
+// 更新アクション
+export async function update{{Resource}}(
+  id: string,
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const session = await auth()
+  if (!session) {
+    return { success: false, message: 'Unauthorized' }
+  }
+
+  // 認可チェック
+  const existing = await db.{{resource}}.findUnique({ where: { id } })
+  if (!existing || existing.authorId !== session.user.id) {
+    return { success: false, message: 'Forbidden' }
+  }
+
+  const validatedFields = Update{{Resource}}Schema.safeParse({
+    title: formData.get('title'),
+    content: formData.get('content'),
+  })
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: validatedFields.error.flatten().fieldErrors,
+    }
+  }
+
+  try {
+    await db.{{resource}}.update({
+      where: { id },
+      data: validatedFields.data,
+    })
+
+    revalidatePath('/{{resources}}')
+    revalidateTag(`{{resource}}-${id}`)
+
+    return { success: true, message: '{{Resource}} updated successfully' }
+  } catch (error) {
+    console.error('Failed to update {{resource}}:', error)
+    return { success: false, message: 'Failed to update {{resource}}' }
+  }
+}
+
+// 削除アクション
+export async function delete{{Resource}}(id: string): Promise<ActionState> {
+  const session = await auth()
+  if (!session) {
+    return { success: false, message: 'Unauthorized' }
+  }
+
+  const existing = await db.{{resource}}.findUnique({ where: { id } })
+  if (!existing || existing.authorId !== session.user.id) {
+    return { success: false, message: 'Forbidden' }
+  }
+
+  try {
+    await db.{{resource}}.delete({ where: { id } })
+
+    revalidatePath('/{{resources}}')
+    revalidateTag('{{resources}}')
+
+    return { success: true, message: '{{Resource}} deleted successfully' }
+  } catch (error) {
+    console.error('Failed to delete {{resource}}:', error)
+    return { success: false, message: 'Failed to delete {{resource}}' }
+  }
+}
+```
+
+## useFormState を使用するフォーム
+
+```typescript
+// components/{{resource}}-form.tsx
+'use client'
+
+import { useFormState, useFormStatus } from 'react-dom'
+import { create{{Resource}} } from '@/app/actions/{{resource}}'
+
+const initialState = { success: false, message: '', errors: {} }
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+    >
+      {pending ? 'Saving...' : 'Save'}
+    </button>
+  )
+}
+
+export function {{Resource}}Form() {
+  const [state, formAction] = useFormState(create{{Resource}}, initialState)
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <div>
+        <label htmlFor="title" className="block text-sm font-medium">
+          Title
+        </label>
+        <input
+          id="title"
+          name="title"
+          type="text"
+          required
+          className="mt-1 block w-full rounded-md border p-2"
+        />
+        {state.errors?.title && (
+          <p className="mt-1 text-sm text-red-600">{state.errors.title[0]}</p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="content" className="block text-sm font-medium">
+          Content
+        </label>
+        <textarea
+          id="content"
+          name="content"
+          required
+          rows={5}
+          className="mt-1 block w-full rounded-md border p-2"
+        />
+        {state.errors?.content && (
+          <p className="mt-1 text-sm text-red-600">{state.errors.content[0]}</p>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <SubmitButton />
+        {state.message && (
+          <p className={state.success ? 'text-green-600' : 'text-red-600'}>
+            {state.message}
+          </p>
+        )}
+      </div>
+    </form>
+  )
+}
+```
+
+## 楽観的更新を使用するリスト
+
+```typescript
+// components/{{resource}}-list.tsx
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+import { delete{{Resource}} } from '@/app/actions/{{resource}}'
+
+type {{Resource}} = {
+  id: string
+  title: string
+  // ...
+}
+
+export function {{Resource}}List({ items }: { items: {{Resource}}[] }) {
+  const [isPending, startTransition] = useTransition()
+
+  const [optimisticItems, removeOptimisticItem] = useOptimistic(
+    items,
+    (state, deletedId: string) => state.filter((item) => item.id !== deletedId)
+  )
+
+  async function handleDelete(id: string) {
+    startTransition(async () => {
+      removeOptimisticItem(id)
+      await delete{{Resource}}(id)
+    })
+  }
+
+  return (
+    <ul className="space-y-2">
+      {optimisticItems.map((item) => (
+        <li
+          key={item.id}
+          className="flex items-center justify-between p-4 border rounded"
+        >
+          <span>{item.title}</span>
+          <button
+            onClick={() => handleDelete(item.id)}
+            disabled={isPending}
+            className="text-red-600 hover:text-red-800 disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{resource}}` | リソース名（単数、camelCase） | `post`, `comment`, `task` |
+| `{{Resource}}` | リソース名（単数、PascalCase） | `Post`, `Comment`, `Task` |
+| `{{resources}}` | リソース名（複数、camelCase） | `posts`, `comments`, `tasks` |

--- a/.claude/skills/skill_list.md
+++ b/.claude/skills/skill_list.md
@@ -95,13 +95,13 @@
 ```markdown
 - **必要なスキル**:
 
-| スキル名                       | 概要                                              |
-| ------------------------------ | ------------------------------------------------- |
-| **nextjs-app-router**          | Server/Client Components、Dynamic Routes、Layouts |
-| **server-components-patterns** | データフェッチ最適化、Suspense 活用               |
-| **seo-optimization**           | Metadata API、動的 OGP、構造化データ              |
-| **web-performance**            | 動的インポート、画像最適化、Code Splitting        |
-| **error-handling-pages**       | error.tsx、not-found.tsx、global-error.tsx        |
+| スキル名                       | パス | 概要                                              |
+| ------------------------------ | ---- | ------------------------------------------------- |
+| **nextjs-app-router**          | `.claude/skills/nextjs-app-router/SKILL.md` | App Routerアーキテクチャ、Server/Client Components分離、Dynamic Routes |
+| **server-components-patterns** | `.claude/skills/server-components-patterns/SKILL.md` | サーバーサイドデータフェッチ、Suspense活用、キャッシュ戦略 |
+| **seo-optimization**           | `.claude/skills/seo-optimization/SKILL.md` | Metadata API、OGP/Twitter Cards、構造化データ（JSON-LD） |
+| **web-performance**            | `.claude/skills/web-performance/SKILL.md` | 動的インポート、next/image最適化、Code Splitting、Core Web Vitals |
+| **error-handling-pages**       | `.claude/skills/error-handling-pages/SKILL.md` | error.tsx、not-found.tsx、global-error.tsx、loading.tsx |
 ```
 
 ## 7. クライアント状態管理

--- a/.claude/skills/web-performance/SKILL.md
+++ b/.claude/skills/web-performance/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: web-performance
+description: |
+  Next.jsアプリケーションのパフォーマンス最適化を専門とするスキル。
+  Core Web Vitals改善、バンドルサイズ最適化、画像/フォント最適化を実現します。
+
+  専門分野:
+  - 動的インポート: React.lazy、next/dynamic による遅延読み込み
+  - 画像最適化: next/image、画像フォーマット、レスポンシブ画像
+  - フォント最適化: next/font、フォントサブセット、表示戦略
+  - Code Splitting: ルートベース、コンポーネントベース分割
+
+  使用タイミング:
+  - Core Web Vitals（LCP、FID、CLS）を改善する時
+  - バンドルサイズを削減したい時
+  - 画像やフォントの読み込みを最適化する時
+  - 初期ロード時間を短縮したい時
+
+  Use proactively when implementing performance optimizations,
+  code splitting, or image/font optimization.
+version: 1.0.0
+---
+
+# Web Performance
+
+## 概要
+
+このスキルは、Next.js App Routerにおけるパフォーマンス最適化の
+ベストプラクティスを提供します。Core Web Vitalsの改善と
+ユーザー体験の向上を実現します。
+
+**核心哲学**:
+- **Speed First**: 初期ロードの最小化とインタラクション最適化
+- **Progressive Loading**: 必要な時に必要なものだけを読み込む
+- **Measurable**: 測定可能な指標に基づく最適化
+
+**主要な価値**:
+- Core Web Vitals（LCP、FID、CLS）の改善
+- バンドルサイズの最適化
+- ユーザー体験の向上
+
+## リソース構造
+
+```
+web-performance/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── dynamic-import.md                       # 動的インポートガイド
+│   ├── image-optimization.md                   # 画像最適化ガイド
+│   ├── font-optimization.md                    # フォント最適化ガイド
+│   └── code-splitting.md                       # Code Splittingガイド
+├── scripts/
+│   └── analyze-bundle.mjs                      # バンドル分析スクリプト
+└── templates/
+    ├── dynamic-import-template.md              # 動的インポートテンプレート
+    └── image-component-template.md             # 画像コンポーネントテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# 動的インポートガイド
+cat .claude/skills/web-performance/resources/dynamic-import.md
+
+# 画像最適化ガイド
+cat .claude/skills/web-performance/resources/image-optimization.md
+
+# フォント最適化ガイド
+cat .claude/skills/web-performance/resources/font-optimization.md
+
+# Code Splittingガイド
+cat .claude/skills/web-performance/resources/code-splitting.md
+```
+
+### スクリプト実行
+
+```bash
+# バンドル分析
+node .claude/skills/web-performance/scripts/analyze-bundle.mjs <build-output-dir>
+```
+
+### テンプレート参照
+
+```bash
+# 動的インポートテンプレート
+cat .claude/skills/web-performance/templates/dynamic-import-template.md
+
+# 画像コンポーネントテンプレート
+cat .claude/skills/web-performance/templates/image-component-template.md
+```
+
+## いつ使うか
+
+### シナリオ1: 初期ロード最適化
+**状況**: ページの初期読み込みが遅い
+
+**適用条件**:
+- [ ] LCPが2.5秒を超えている
+- [ ] バンドルサイズが大きい
+- [ ] 不要なJavaScriptが初期ロードに含まれている
+
+**期待される成果**: LCPの改善、TTFBの短縮
+
+### シナリオ2: インタラクション最適化
+**状況**: ユーザー操作への応答が遅い
+
+**適用条件**:
+- [ ] FID/INPが100msを超えている
+- [ ] 重いコンポーネントがある
+- [ ] サードパーティスクリプトが多い
+
+**期待される成果**: インタラクション応答性の向上
+
+### シナリオ3: 視覚的安定性
+**状況**: ページ読み込み時にレイアウトがずれる
+
+**適用条件**:
+- [ ] CLSが0.1を超えている
+- [ ] 画像サイズが未指定
+- [ ] フォントがFOUTを引き起こしている
+
+**期待される成果**: 視覚的安定性の向上
+
+## 知識領域
+
+### 領域1: 動的インポート
+
+**next/dynamic**:
+```typescript
+import dynamic from 'next/dynamic'
+
+const HeavyComponent = dynamic(() => import('./HeavyComponent'), {
+  loading: () => <Skeleton />,
+  ssr: false, // クライアントのみ
+})
+```
+
+**React.lazy（Client Components内）**:
+```typescript
+'use client'
+import { lazy, Suspense } from 'react'
+
+const LazyComponent = lazy(() => import('./LazyComponent'))
+```
+
+**詳細は**: `resources/dynamic-import.md` を参照
+
+### 領域2: 画像最適化
+
+**next/image**:
+```typescript
+import Image from 'next/image'
+
+<Image
+  src="/image.jpg"
+  alt="説明"
+  width={800}
+  height={600}
+  priority // LCP画像の場合
+  placeholder="blur"
+/>
+```
+
+**詳細は**: `resources/image-optimization.md` を参照
+
+### 領域3: フォント最適化
+
+**next/font**:
+```typescript
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})
+```
+
+**詳細は**: `resources/font-optimization.md` を参照
+
+### 領域4: Code Splitting
+
+**ルートベース分割**（自動）:
+- App Routerは各ルートを自動的に分割
+- Layoutは共有、Pageは個別バンドル
+
+**コンポーネントベース分割**:
+- 条件付きコンポーネントをdynamic importで分割
+- モーダル、ドロワー、タブコンテンツなど
+
+**詳細は**: `resources/code-splitting.md` を参照
+
+## ワークフロー
+
+### Phase 1: 測定
+1. Lighthouseでベースラインを測定
+2. Core Web Vitalsを記録
+3. バンドルサイズを分析
+
+### Phase 2: 分析
+1. ボトルネックを特定
+2. 優先順位を決定
+3. 改善計画を策定
+
+### Phase 3: 最適化
+1. 画像/フォント最適化
+2. 動的インポート適用
+3. Code Splitting実装
+
+### Phase 4: 検証
+1. Lighthouseで再測定
+2. 改善効果を確認
+3. 回帰テスト実施
+
+### Phase 5: 監視
+1. Real User Monitoring設定
+2. パフォーマンスバジェット設定
+3. 継続的な監視
+
+## 設計原則
+
+### 遅延読み込みの原則
+Above the Fold（ファーストビュー）以外は遅延読み込みを検討する。
+
+### 優先度の原則
+LCP要素には`priority`を設定し、その他は遅延読み込みする。
+
+### 測定の原則
+最適化前後で必ず測定し、効果を検証する。
+
+### 予算の原則
+パフォーマンスバジェットを設定し、超過を監視する。
+
+## Core Web Vitals目標値
+
+| 指標 | 良好 | 改善が必要 | 不良 |
+|------|------|-----------|------|
+| LCP | ≤2.5s | ≤4.0s | >4.0s |
+| FID | ≤100ms | ≤300ms | >300ms |
+| INP | ≤200ms | ≤500ms | >500ms |
+| CLS | ≤0.1 | ≤0.25 | >0.25 |
+
+## 関連スキル
+
+- `.claude/skills/nextjs-app-router/SKILL.md` - ルーティング構造
+- `.claude/skills/server-components-patterns/SKILL.md` - データフェッチ最適化
+- `.claude/skills/seo-optimization/SKILL.md` - SEO最適化
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/web-performance/resources/code-splitting.md
+++ b/.claude/skills/web-performance/resources/code-splitting.md
@@ -1,0 +1,362 @@
+# Code Splitting
+
+## 概要
+
+Code Splittingは、JavaScriptバンドルを小さなチャンクに分割し、
+必要な時に必要なコードだけを読み込む技術です。
+Next.js App Routerは自動的にルートベースの分割を行います。
+
+## 自動Code Splitting
+
+### ルートベース分割（自動）
+
+```
+app/
+├── layout.tsx          # 共有レイアウト（全ページで共有）
+├── page.tsx            # ホーム用チャンク
+├── about/
+│   └── page.tsx        # /about用チャンク
+└── blog/
+    ├── page.tsx        # /blog用チャンク
+    └── [slug]/
+        └── page.tsx    # /blog/[slug]用チャンク
+```
+
+Next.jsは自動的に：
+- 各ページを個別のチャンクに分割
+- 共有コード（layout）を別チャンクに抽出
+- 動的ルートは個別にバンドル
+
+### 共有コードの抽出
+
+```typescript
+// app/layout.tsx - 全ページで共有
+import { Header } from '@/components/header'
+import { Footer } from '@/components/footer'
+
+// これらのコンポーネントは共有チャンクに含まれる
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <Header />
+        {children}
+        <Footer />
+      </body>
+    </html>
+  )
+}
+```
+
+## 手動Code Splitting
+
+### コンポーネントベース分割
+
+```typescript
+import dynamic from 'next/dynamic'
+
+// 条件付きで表示されるコンポーネントを分割
+const Modal = dynamic(() => import('@/components/modal'))
+const Drawer = dynamic(() => import('@/components/drawer'))
+const Chart = dynamic(() => import('@/components/chart'), { ssr: false })
+```
+
+### ライブラリ分割
+
+```typescript
+// 大きなライブラリを分割
+const DatePicker = dynamic(() =>
+  import('react-datepicker').then((mod) => mod.default)
+)
+
+const Editor = dynamic(() =>
+  import('@tiptap/react').then((mod) => mod.EditorContent)
+)
+
+const Map = dynamic(() =>
+  import('react-map-gl').then((mod) => mod.Map),
+  { ssr: false }
+)
+```
+
+### 機能ベース分割
+
+```typescript
+// features/admin/index.tsx
+export const AdminDashboard = dynamic(
+  () => import('./components/dashboard'),
+  { loading: () => <DashboardSkeleton /> }
+)
+
+export const AdminSettings = dynamic(
+  () => import('./components/settings'),
+  { loading: () => <SettingsSkeleton /> }
+)
+
+export const AdminUsers = dynamic(
+  () => import('./components/users'),
+  { loading: () => <UsersSkeleton /> }
+)
+```
+
+## バンドル分析
+
+### @next/bundle-analyzer
+
+```javascript
+// next.config.js
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+})
+
+module.exports = withBundleAnalyzer({
+  // 他の設定
+})
+```
+
+```bash
+# バンドル分析を実行
+ANALYZE=true npm run build
+```
+
+### 分析結果の読み方
+
+```
+バンドル分析で確認すべきポイント：
+1. 巨大なチャンク（>100KB）を特定
+2. 重複インポートを発見
+3. 未使用コードを特定
+4. サードパーティライブラリのサイズを確認
+```
+
+## 最適化パターン
+
+### 条件付きインポート
+
+```typescript
+// ❌ 常にインポート
+import { heavyFunction } from '@/lib/heavy'
+
+export function Component({ condition }) {
+  if (condition) {
+    return heavyFunction()
+  }
+  return null
+}
+
+// ✅ 条件付きで動的インポート
+export function Component({ condition }) {
+  const [result, setResult] = useState(null)
+
+  useEffect(() => {
+    if (condition) {
+      import('@/lib/heavy').then((mod) => {
+        setResult(mod.heavyFunction())
+      })
+    }
+  }, [condition])
+
+  return result
+}
+```
+
+### Tree Shaking対応
+
+```typescript
+// ❌ 全体インポート
+import _ from 'lodash'
+_.debounce(fn, 300)
+
+// ✅ 個別インポート（Tree Shakingが効く）
+import debounce from 'lodash/debounce'
+debounce(fn, 300)
+
+// ✅ ESM対応ライブラリを使用
+import { debounce } from 'lodash-es'
+```
+
+### Barrel Exports の注意点
+
+```typescript
+// ❌ Barrel export（Tree Shakingが効きにくい）
+// components/index.ts
+export { Button } from './button'
+export { Input } from './input'
+export { Modal } from './modal'
+// ...100個のコンポーネント
+
+// 使用側
+import { Button } from '@/components' // 全コンポーネントがバンドルされる可能性
+
+// ✅ 直接インポート
+import { Button } from '@/components/button'
+```
+
+### サードパーティライブラリの最適化
+
+```typescript
+// moment.js → date-fns（より軽量）
+import { format } from 'date-fns'
+
+// lodash → lodash-es + 個別インポート
+import debounce from 'lodash-es/debounce'
+
+// 巨大なライブラリは動的インポート
+const heavyLib = await import('heavy-library')
+```
+
+## Route Groups による分割
+
+```
+app/
+├── (marketing)/          # マーケティングページグループ
+│   ├── layout.tsx       # 軽量レイアウト
+│   ├── page.tsx
+│   └── about/
+│       └── page.tsx
+├── (app)/                # アプリケーショングループ
+│   ├── layout.tsx       # 機能豊富なレイアウト
+│   ├── dashboard/
+│   │   └── page.tsx
+│   └── settings/
+│       └── page.tsx
+└── (admin)/              # 管理者グループ
+    ├── layout.tsx       # 管理者専用レイアウト
+    └── admin/
+        └── page.tsx
+```
+
+## Parallel Routes による最適化
+
+```typescript
+// app/layout.tsx
+export default function Layout({
+  children,
+  modal,
+  sidebar,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <aside>{sidebar}</aside>
+      <main>{children}</main>
+      {modal}
+    </div>
+  )
+}
+
+// @modal/default.tsx - モーダルがない場合
+export default function Default() {
+  return null // モーダルコードは読み込まれない
+}
+
+// @modal/(..)photo/[id]/page.tsx
+// モーダルが開かれた時のみチャンクが読み込まれる
+```
+
+## パフォーマンス予算
+
+### 予算の設定
+
+```javascript
+// next.config.js
+module.exports = {
+  experimental: {
+    outputFileTracingExcludes: {
+      '*': [
+        'node_modules/@swc/core-linux-x64-gnu',
+        'node_modules/@swc/core-linux-x64-musl',
+      ],
+    },
+  },
+}
+```
+
+### 予算チェック
+
+```javascript
+// scripts/check-bundle-size.js
+const fs = require('fs')
+const path = require('path')
+
+const BUDGET = {
+  'main': 100 * 1024,      // 100KB
+  'vendor': 300 * 1024,    // 300KB
+  'page': 50 * 1024,       // 50KB per page
+}
+
+// ビルド後にチャンクサイズをチェック
+```
+
+## Server Components による最適化
+
+### クライアントバンドルの削減
+
+```typescript
+// Server Component（バンドルに含まれない）
+import { db } from '@/lib/db'
+
+export default async function ProductList() {
+  const products = await db.product.findMany() // サーバーで実行
+
+  return (
+    <ul>
+      {products.map((p) => (
+        <li key={p.id}>{p.name}</li>
+      ))}
+    </ul>
+  )
+}
+
+// Client Component（バンドルに含まれる）
+'use client'
+
+export function AddToCartButton({ productId }) {
+  // インタラクションが必要な部分のみClient Component
+  return <button>Add to Cart</button>
+}
+```
+
+### 境界の最適化
+
+```typescript
+// ❌ 大きなClient Component
+'use client'
+
+export function ProductPage({ product }) {
+  // 全てがクライアントバンドルに含まれる
+  return (
+    <div>
+      <ProductDetails product={product} />
+      <Reviews reviews={product.reviews} />
+      <AddToCartButton productId={product.id} />
+    </div>
+  )
+}
+
+// ✅ 最小限のClient Component
+// ProductDetails と Reviews は Server Component
+export default function ProductPage({ product }) {
+  return (
+    <div>
+      <ProductDetails product={product} />
+      <Reviews reviews={product.reviews} />
+      <AddToCartButton productId={product.id} /> {/* これだけClient */}
+    </div>
+  )
+}
+```
+
+## チェックリスト
+
+- [ ] @next/bundle-analyzerでバンドルを分析
+- [ ] 100KB以上のチャンクを特定・分割
+- [ ] 条件付きコンポーネントをdynamic importで分割
+- [ ] Tree Shakingが効くようにインポート
+- [ ] Barrel exportsを避ける
+- [ ] サードパーティライブラリの軽量版を使用
+- [ ] Server Componentsを活用してクライアントバンドルを削減
+- [ ] パフォーマンス予算を設定・監視

--- a/.claude/skills/web-performance/resources/dynamic-import.md
+++ b/.claude/skills/web-performance/resources/dynamic-import.md
@@ -1,0 +1,330 @@
+# 動的インポート
+
+## 概要
+
+動的インポートは、必要な時に必要なコードだけを読み込む技術です。
+初期バンドルサイズを削減し、ページの読み込み速度を向上させます。
+
+## next/dynamic
+
+### 基本的な使い方
+
+```typescript
+import dynamic from 'next/dynamic'
+
+// 基本的な動的インポート
+const DynamicComponent = dynamic(() => import('./HeavyComponent'))
+
+// ローディング状態付き
+const DynamicWithLoading = dynamic(() => import('./HeavyComponent'), {
+  loading: () => <p>Loading...</p>,
+})
+
+// SSR無効化
+const DynamicNoSSR = dynamic(() => import('./ClientOnlyComponent'), {
+  ssr: false,
+})
+```
+
+### Named Exports の動的インポート
+
+```typescript
+// Named exportをインポートする場合
+const DynamicHello = dynamic(() =>
+  import('./components').then((mod) => mod.Hello)
+)
+
+// または
+const DynamicHello = dynamic(
+  () => import('./components').then((mod) => ({ default: mod.Hello }))
+)
+```
+
+### 複雑なローディングUI
+
+```typescript
+const DynamicChart = dynamic(() => import('./Chart'), {
+  loading: () => (
+    <div className="w-full h-64 animate-pulse bg-gray-200 rounded-lg" />
+  ),
+  ssr: false,
+})
+```
+
+## React.lazy（Client Components）
+
+### 基本的な使い方
+
+```typescript
+'use client'
+
+import { lazy, Suspense } from 'react'
+
+const LazyComponent = lazy(() => import('./LazyComponent'))
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <LazyComponent />
+    </Suspense>
+  )
+}
+```
+
+### エラーバウンダリとの組み合わせ
+
+```typescript
+'use client'
+
+import { lazy, Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+
+const LazyComponent = lazy(() => import('./LazyComponent'))
+
+function ErrorFallback({ error, resetErrorBoundary }) {
+  return (
+    <div>
+      <p>エラーが発生しました: {error.message}</p>
+      <button onClick={resetErrorBoundary}>再試行</button>
+    </div>
+  )
+}
+
+export default function Page() {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <LazyComponent />
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+```
+
+## 使用パターン
+
+### モーダル/ダイアログ
+
+```typescript
+'use client'
+
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+
+const Modal = dynamic(() => import('./Modal'), {
+  loading: () => <div className="fixed inset-0 bg-black/50" />,
+})
+
+export function ModalTrigger() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>モーダルを開く</button>
+      {isOpen && <Modal onClose={() => setIsOpen(false)} />}
+    </>
+  )
+}
+```
+
+### タブコンテンツ
+
+```typescript
+'use client'
+
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+
+const TabContent = {
+  overview: dynamic(() => import('./tabs/Overview')),
+  details: dynamic(() => import('./tabs/Details')),
+  reviews: dynamic(() => import('./tabs/Reviews')),
+}
+
+export function Tabs() {
+  const [activeTab, setActiveTab] = useState<keyof typeof TabContent>('overview')
+
+  const ActiveContent = TabContent[activeTab]
+
+  return (
+    <div>
+      <div className="flex gap-4">
+        {Object.keys(TabContent).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab as keyof typeof TabContent)}
+            className={activeTab === tab ? 'font-bold' : ''}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">
+        <ActiveContent />
+      </div>
+    </div>
+  )
+}
+```
+
+### 条件付きコンポーネント
+
+```typescript
+import dynamic from 'next/dynamic'
+
+// 管理者のみに表示されるダッシュボード
+const AdminDashboard = dynamic(() => import('./AdminDashboard'), {
+  ssr: false,
+})
+
+export function Dashboard({ user }) {
+  if (!user.isAdmin) {
+    return <UserDashboard />
+  }
+
+  return <AdminDashboard />
+}
+```
+
+### 外部ライブラリ
+
+```typescript
+import dynamic from 'next/dynamic'
+
+// 重い外部ライブラリを遅延読み込み
+const Chart = dynamic(() => import('chart.js').then((mod) => {
+  // 必要なコンポーネントのみを登録
+  mod.Chart.register(
+    mod.CategoryScale,
+    mod.LinearScale,
+    mod.BarElement
+  )
+  return import('./ChartComponent')
+}), {
+  ssr: false,
+  loading: () => <div className="h-64 animate-pulse bg-gray-200" />,
+})
+
+// マップライブラリ
+const Map = dynamic(() => import('./MapComponent'), {
+  ssr: false,
+  loading: () => <div className="h-96 animate-pulse bg-gray-200" />,
+})
+
+// リッチテキストエディタ
+const Editor = dynamic(() => import('./RichTextEditor'), {
+  ssr: false,
+  loading: () => <div className="h-48 border rounded" />,
+})
+```
+
+## SSR制御
+
+### SSR無効化が必要なケース
+
+```typescript
+// window/document を使用するコンポーネント
+const ClientComponent = dynamic(() => import('./ClientComponent'), {
+  ssr: false,
+})
+
+// ブラウザ固有のAPI
+const MapComponent = dynamic(() => import('./MapComponent'), {
+  ssr: false, // Geolocation API使用
+})
+
+// Web Storage
+const StorageComponent = dynamic(() => import('./StorageComponent'), {
+  ssr: false, // localStorage/sessionStorage使用
+})
+
+// Canvas/WebGL
+const CanvasComponent = dynamic(() => import('./CanvasComponent'), {
+  ssr: false,
+})
+```
+
+### useEffect の代替としての ssr: false
+
+```typescript
+// ❌ useEffectで囲む必要がある
+function Component() {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) return null
+
+  return <ClientOnlyContent />
+}
+
+// ✅ dynamic import の方がクリーン
+const ClientOnlyContent = dynamic(() => import('./ClientOnlyContent'), {
+  ssr: false,
+})
+```
+
+## パフォーマンス考慮事項
+
+### プリロード
+
+```typescript
+import dynamic from 'next/dynamic'
+
+const HeavyComponent = dynamic(() => import('./HeavyComponent'))
+
+// マウスオーバー時にプリロード
+function Button() {
+  const preload = () => {
+    import('./HeavyComponent')
+  }
+
+  return (
+    <button onMouseEnter={preload}>
+      Open Heavy Component
+    </button>
+  )
+}
+```
+
+### バンドル分析との組み合わせ
+
+```bash
+# バンドルサイズの分析
+npx @next/bundle-analyzer
+```
+
+## アンチパターン
+
+### 過度な分割
+
+```typescript
+// ❌ 小さなコンポーネントを分割しても効果薄
+const Button = dynamic(() => import('./Button'))
+const Icon = dynamic(() => import('./Icon'))
+
+// ✅ 大きなコンポーネントのみ分割
+const Dashboard = dynamic(() => import('./Dashboard'))
+const DataTable = dynamic(() => import('./DataTable'))
+```
+
+### ファーストビューでの動的インポート
+
+```typescript
+// ❌ LCPに影響するコンポーネントを遅延読み込み
+const Hero = dynamic(() => import('./Hero'))
+
+// ✅ ファーストビューは通常のインポート
+import Hero from './Hero'
+```
+
+## チェックリスト
+
+- [ ] モーダル、ドロワーなどの条件付きUIは動的インポートを使用
+- [ ] 重い外部ライブラリは動的インポートで分割
+- [ ] ブラウザ固有のAPIを使用するコンポーネントはssr: falseを設定
+- [ ] ファーストビューのコンポーネントは通常のインポートを使用
+- [ ] 適切なローディングUIを提供
+- [ ] プリロードが有効な場合は実装

--- a/.claude/skills/web-performance/resources/font-optimization.md
+++ b/.claude/skills/web-performance/resources/font-optimization.md
@@ -1,0 +1,382 @@
+# フォント最適化
+
+## 概要
+
+next/fontは自動的なフォント最適化を提供します。
+セルフホスティング、サブセット化、プリロードを自動化し、
+CLSを防止してパフォーマンスを向上させます。
+
+## Google Fonts
+
+### 基本的な使い方
+
+```typescript
+// app/layout.tsx
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="ja" className={inter.className}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+### 日本語フォント
+
+```typescript
+import { Noto_Sans_JP } from 'next/font/google'
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  display: 'swap',
+  preload: false, // 大きなフォントはpreloadを無効化
+})
+```
+
+### 複数フォントの使用
+
+```typescript
+import { Inter, Roboto_Mono } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+})
+
+const robotoMono = Roboto_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-roboto-mono',
+})
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en" className={`${inter.variable} ${robotoMono.variable}`}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+### Tailwind CSSとの統合
+
+```typescript
+// app/layout.tsx
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+})
+
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', 'sans-serif'],
+      },
+    },
+  },
+}
+```
+
+## ローカルフォント
+
+### 基本的な使い方
+
+```typescript
+import localFont from 'next/font/local'
+
+const myFont = localFont({
+  src: './fonts/MyFont.woff2',
+  display: 'swap',
+})
+
+// または複数のウェイト
+const myFont = localFont({
+  src: [
+    {
+      path: './fonts/MyFont-Regular.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: './fonts/MyFont-Bold.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+    {
+      path: './fonts/MyFont-Italic.woff2',
+      weight: '400',
+      style: 'italic',
+    },
+  ],
+  display: 'swap',
+})
+```
+
+### Variable Font
+
+```typescript
+import localFont from 'next/font/local'
+
+const inter = localFont({
+  src: './fonts/Inter-Variable.woff2',
+  display: 'swap',
+  variable: '--font-inter',
+})
+```
+
+## display オプション
+
+### swap（推奨）
+
+```typescript
+const font = Font({
+  subsets: ['latin'],
+  display: 'swap', // フォールバックフォントを即座に表示、読み込み後スワップ
+})
+```
+
+### optional
+
+```typescript
+const font = Font({
+  subsets: ['latin'],
+  display: 'optional', // フォントがすぐに利用可能な場合のみ使用
+})
+```
+
+### 各オプションの比較
+
+| display | FOUT | FOIT | LCP影響 | 推奨用途 |
+|---------|------|------|--------|---------|
+| swap | あり | なし | 低 | 本文テキスト |
+| optional | なし | なし | 最低 | アイコンフォント |
+| block | なし | あり | 高 | 非推奨 |
+| fallback | 短 | 短 | 中 | バランス重視 |
+
+## サブセット
+
+### 言語別サブセット
+
+```typescript
+// 英語サイト
+const inter = Inter({
+  subsets: ['latin'],
+})
+
+// 日本語サイト
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'], // 日本語は自動的に含まれる
+})
+
+// 多言語サイト
+const notoSans = Noto_Sans({
+  subsets: ['latin', 'latin-ext', 'cyrillic'],
+})
+```
+
+### カスタム文字セット
+
+```typescript
+const font = localFont({
+  src: './fonts/CustomFont.woff2',
+  // 特定の文字のみを含める
+  unicodeRange: 'U+0000-00FF, U+0131, U+0152-0153',
+})
+```
+
+## 高度な設定
+
+### adjustFontFallback
+
+```typescript
+const inter = Inter({
+  subsets: ['latin'],
+  adjustFontFallback: true, // フォールバックフォントのサイズを自動調整
+})
+```
+
+### preload制御
+
+```typescript
+// 大きなフォントはpreloadを無効化してLCPを改善
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  preload: false, // 遅延読み込み
+})
+```
+
+### weight と style
+
+```typescript
+// 特定のウェイトのみ
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'], // 必要なウェイトのみ
+})
+
+// Variable font（推奨）
+const inter = Inter({
+  subsets: ['latin'],
+  // weightを指定しない = variable fontとして全ウェイト利用可能
+})
+```
+
+## パターン
+
+### ヘッディング用フォント
+
+```typescript
+// components/heading.tsx
+import { Playfair_Display } from 'next/font/google'
+
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  weight: ['700'],
+  display: 'swap',
+})
+
+export function Heading({ children }) {
+  return <h1 className={playfair.className}>{children}</h1>
+}
+```
+
+### コード用フォント
+
+```typescript
+// components/code-block.tsx
+import { Fira_Code } from 'next/font/google'
+
+const firaCode = Fira_Code({
+  subsets: ['latin'],
+  display: 'swap',
+})
+
+export function CodeBlock({ children }) {
+  return <pre className={firaCode.className}>{children}</pre>
+}
+```
+
+### アイコンフォント（非推奨）
+
+```typescript
+// ⚠️ アイコンフォントよりSVGアイコンを推奨
+
+// もし使用する場合
+import localFont from 'next/font/local'
+
+const iconFont = localFont({
+  src: './fonts/icons.woff2',
+  display: 'optional', // アイコンは遅延しても問題ない
+})
+```
+
+## パフォーマンス考慮事項
+
+### フォントファイルサイズ
+
+```typescript
+// ❌ 全ウェイトを読み込む
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+})
+
+// ✅ 必要なウェイトのみ
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '600'], // 実際に使用するウェイトのみ
+})
+```
+
+### 日本語フォントの最適化
+
+```typescript
+// 日本語フォントは大きいため特別な配慮が必要
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  weight: ['400', '700'], // 最小限のウェイト
+  display: 'swap',
+  preload: false, // プリロードを無効化
+})
+```
+
+### システムフォントスタックとの併用
+
+```typescript
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      fontFamily: {
+        // Variable fontをシステムフォントと組み合わせ
+        sans: [
+          'var(--font-inter)',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'sans-serif',
+        ],
+      },
+    },
+  },
+}
+```
+
+## CLS防止
+
+### サイズ調整
+
+```css
+/* フォールバックフォントのサイズを調整 */
+@font-face {
+  font-family: 'Adjusted Arial';
+  src: local('Arial');
+  size-adjust: 100.06%;
+  ascent-override: 95%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+```
+
+### next/fontの自動調整
+
+```typescript
+// adjustFontFallbackがデフォルトで有効
+const inter = Inter({
+  subsets: ['latin'],
+  adjustFontFallback: true, // CLSを最小化
+})
+```
+
+## チェックリスト
+
+- [ ] 必要なウェイトのみを読み込んでいる
+- [ ] display: 'swap'を設定している
+- [ ] 日本語フォントはpreload: falseを検討
+- [ ] variable fontを可能な限り使用
+- [ ] Tailwind CSSとの統合が正しい
+- [ ] adjustFontFallbackが有効
+- [ ] システムフォントをフォールバックに含めている

--- a/.claude/skills/web-performance/resources/image-optimization.md
+++ b/.claude/skills/web-performance/resources/image-optimization.md
@@ -1,0 +1,418 @@
+# 画像最適化
+
+## 概要
+
+next/imageは自動的な画像最適化を提供します。
+適切なサイズ、フォーマット、遅延読み込みでLCPとCLSを改善します。
+
+## 基本的な使い方
+
+### ローカル画像
+
+```typescript
+import Image from 'next/image'
+import heroImage from '@/public/hero.jpg'
+
+export function Hero() {
+  return (
+    <Image
+      src={heroImage}
+      alt="ヒーロー画像"
+      placeholder="blur" // 自動的にblurDataURLが生成
+      priority // LCP画像の場合
+    />
+  )
+}
+```
+
+### リモート画像
+
+```typescript
+import Image from 'next/image'
+
+export function RemoteImage() {
+  return (
+    <Image
+      src="https://example.com/image.jpg"
+      alt="リモート画像"
+      width={800}
+      height={600}
+    />
+  )
+}
+```
+
+### next.config.jsの設定
+
+```javascript
+// next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'example.com',
+        port: '',
+        pathname: '/images/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.cloudinary.com',
+      },
+    ],
+    // 画像フォーマット
+    formats: ['image/avif', 'image/webp'],
+    // デバイスサイズ
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    // 画像サイズ
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+  },
+}
+```
+
+## レイアウトパターン
+
+### fill（親要素にフィット）
+
+```typescript
+<div className="relative w-full h-64">
+  <Image
+    src="/image.jpg"
+    alt="説明"
+    fill
+    className="object-cover"
+  />
+</div>
+```
+
+### 固定サイズ
+
+```typescript
+<Image
+  src="/avatar.jpg"
+  alt="アバター"
+  width={48}
+  height={48}
+  className="rounded-full"
+/>
+```
+
+### レスポンシブ
+
+```typescript
+<Image
+  src="/hero.jpg"
+  alt="ヒーロー"
+  width={1200}
+  height={600}
+  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+  className="w-full h-auto"
+/>
+```
+
+## sizes属性の最適化
+
+### 基本的なサイズ指定
+
+```typescript
+// フルワイドス画像
+<Image
+  src="/hero.jpg"
+  alt="ヒーロー"
+  width={1920}
+  height={1080}
+  sizes="100vw"
+/>
+
+// 2カラムレイアウト
+<Image
+  src="/product.jpg"
+  alt="商品"
+  width={600}
+  height={400}
+  sizes="(max-width: 768px) 100vw, 50vw"
+/>
+
+// 3カラムグリッド
+<Image
+  src="/card.jpg"
+  alt="カード"
+  width={400}
+  height={300}
+  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+/>
+```
+
+### コンテナベースのサイズ
+
+```typescript
+// サイドバーがある場合
+<Image
+  src="/content.jpg"
+  alt="コンテンツ"
+  width={800}
+  height={600}
+  sizes="(max-width: 768px) 100vw, calc(100vw - 300px)"
+/>
+```
+
+## 優先度とプリロード
+
+### priority属性
+
+```typescript
+// LCP（Largest Contentful Paint）に影響する画像
+<Image
+  src="/hero.jpg"
+  alt="ヒーロー"
+  width={1200}
+  height={600}
+  priority // <link rel="preload"> が追加される
+/>
+```
+
+### priority を使うべきケース
+
+1. Above the Fold（ファーストビュー）の画像
+2. LCPの候補となる画像
+3. スライダーの最初の画像
+
+```typescript
+// スライダーの例
+{slides.map((slide, index) => (
+  <Image
+    key={slide.id}
+    src={slide.image}
+    alt={slide.alt}
+    width={1200}
+    height={600}
+    priority={index === 0} // 最初の画像のみ priority
+  />
+))}
+```
+
+## Placeholder
+
+### blur（ローカル画像）
+
+```typescript
+import heroImage from '@/public/hero.jpg'
+
+<Image
+  src={heroImage}
+  alt="ヒーロー"
+  placeholder="blur" // 自動生成
+/>
+```
+
+### blurDataURL（リモート画像）
+
+```typescript
+// 小さなBase64画像をプレースホルダーとして使用
+<Image
+  src="https://example.com/image.jpg"
+  alt="画像"
+  width={800}
+  height={600}
+  placeholder="blur"
+  blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD..."
+/>
+```
+
+### プレースホルダー生成ユーティリティ
+
+```typescript
+// lib/placeholder.ts
+import { getPlaiceholder } from 'plaiceholder'
+
+export async function getBlurDataURL(src: string) {
+  const { base64 } = await getPlaiceholder(src)
+  return base64
+}
+
+// 使用例
+const blurDataURL = await getBlurDataURL('/path/to/image.jpg')
+```
+
+### カスタムプレースホルダー
+
+```typescript
+// グラデーションプレースホルダー
+const shimmer = (w: number, h: number) => `
+<svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g">
+      <stop stop-color="#f6f7f8" offset="0%" />
+      <stop stop-color="#edeef1" offset="20%" />
+      <stop stop-color="#f6f7f8" offset="40%" />
+      <stop stop-color="#f6f7f8" offset="100%" />
+    </linearGradient>
+  </defs>
+  <rect fill="url(#g)" width="${w}" height="${h}" />
+</svg>`
+
+const toBase64 = (str: string) =>
+  typeof window === 'undefined'
+    ? Buffer.from(str).toString('base64')
+    : window.btoa(str)
+
+<Image
+  src="/image.jpg"
+  alt="画像"
+  width={800}
+  height={600}
+  placeholder="blur"
+  blurDataURL={`data:image/svg+xml;base64,${toBase64(shimmer(800, 600))}`}
+/>
+```
+
+## 遅延読み込み
+
+### デフォルトの動作
+
+```typescript
+// loading="lazy" がデフォルト
+<Image src="/image.jpg" alt="画像" width={800} height={600} />
+```
+
+### Eager loading
+
+```typescript
+// ファーストビューの画像
+<Image
+  src="/hero.jpg"
+  alt="ヒーロー"
+  width={1200}
+  height={600}
+  loading="eager"
+  priority
+/>
+```
+
+## 画像コンポーネントパターン
+
+### レスポンシブ画像コンポーネント
+
+```typescript
+// components/responsive-image.tsx
+import Image from 'next/image'
+
+type ResponsiveImageProps = {
+  src: string
+  alt: string
+  aspectRatio?: '16/9' | '4/3' | '1/1'
+  priority?: boolean
+}
+
+export function ResponsiveImage({
+  src,
+  alt,
+  aspectRatio = '16/9',
+  priority = false,
+}: ResponsiveImageProps) {
+  const aspectRatioClasses = {
+    '16/9': 'aspect-video',
+    '4/3': 'aspect-[4/3]',
+    '1/1': 'aspect-square',
+  }
+
+  return (
+    <div className={`relative ${aspectRatioClasses[aspectRatio]}`}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        className="object-cover"
+        priority={priority}
+      />
+    </div>
+  )
+}
+```
+
+### アバターコンポーネント
+
+```typescript
+// components/avatar.tsx
+import Image from 'next/image'
+
+type AvatarProps = {
+  src?: string
+  name: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const sizes = {
+  sm: 32,
+  md: 48,
+  lg: 64,
+}
+
+export function Avatar({ src, name, size = 'md' }: AvatarProps) {
+  const dimension = sizes[size]
+
+  if (!src) {
+    return (
+      <div
+        className="rounded-full bg-gray-200 flex items-center justify-center"
+        style={{ width: dimension, height: dimension }}
+      >
+        {name[0].toUpperCase()}
+      </div>
+    )
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={name}
+      width={dimension}
+      height={dimension}
+      className="rounded-full"
+    />
+  )
+}
+```
+
+## 外部画像サービス
+
+### Cloudinary
+
+```javascript
+// next.config.js
+module.exports = {
+  images: {
+    loader: 'cloudinary',
+    path: 'https://res.cloudinary.com/your-cloud-name/image/upload/',
+  },
+}
+```
+
+### カスタムローダー
+
+```typescript
+// lib/image-loader.ts
+const imageLoader = ({ src, width, quality }) => {
+  return `https://example.com/image?url=${src}&w=${width}&q=${quality || 75}`
+}
+
+// 使用
+<Image
+  loader={imageLoader}
+  src="/path/to/image.jpg"
+  alt="画像"
+  width={800}
+  height={600}
+/>
+```
+
+## チェックリスト
+
+- [ ] LCP画像にはpriorityを設定
+- [ ] sizes属性を適切に設定
+- [ ] リモート画像のドメインをremotePatternsに追加
+- [ ] プレースホルダーを設定してCLSを防止
+- [ ] 適切なアスペクト比を維持
+- [ ] alt属性を適切に設定
+- [ ] 不要に大きな画像を使用していない

--- a/.claude/skills/web-performance/scripts/analyze-bundle.mjs
+++ b/.claude/skills/web-performance/scripts/analyze-bundle.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+/**
+ * バンドル分析スクリプト
+ *
+ * 使用方法:
+ *   node analyze-bundle.mjs <build-output-dir>
+ *
+ * 例:
+ *   node analyze-bundle.mjs .next
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+class BundleAnalyzer {
+  constructor(buildDir) {
+    this.buildDir = path.resolve(buildDir);
+    this.chunks = [];
+    this.totalSize = 0;
+    this.issues = [];
+    this.suggestions = [];
+  }
+
+  analyze() {
+    if (!fs.existsSync(this.buildDir)) {
+      console.error(`Error: Build directory not found: ${this.buildDir}`);
+      console.log('Run `npm run build` first to generate the build output.');
+      process.exit(1);
+    }
+
+    console.log(`\n📦 Bundle Analysis: ${this.buildDir}\n`);
+    console.log('='.repeat(60));
+
+    this.analyzeServerChunks();
+    this.analyzeStaticChunks();
+    this.analyzePages();
+    this.printSummary();
+    this.printIssues();
+    this.printSuggestions();
+  }
+
+  analyzeServerChunks() {
+    const serverDir = path.join(this.buildDir, 'server');
+    if (!fs.existsSync(serverDir)) return;
+
+    console.log('\n📁 Server Chunks:');
+    console.log('-'.repeat(40));
+
+    const chunks = this.getJSFiles(serverDir);
+    let serverTotal = 0;
+
+    const sortedChunks = chunks
+      .map((file) => ({
+        name: path.relative(serverDir, file),
+        size: fs.statSync(file).size,
+      }))
+      .sort((a, b) => b.size - a.size)
+      .slice(0, 10);
+
+    for (const chunk of sortedChunks) {
+      serverTotal += chunk.size;
+      console.log(`  ${this.formatSize(chunk.size).padStart(10)} ${chunk.name}`);
+    }
+
+    console.log(`  ${'─'.repeat(38)}`);
+    console.log(`  ${this.formatSize(serverTotal).padStart(10)} Total (top 10)`);
+  }
+
+  analyzeStaticChunks() {
+    const staticDir = path.join(this.buildDir, 'static', 'chunks');
+    if (!fs.existsSync(staticDir)) return;
+
+    console.log('\n📁 Static Chunks (Client):');
+    console.log('-'.repeat(40));
+
+    const chunks = this.getJSFiles(staticDir);
+    let clientTotal = 0;
+
+    const sortedChunks = chunks
+      .map((file) => ({
+        name: path.relative(staticDir, file),
+        size: fs.statSync(file).size,
+      }))
+      .sort((a, b) => b.size - a.size);
+
+    // 大きなチャンクを警告
+    for (const chunk of sortedChunks) {
+      clientTotal += chunk.size;
+      this.totalSize += chunk.size;
+
+      const sizeStr = this.formatSize(chunk.size).padStart(10);
+      let indicator = '';
+
+      if (chunk.size > 500 * 1024) {
+        indicator = ' ❌ Very Large';
+        this.issues.push({
+          type: 'error',
+          message: `${chunk.name} (${this.formatSize(chunk.size)}) が非常に大きい`,
+        });
+      } else if (chunk.size > 200 * 1024) {
+        indicator = ' ⚠️  Large';
+        this.issues.push({
+          type: 'warning',
+          message: `${chunk.name} (${this.formatSize(chunk.size)}) が大きい`,
+        });
+      } else if (chunk.size > 100 * 1024) {
+        indicator = ' 📊';
+      }
+
+      console.log(`  ${sizeStr} ${chunk.name}${indicator}`);
+      this.chunks.push(chunk);
+    }
+
+    console.log(`  ${'─'.repeat(38)}`);
+    console.log(`  ${this.formatSize(clientTotal).padStart(10)} Total Client JS`);
+  }
+
+  analyzePages() {
+    const pagesManifest = path.join(this.buildDir, 'server', 'pages-manifest.json');
+    const appPathsManifest = path.join(this.buildDir, 'server', 'app-paths-manifest.json');
+
+    let pageCount = 0;
+
+    if (fs.existsSync(pagesManifest)) {
+      const manifest = JSON.parse(fs.readFileSync(pagesManifest, 'utf-8'));
+      pageCount += Object.keys(manifest).length;
+    }
+
+    if (fs.existsSync(appPathsManifest)) {
+      const manifest = JSON.parse(fs.readFileSync(appPathsManifest, 'utf-8'));
+      pageCount += Object.keys(manifest).length;
+    }
+
+    console.log(`\n📄 Pages: ${pageCount}`);
+  }
+
+  getJSFiles(dir) {
+    const files = [];
+
+    const walk = (currentDir) => {
+      const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = path.join(currentDir, entry.name);
+
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.js')) {
+          files.push(fullPath);
+        }
+      }
+    };
+
+    walk(dir);
+    return files;
+  }
+
+  formatSize(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  }
+
+  printSummary() {
+    console.log('\n' + '='.repeat(60));
+    console.log('📊 Summary:');
+    console.log('-'.repeat(40));
+    console.log(`  Total Client JS: ${this.formatSize(this.totalSize)}`);
+    console.log(`  Chunks: ${this.chunks.length}`);
+
+    // サイズ分布
+    const large = this.chunks.filter((c) => c.size > 200 * 1024).length;
+    const medium = this.chunks.filter((c) => c.size > 100 * 1024 && c.size <= 200 * 1024).length;
+    const small = this.chunks.filter((c) => c.size <= 100 * 1024).length;
+
+    console.log(`\n  Size Distribution:`);
+    console.log(`    >200KB: ${large} chunks`);
+    console.log(`    100-200KB: ${medium} chunks`);
+    console.log(`    <100KB: ${small} chunks`);
+
+    // スコア計算
+    const score = this.calculateScore();
+    console.log(`\n  📈 Bundle Score: ${score}/100`);
+  }
+
+  calculateScore() {
+    let score = 100;
+
+    // 大きなチャンクのペナルティ
+    for (const chunk of this.chunks) {
+      if (chunk.size > 500 * 1024) score -= 20;
+      else if (chunk.size > 200 * 1024) score -= 10;
+      else if (chunk.size > 100 * 1024) score -= 5;
+    }
+
+    // 合計サイズのペナルティ
+    if (this.totalSize > 1024 * 1024) score -= 20;
+    else if (this.totalSize > 500 * 1024) score -= 10;
+
+    return Math.max(0, score);
+  }
+
+  printIssues() {
+    console.log('\n⚠️  Issues:');
+    console.log('-'.repeat(40));
+
+    if (this.issues.length === 0) {
+      console.log('  ✅ No issues found');
+    } else {
+      const errors = this.issues.filter((i) => i.type === 'error');
+      const warnings = this.issues.filter((i) => i.type === 'warning');
+
+      for (const error of errors) {
+        console.log(`  ❌ ${error.message}`);
+      }
+      for (const warning of warnings) {
+        console.log(`  ⚠️  ${warning.message}`);
+      }
+    }
+  }
+
+  printSuggestions() {
+    console.log('\n💡 Suggestions:');
+    console.log('-'.repeat(40));
+
+    // チャンクサイズに基づく提案
+    const largeChunks = this.chunks.filter((c) => c.size > 200 * 1024);
+    if (largeChunks.length > 0) {
+      this.suggestions.push('大きなチャンクをdynamic importで分割することを検討');
+    }
+
+    // 合計サイズに基づく提案
+    if (this.totalSize > 500 * 1024) {
+      this.suggestions.push('Tree Shakingが効いているか確認（lodash-es、date-fns等を使用）');
+      this.suggestions.push('不要なサードパーティライブラリを削除');
+    }
+
+    // node_modulesチャンクの提案
+    const vendorChunks = this.chunks.filter((c) => c.name.includes('node_modules'));
+    if (vendorChunks.some((c) => c.size > 200 * 1024)) {
+      this.suggestions.push('大きなnode_modulesライブラリを動的インポートに変更');
+    }
+
+    // 一般的な提案
+    this.suggestions.push('@next/bundle-analyzerで詳細分析を実行');
+    this.suggestions.push('Server Componentsを活用してクライアントバンドルを削減');
+
+    for (const suggestion of this.suggestions) {
+      console.log(`  → ${suggestion}`);
+    }
+
+    console.log('\n' + '='.repeat(60) + '\n');
+  }
+}
+
+// Main execution
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.log('Usage: node analyze-bundle.mjs <build-output-dir>');
+  console.log('Example: node analyze-bundle.mjs .next');
+  process.exit(1);
+}
+
+const analyzer = new BundleAnalyzer(args[0]);
+analyzer.analyze();

--- a/.claude/skills/web-performance/templates/dynamic-import-template.md
+++ b/.claude/skills/web-performance/templates/dynamic-import-template.md
@@ -1,0 +1,375 @@
+# 動的インポートテンプレート
+
+## 基本テンプレート
+
+```typescript
+// components/lazy-{{component}}.tsx
+import dynamic from 'next/dynamic'
+
+export const {{Component}} = dynamic(
+  () => import('./{{component}}'),
+  {
+    loading: () => <{{Component}}Skeleton />,
+    ssr: {{ssr}}, // true | false
+  }
+)
+```
+
+## モーダルコンポーネント
+
+```typescript
+// components/modal/lazy-modal.tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+const Modal = dynamic(() => import('./modal'), {
+  loading: () => (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+      <div className="bg-white rounded-lg p-8 animate-pulse">
+        <div className="h-4 w-48 bg-gray-200 rounded" />
+      </div>
+    </div>
+  ),
+})
+
+type LazyModalProps = {
+  trigger: React.ReactNode
+  title: string
+  children: React.ReactNode
+}
+
+export function LazyModal({ trigger, title, children }: LazyModalProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <div onClick={() => setIsOpen(true)}>{trigger}</div>
+      {isOpen && (
+        <Modal
+          title={title}
+          onClose={() => setIsOpen(false)}
+        >
+          {children}
+        </Modal>
+      )}
+    </>
+  )
+}
+```
+
+## ドロワーコンポーネント
+
+```typescript
+// components/drawer/lazy-drawer.tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+const Drawer = dynamic(() => import('./drawer'), {
+  loading: () => (
+    <div className="fixed inset-y-0 right-0 z-50 w-80 bg-white shadow-lg animate-pulse">
+      <div className="p-4">
+        <div className="h-6 w-32 bg-gray-200 rounded" />
+      </div>
+    </div>
+  ),
+})
+
+type LazyDrawerProps = {
+  trigger: React.ReactNode
+  title: string
+  children: React.ReactNode
+}
+
+export function LazyDrawer({ trigger, title, children }: LazyDrawerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>{trigger}</button>
+      {isOpen && (
+        <Drawer
+          title={title}
+          onClose={() => setIsOpen(false)}
+        >
+          {children}
+        </Drawer>
+      )}
+    </>
+  )
+}
+```
+
+## タブコンテンツ
+
+```typescript
+// components/tabs/lazy-tabs.tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState, type ComponentType } from 'react'
+
+type TabConfig<T extends string> = {
+  [K in T]: {
+    label: string
+    component: ComponentType<any>
+  }
+}
+
+// タブコンテンツを動的インポート
+const tabContents = {
+  overview: {
+    label: 'Overview',
+    component: dynamic(() => import('./tabs/overview'), {
+      loading: () => <TabSkeleton />,
+    }),
+  },
+  details: {
+    label: 'Details',
+    component: dynamic(() => import('./tabs/details'), {
+      loading: () => <TabSkeleton />,
+    }),
+  },
+  reviews: {
+    label: 'Reviews',
+    component: dynamic(() => import('./tabs/reviews'), {
+      loading: () => <TabSkeleton />,
+    }),
+  },
+} satisfies TabConfig<'overview' | 'details' | 'reviews'>
+
+function TabSkeleton() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-4 bg-gray-200 rounded w-3/4" />
+      <div className="h-4 bg-gray-200 rounded w-1/2" />
+      <div className="h-4 bg-gray-200 rounded w-2/3" />
+    </div>
+  )
+}
+
+export function LazyTabs() {
+  const [activeTab, setActiveTab] = useState<keyof typeof tabContents>('overview')
+
+  const ActiveContent = tabContents[activeTab].component
+
+  return (
+    <div>
+      <div className="flex border-b">
+        {Object.entries(tabContents).map(([key, { label }]) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key as keyof typeof tabContents)}
+            className={`px-4 py-2 ${
+              activeTab === key
+                ? 'border-b-2 border-blue-500 font-medium'
+                : 'text-gray-500'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="p-4">
+        <ActiveContent />
+      </div>
+    </div>
+  )
+}
+```
+
+## 外部ライブラリ
+
+```typescript
+// components/chart/lazy-chart.tsx
+import dynamic from 'next/dynamic'
+
+export const LazyChart = dynamic(
+  () => import('./chart-component'),
+  {
+    ssr: false, // チャートライブラリはSSRで問題が発生することが多い
+    loading: () => (
+      <div className="h-64 w-full animate-pulse bg-gray-200 rounded-lg" />
+    ),
+  }
+)
+
+// components/chart/chart-component.tsx
+'use client'
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+import { Bar } from 'react-chartjs-2'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+)
+
+type ChartProps = {
+  data: {
+    labels: string[]
+    datasets: {
+      label: string
+      data: number[]
+      backgroundColor: string
+    }[]
+  }
+}
+
+export default function ChartComponent({ data }: ChartProps) {
+  return <Bar data={data} options={{ responsive: true }} />
+}
+```
+
+## リッチテキストエディタ
+
+```typescript
+// components/editor/lazy-editor.tsx
+import dynamic from 'next/dynamic'
+
+export const LazyEditor = dynamic(
+  () => import('./rich-text-editor'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-48 w-full border rounded-lg animate-pulse bg-gray-100" />
+    ),
+  }
+)
+
+// components/editor/rich-text-editor.tsx
+'use client'
+
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+
+type EditorProps = {
+  content: string
+  onChange: (content: string) => void
+}
+
+export default function RichTextEditor({ content, onChange }: EditorProps) {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content,
+    onUpdate: ({ editor }) => {
+      onChange(editor.getHTML())
+    },
+  })
+
+  return (
+    <div className="border rounded-lg">
+      <EditorContent editor={editor} />
+    </div>
+  )
+}
+```
+
+## マップコンポーネント
+
+```typescript
+// components/map/lazy-map.tsx
+import dynamic from 'next/dynamic'
+
+export const LazyMap = dynamic(
+  () => import('./map-component'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-96 w-full animate-pulse bg-gray-200 rounded-lg flex items-center justify-center">
+        <span className="text-gray-500">Loading map...</span>
+      </div>
+    ),
+  }
+)
+
+// components/map/map-component.tsx
+'use client'
+
+import Map, { Marker } from 'react-map-gl'
+import 'mapbox-gl/dist/mapbox-gl.css'
+
+type MapProps = {
+  latitude: number
+  longitude: number
+  zoom?: number
+}
+
+export default function MapComponent({
+  latitude,
+  longitude,
+  zoom = 14,
+}: MapProps) {
+  return (
+    <Map
+      mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+      initialViewState={{
+        latitude,
+        longitude,
+        zoom,
+      }}
+      style={{ width: '100%', height: '100%' }}
+      mapStyle="mapbox://styles/mapbox/streets-v12"
+    >
+      <Marker latitude={latitude} longitude={longitude} />
+    </Map>
+  )
+}
+```
+
+## プリロード付きコンポーネント
+
+```typescript
+// components/preloadable/lazy-preloadable.tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useCallback } from 'react'
+
+const HeavyComponent = dynamic(() => import('./heavy-component'))
+
+// プリロード関数をエクスポート
+export const preloadHeavyComponent = () => {
+  void import('./heavy-component')
+}
+
+type LazyPreloadableProps = {
+  children: React.ReactNode
+  onActivate: () => void
+}
+
+export function LazyPreloadable({ children, onActivate }: LazyPreloadableProps) {
+  const handleMouseEnter = useCallback(() => {
+    preloadHeavyComponent()
+  }, [])
+
+  return (
+    <div onMouseEnter={handleMouseEnter}>
+      <button onClick={onActivate}>{children}</button>
+    </div>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `{{component}}` | コンポーネントファイル名 | `modal`, `drawer`, `chart` |
+| `{{Component}}` | コンポーネント名（PascalCase） | `Modal`, `Drawer`, `Chart` |
+| `{{ssr}}` | SSR設定 | `true`, `false` |

--- a/.claude/skills/web-performance/templates/image-component-template.md
+++ b/.claude/skills/web-performance/templates/image-component-template.md
@@ -1,0 +1,441 @@
+# 画像コンポーネントテンプレート
+
+## レスポンシブ画像コンポーネント
+
+```typescript
+// components/responsive-image.tsx
+import Image from 'next/image'
+
+type AspectRatio = '16/9' | '4/3' | '1/1' | '3/4' | '9/16'
+
+type ResponsiveImageProps = {
+  src: string
+  alt: string
+  aspectRatio?: AspectRatio
+  priority?: boolean
+  className?: string
+  sizes?: string
+  fill?: boolean
+  width?: number
+  height?: number
+}
+
+const aspectRatioClasses: Record<AspectRatio, string> = {
+  '16/9': 'aspect-video',
+  '4/3': 'aspect-[4/3]',
+  '1/1': 'aspect-square',
+  '3/4': 'aspect-[3/4]',
+  '9/16': 'aspect-[9/16]',
+}
+
+export function ResponsiveImage({
+  src,
+  alt,
+  aspectRatio = '16/9',
+  priority = false,
+  className = '',
+  sizes = '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+  fill = true,
+  width,
+  height,
+}: ResponsiveImageProps) {
+  if (fill) {
+    return (
+      <div className={`relative ${aspectRatioClasses[aspectRatio]} ${className}`}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          sizes={sizes}
+          className="object-cover"
+          priority={priority}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      sizes={sizes}
+      className={`w-full h-auto ${className}`}
+      priority={priority}
+    />
+  )
+}
+```
+
+## アバターコンポーネント
+
+```typescript
+// components/avatar.tsx
+import Image from 'next/image'
+
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+type AvatarProps = {
+  src?: string | null
+  name: string
+  size?: AvatarSize
+  className?: string
+}
+
+const sizeMap: Record<AvatarSize, { dimension: number; fontSize: string }> = {
+  xs: { dimension: 24, fontSize: 'text-xs' },
+  sm: { dimension: 32, fontSize: 'text-sm' },
+  md: { dimension: 40, fontSize: 'text-base' },
+  lg: { dimension: 56, fontSize: 'text-lg' },
+  xl: { dimension: 80, fontSize: 'text-2xl' },
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+function getColorFromName(name: string): string {
+  const colors = [
+    'bg-red-500',
+    'bg-orange-500',
+    'bg-amber-500',
+    'bg-yellow-500',
+    'bg-lime-500',
+    'bg-green-500',
+    'bg-emerald-500',
+    'bg-teal-500',
+    'bg-cyan-500',
+    'bg-sky-500',
+    'bg-blue-500',
+    'bg-indigo-500',
+    'bg-violet-500',
+    'bg-purple-500',
+    'bg-fuchsia-500',
+    'bg-pink-500',
+  ]
+  const index = name.charCodeAt(0) % colors.length
+  return colors[index]
+}
+
+export function Avatar({ src, name, size = 'md', className = '' }: AvatarProps) {
+  const { dimension, fontSize } = sizeMap[size]
+
+  if (!src) {
+    const bgColor = getColorFromName(name)
+    return (
+      <div
+        className={`rounded-full flex items-center justify-center text-white font-medium ${bgColor} ${fontSize} ${className}`}
+        style={{ width: dimension, height: dimension }}
+      >
+        {getInitials(name)}
+      </div>
+    )
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={name}
+      width={dimension}
+      height={dimension}
+      className={`rounded-full object-cover ${className}`}
+    />
+  )
+}
+```
+
+## ヒーロー画像コンポーネント
+
+```typescript
+// components/hero-image.tsx
+import Image from 'next/image'
+
+type HeroImageProps = {
+  src: string
+  alt: string
+  title?: string
+  subtitle?: string
+  overlay?: boolean
+  overlayOpacity?: number
+}
+
+export function HeroImage({
+  src,
+  alt,
+  title,
+  subtitle,
+  overlay = true,
+  overlayOpacity = 0.4,
+}: HeroImageProps) {
+  return (
+    <div className="relative h-[60vh] min-h-[400px] w-full">
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        priority // ヒーロー画像は常にpriority
+        sizes="100vw"
+        className="object-cover"
+      />
+
+      {overlay && (
+        <div
+          className="absolute inset-0 bg-black"
+          style={{ opacity: overlayOpacity }}
+        />
+      )}
+
+      {(title || subtitle) && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-white z-10">
+          {title && (
+            <h1 className="text-4xl md:text-6xl font-bold text-center px-4">
+              {title}
+            </h1>
+          )}
+          {subtitle && (
+            <p className="mt-4 text-xl md:text-2xl text-center px-4 max-w-2xl">
+              {subtitle}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+## カードサムネイルコンポーネント
+
+```typescript
+// components/card-thumbnail.tsx
+import Image from 'next/image'
+import Link from 'next/link'
+
+type CardThumbnailProps = {
+  href: string
+  src: string
+  alt: string
+  title: string
+  description?: string
+  badge?: string
+}
+
+export function CardThumbnail({
+  href,
+  src,
+  alt,
+  title,
+  description,
+  badge,
+}: CardThumbnailProps) {
+  return (
+    <Link href={href} className="group block">
+      <article className="overflow-hidden rounded-lg border bg-white shadow-sm transition-shadow hover:shadow-md">
+        <div className="relative aspect-video">
+          <Image
+            src={src}
+            alt={alt}
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            className="object-cover transition-transform group-hover:scale-105"
+          />
+          {badge && (
+            <span className="absolute top-2 left-2 bg-blue-600 text-white text-xs px-2 py-1 rounded">
+              {badge}
+            </span>
+          )}
+        </div>
+        <div className="p-4">
+          <h3 className="font-semibold text-lg line-clamp-2 group-hover:text-blue-600">
+            {title}
+          </h3>
+          {description && (
+            <p className="mt-2 text-gray-600 text-sm line-clamp-2">
+              {description}
+            </p>
+          )}
+        </div>
+      </article>
+    </Link>
+  )
+}
+```
+
+## 画像ギャラリーコンポーネント
+
+```typescript
+// components/image-gallery.tsx
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+
+type GalleryImage = {
+  src: string
+  alt: string
+}
+
+type ImageGalleryProps = {
+  images: GalleryImage[]
+}
+
+export function ImageGallery({ images }: ImageGalleryProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  if (images.length === 0) return null
+
+  return (
+    <div className="space-y-4">
+      {/* メイン画像 */}
+      <div className="relative aspect-video rounded-lg overflow-hidden">
+        <Image
+          src={images[selectedIndex].src}
+          alt={images[selectedIndex].alt}
+          fill
+          sizes="(max-width: 768px) 100vw, 60vw"
+          className="object-contain bg-gray-100"
+          priority={selectedIndex === 0}
+        />
+      </div>
+
+      {/* サムネイル */}
+      {images.length > 1 && (
+        <div className="flex gap-2 overflow-x-auto pb-2">
+          {images.map((image, index) => (
+            <button
+              key={index}
+              onClick={() => setSelectedIndex(index)}
+              className={`relative flex-shrink-0 w-20 h-20 rounded-md overflow-hidden border-2 transition ${
+                selectedIndex === index
+                  ? 'border-blue-500'
+                  : 'border-transparent'
+              }`}
+            >
+              <Image
+                src={image.src}
+                alt={image.alt}
+                fill
+                sizes="80px"
+                className="object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+## 遅延画像（Intersection Observer）
+
+```typescript
+// components/lazy-image.tsx
+'use client'
+
+import Image from 'next/image'
+import { useRef, useState, useEffect } from 'react'
+
+type LazyImageProps = {
+  src: string
+  alt: string
+  width: number
+  height: number
+  className?: string
+}
+
+export function LazyImage({
+  src,
+  alt,
+  width,
+  height,
+  className = '',
+}: LazyImageProps) {
+  const [isVisible, setIsVisible] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '200px' } // 200px手前で読み込み開始
+    )
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      className={`bg-gray-200 ${className}`}
+      style={{ width, height }}
+    >
+      {isVisible && (
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className={className}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+## OGP画像コンポーネント
+
+```typescript
+// components/og-image.tsx
+import Image from 'next/image'
+
+type OgImageProps = {
+  src: string
+  alt: string
+  title?: string
+}
+
+export function OgImage({ src, alt, title }: OgImageProps) {
+  return (
+    <div className="relative w-full" style={{ aspectRatio: '1200/630' }}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        sizes="(max-width: 768px) 100vw, 1200px"
+        className="object-cover rounded-lg"
+      />
+      {title && (
+        <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/70 to-transparent">
+          <p className="text-white font-medium text-lg">{title}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+## 変数説明
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `src` | 画像ソースURL | `/images/hero.jpg` |
+| `alt` | 代替テキスト | `商品のサムネイル` |
+| `aspectRatio` | アスペクト比 | `16/9`, `4/3`, `1/1` |
+| `sizes` | レスポンシブサイズ | `(max-width: 768px) 100vw, 50vw` |
+| `priority` | プリロード設定 | `true`, `false` |


### PR DESCRIPTION
## 概要
`@router-dev` エージェントを5つの専門スキルに分離し、Progressive Disclosure原則を適用して軽量化しました。

## 変更内容

### 新規作成されたスキル（5つ）

1. **nextjs-app-router** (`.claude/skills/nextjs-app-router/`)
   - App Routerアーキテクチャとルーティングパターン
   - Server/Client Components分離の判断基準
   - Dynamic Routes、Route Groups、Parallel Routes

2. **server-components-patterns** (`.claude/skills/server-components-patterns/`)
   - サーバーサイドデータフェッチ最適化
   - Suspenseとストリーミングレンダリング
   - キャッシュ戦略とServer Actions

3. **seo-optimization** (`.claude/skills/seo-optimization/`)
   - Metadata API実装パターン
   - OGP/Twitter Cards設定
   - 構造化データ（JSON-LD）とsitemap/robots

4. **web-performance** (`.claude/skills/web-performance/`)
   - 動的インポートとCode Splitting
   - next/imageとnext/font最適化
   - Core Web Vitals改善テクニック

5. **error-handling-pages** (`.claude/skills/error-handling-pages/`)
   - error.tsx、not-found.tsx、global-error.tsx
   - loading.tsxとSuspense統合
   - エラーリカバリーパターン

### 各スキルの構造
```
.claude/skills/{skill-name}/
├── SKILL.md           # コア概要（Progressive Disclosure）
├── resources/         # 4つの詳細リソース
├── scripts/           # 分析スクリプト（.mjs）
└── templates/         # 2つの実装テンプレート
```

### エージェント更新
- **router-dev.md**: 1046行 → 400行（61.7%削減）
- バージョン更新: v2.0.0 → v3.0.0
- スキル参照による知識分離を実現

### リスト更新
- `agent_list.md`: router-devエントリにスキルパス追加
- `skill_list.md`: 同様にスキルパス追加

## テスト
- [x] 全5スキルの構造検証（SKILL.md、resources/、scripts/、templates/）
- [x] router-dev.mdのスキル参照整合性確認
- [x] agent_list.mdとskill_list.mdの整合性確認
- [x] Markdownファイルの構文確認

## 軽量化効果
```
元のrouter-dev.md:      1,046行（すべて1ファイル）
新しいrouter-dev.md:      400行（コア定義のみ）
5つのスキル合計:      12,736行（詳細知識）
削減率:              61.7%
```

## デザインパターン
- ✅ Progressive Disclosure原則の完全実装
- ✅ @meta-agent-designerパターンに準拠
- ✅ @skill-librarianパターンに準拠
- ✅ Guillermo Rauch（Vercel CEO）の思想を反映

## 破壊的変更
なし（既存のrouter-devエージェントは互換性を保ちつつ軽量化）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)