### PR TITLE
docs(prompt): Add command creation prompt template

### DIFF
--- a/.claude/prompt/agents_skills_command_作成/プロンプト_commands_作成.md
+++ b/.claude/prompt/agents_skills_command_作成/プロンプト_commands_作成.md
@@ -1,0 +1,99 @@
+次のリスト・エージェントから、Claude Code で使用するcommandを作成して。
+commandは次の階層化に作成して。
+"""
+- .claude/commands/ai
+"""
+
+関係するエージェント・スキルを参照して、commandに記述して
+コマンド作成エージェント: @.claude/agents/command-arch.md
+コマンドリスト: @.claude/commands/ai/command_list.md
+エージェントリスト(エージェントが使うスキルも記述): @.claude/agents/agent_list.md
+参考情報:
+- @.claude/prompt/agents_skills_command_作成/プロンプト_Claude_Code_agents_skills_command_ジェネレータ.md
+- @.claude/prompt/agents_skills_command_作成/ナレッジ_Claude_Code_command_ガイド.md
+
+作って欲しいのは、次のcommandです。
+ただし次の内容はあくまでも叩き台で作成しているものなので最適ではないです。この部分を最適化して/commandとcommand-listを改善修正作成してください。
+下記のたたき台を元に作成して。
+"""
+@.claude/commands/ai/create-command.md
+### `/ai:create-command`
+- **目的**: 新しいスラッシュコマンド（.claude/commands/*.md）の作成
+- **引数**: `[command-name]` - コマンド名（オプション、未指定時はインタラクティブ）
+- **使用エージェント**: @command-arch
+- **スキル活用**:
+  - command-structure-fundamentals: YAML Frontmatter設計
+  - command-arguments-system: 引数システム設計
+  - command-security-design: セキュリティレビュー
+  - command-basic-patterns: 実装パターン選択
+  - command-advanced-patterns: 高度なパターン（必要時）
+  - command-agent-skill-integration: エージェント・スキル統合
+  - command-activation-mechanisms: 自動起動設計
+  - command-error-handling: エラーハンドリング設計
+  - command-naming-conventions: 命名決定
+  - command-documentation-patterns: ドキュメンテーション作成
+  - command-placement-priority: ファイル配置決定
+  - command-best-practices: 設計原則確認
+  - command-performance-optimization: 最適化
+- **フロー**:
+  1. @command-arch: Phase 1 - 要件収集と初期分析
+  2. @command-arch: Phase 2 - コマンド設計（命名、Frontmatter、パターン選択、引数設計）
+  3. @command-arch: Phase 3 - エラーハンドリングとセキュリティレビュー
+  4. @command-arch: Phase 4 - ドキュメンテーションと例の作成
+  5. @command-arch: Phase 5 - ベストプラクティス確認と最適化
+- **成果物**:
+  - .claude/commands/*.md（完全なYAML Frontmatter + Markdown本文）
+  - 充実したドキュメンテーション
+  - 使用例とトラブルシューティングガイド
+- **設定**:
+  - `model: sonnet`
+  - `allowed-tools: [Read, Write(.claude/commands/**)]`
+  - **品質基準**: 単一責任原則、組み合わせ可能性、冪等性、セキュリティベストプラクティス
+"""
+
+メタ情報のdescription には、参照するエージェントとスキルを記述すること
+例:
+"""
+---
+description: |
+  新しいスラッシュコマンド（.claude/commands/*.md）を作成する専門コマンド。
+
+  YAML Frontmatter + Markdown 本文の構造を持つハブ特化型コマンドファイルを生成します。
+
+  🤖 起動エージェント:
+  - `.claude/agents/command-arch.md`: スラッシュコマンド作成専門エージェント（Phase 2で起動）
+
+  📚 利用可能スキル（タスクに応じてcommand-archエージェントが必要時に参照）:
+  **Phase 1（要件収集時）:** command-naming-conventions, command-placement-priority
+  **Phase 2（設計時）:** command-structure-fundamentals, command-arguments-system, command-basic-patterns
+  **Phase 3（セキュリティ時）:** command-security-design, command-error-handling（必要時）
+  **Phase 4（品質時）:** command-best-practices, command-documentation-patterns（必要時）
+  **Phase 5（最適化時）:** command-performance-optimization（必要時）, command-agent-skill-integration（必要時）
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: オプション引数1つ（未指定時はインタラクティブ）
+  - allowed-tools: エージェント起動と最小限の確認用
+    • Task: command-archエージェント起動用
+    • Read: 既存コマンド・スキル参照確認用
+    • Write(.claude/commands/**): コマンドファイル生成用（パス制限）
+    • Grep, Glob: 既存パターン検索・重複チェック用
+  - model: sonnet（標準的なコマンド作成タスク）
+
+  トリガーキーワード: command, slash-command, コマンド作成, workflow, 自動化
+argument-hint: "[command-name]"
+allowed-tools: [Task, Read, Write(.claude/commands/**), Grep, Glob]
+model: sonnet
+---
+"""
+
+commandが作成できたら、次のリストも修正しておくこと。
+@.claude/commands/ai/command_list.md
+
+
+下記のエージェントによって
+ステップバイステップで一つ一つ確実に実行してスキルとエージェントを作成してください。各エージェントやスキルに記述されている内容をステップバイステップで確実に実行してください。フォーマットや各ディレクトリの作成、ファイルの作成、一切漏れなく作成してください。 特にエージェントのが、コマンドでスキルを呼び出しているのか、相対パスで記述しているのかを確認しておくこと。　
+エージェント名やスキル名を記述するのではなく、相対パスを記述するようにしてください。相対パスとは次のような内容で記述してください。`.claude/skills/agent-lifecycle-management/SKILL.md`
+エージェント:
+@.claude/agents/command-arch.md
+
+あくまでも/commandはエージェントスキルを実行する上でのコマンドにすぎないです。ロジックに関してはエージェントやスキルの方に任せるように責務を分けて作成するようにしてください。


### PR DESCRIPTION
## 概要

コマンド作成用の包括的なプロンプトテンプレートを追加します。

## 変更内容

**追加ファイル:**
- `.claude/prompt/agents_skills_command_作成/プロンプト_commands_作成.md`

**内容:**
- `/ai:create-command` スタイルのコマンド作成テンプレート
- command-arch エージェントと関連スキルへの参照
- 責務分離の強調（コマンドはハブ、ロジックはエージェント・スキル）
- 最適な description 構造の例（エージェント・スキルを含む）

## 用途

このプロンプトは以下の場合に使用:
- 新しい `/ai:*` コマンドを作成する際の参照テンプレート
- command-arch エージェントへの指示の標準化
- ハブ特化型設計原則の理解

## 関連

- 関連PR: #50 (command-arch v4.0.0 ハブ特化型最適化)
- 参照エージェント: `.claude/agents/command-arch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)