### PR TITLE
feat(commands): Add /ai:gather-requirements command with project-specific requirements

### DIFF
--- a/.claude/commands/ai/command_list.md
+++ b/.claude/commands/ai/command_list.md
@@ -70,14 +70,31 @@
 ## 2. 要件定義・仕様策定
 
 ### `/ai:gather-requirements`
-- **目的**: ステークホルダーへのヒアリングと要件整理
-- **引数**: `[stakeholder-name]` - ステークホルダー名(オプション)
-- **使用エージェント**: @req-analyst
-- **スキル活用**: requirements-engineering, interview-techniques
-- **成果物**: docs/00-requirements/requirements.md
+- **目的**: ステークホルダーへのヒアリングと要件整理（**Specification-Driven Development**の起点）
+- **引数**: `[stakeholder-name]` - ステークホルダー名(オプション、未指定時は汎用質問)
+- **使用エージェント**: `.claude/agents/req-analyst.md`
+- **スキル活用**（フェーズ別）:
+  - **Phase 1**: `.claude/skills/interview-techniques/SKILL.md`, `.claude/skills/requirements-engineering/SKILL.md`
+  - **Phase 2-5**: エージェント内で8つの依存スキルを自動参照（requirements-triage, ambiguity-elimination等）
+- **フロー**:
+  1. Phase 1: エージェント起動と準備（**master_system_design.md**の参照必須）
+  2. Phase 2: プロジェクト固有制約の確認（TDD、Clean Architecture、ハイブリッド構造）
+  3. Phase 3: 要件収集実行（ソクラテス式質問、5W1H分析）
+  4. Phase 4: 成果物生成（**プロジェクト用語・制約を含む**構造化要件書）
+  5. Phase 5: TDDフロー準備（テストファイルパス、詳細仕様への連携）
+- **成果物**:
+  - `docs/00-requirements/requirements.md`（要件ドキュメント、曖昧性0・完全性>95%）
+  - **プロジェクト制約セクション**（TDD必須、ハイブリッド構造、技術スタック）
+  - **用語集**（workflows, executor, registry, shared/, features/）
+  - **次フェーズ連携情報**（詳細仕様、テスト作成、Executor実装への引き継ぎ）
 - **設定**:
-  - `model: opus` (複雑なヒアリング分析)
-  - `allowed-tools: Read, Write(docs/**)`
+  - `model: opus` (複雑なヒアリング分析と曖昧性除去の判断が必要)
+  - `allowed-tools: Read(docs/**), Write(docs/00-requirements/**)`（ドキュメント作成に必要な最小権限）
+- **プロジェクト固有の考慮**:
+  - [ ] TDD準拠（仕様 → テスト → 実装の順序を要件に明記）
+  - [ ] ハイブリッド構造（shared/ と features/ の責務を要件に反映）
+  - [ ] 用語集（workflows, executor, registry等を必ず定義）
+- **トリガーキーワード**: requirements, stakeholder, ヒアリング, 要件整理, インタビュー, 仕様駆動
 
 ### `/ai:create-user-stories`
 - **目的**: ユーザーストーリーとアクセプタンスクライテリアの作成

--- a/.claude/commands/ai/gather-requirements.md
+++ b/.claude/commands/ai/gather-requirements.md
@@ -1,0 +1,161 @@
+---
+description: |
+  ステークホルダーへのヒアリングを実施し、曖昧な要望を検証可能な要件に変換します。
+
+  🤖 起動エージェント:
+  - `.claude/agents/req-analyst.md`: 要件定義スペシャリスト（カール・ウィーガーズの要求工学に基づく曖昧性除去と要件構造化）
+
+  📚 利用可能スキル（フェーズごとに必要時のみ参照）:
+  **Phase 1（要望収集・初期分析）:**
+  - `.claude/skills/interview-techniques/SKILL.md`: 5W1H質問法、Why分析による要求抽出
+  - `.claude/skills/requirements-engineering/SKILL.md`: MoSCoW分類による優先順位付け
+
+  **Phase 2-5（明確化・構造化・文書化・検証・レビュー）:**
+  - エージェント内の8つの依存スキル（requirements-triage, ambiguity-elimination等）を自動参照
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: "[stakeholder-name]（オプション: ヒアリング対象者、省略時は汎用質問セット）"
+  - allowed-tools: Read(docs/**), Write(docs/00-requirements/**)
+  - model: opus（複雑なヒアリング分析と曖昧性除去の判断が必要）
+
+  トリガーキーワード: 要件定義、ヒアリング、要求分析、requirements gathering
+---
+
+# /ai:gather-requirements
+
+## Phase 1: エージェント起動と準備
+
+### 1.1 Requirements Analystの起動
+```bash
+# @req-analyst エージェントのロード
+cat .claude/agents/req-analyst.md
+```
+
+**起動確認**:
+- [ ] エージェントの役割定義が確認できたか
+- [ ] 5つのフェーズワークフローが理解できたか
+- [ ] ツール使用方針が明確か
+
+### 1.2 プロジェクトコンテキストの把握
+```bash
+# システム設計仕様書の確認（必須）
+cat docs/00-requirements/master_system_design.md
+```
+
+**プロジェクト固有の制約確認**:
+- [ ] **Specification-Driven Development**: 仕様書を正本とし、実装はその変換結果とする原則
+- [ ] **TDD必須**: すべての機能追加はテスト記述から着手（仕様書 → テスト → 実装）
+- [ ] **Clean Architecture**: 依存関係は外→内（Infrastructure → Application → Domain）
+- [ ] **ハイブリッド構造**: 共通インフラ（shared/）と機能プラグイン（features/）の分離
+- [ ] **技術スタック**: Next.js 15.x, Railway, Neon (PostgreSQL + pgvector), Drizzle ORM
+- [ ] **プロジェクト用語**: workflows (実行単位), executor (実行クラス), registry (機能レジストリ)
+- [ ] **出力構造**: `docs/00-requirements/` (要件), `docs/20-specifications/features/` (詳細仕様)
+
+---
+
+## Phase 2: 要件収集の実行
+
+### 2.1 ステークホルダーヒアリング
+**実行**: `@req-analyst` が以下を実施
+1. interview-techniquesスキルに基づくヒアリング実施
+2. 5W1H質問法による網羅的要求収集
+3. Why分析（5回のWhy繰り返し）による根本ニーズ発見
+
+**引数処理**:
+- 引数あり: 指定されたステークホルダー向けにカスタマイズした質問セット生成
+- 引数なし: 汎用的な要件収集質問セットを使用
+
+**成果物**: 初期要求リスト（MoSCoW分類付き）
+
+### 2.2 要件の明確化と構造化
+**実行**: `@req-analyst` が以下を実施（Phase 2-4）
+1. 曖昧性検出と除去（「速い」→「応答時間<200ms」）
+2. 機能要件（FR）と非機能要件（NFR）への分離
+3. ユースケースと受け入れ基準の定義
+4. 要件品質検証（一貫性・完全性・検証可能性）
+
+**品質基準**:
+- [ ] 曖昧性スコア: 0（曖昧な表現なし）
+- [ ] 完全性スコア: >95%
+- [ ] 検証可能性スコア: 100%
+
+---
+
+## Phase 3: 成果物生成
+
+### 3.1 要件定義書の作成
+**出力先**: `docs/00-requirements/requirements.md`
+
+**必須セクション**:
+- プロジェクト概要（目的、スコープ、ステークホルダー）
+- 機能要件（FR-XXX 形式、優先順位付き）
+- 非機能要件（NFR-XXX 形式、測定可能な基準）
+- ユースケース（基本フロー、代替フロー、例外フロー）
+- 受け入れ基準（Given-When-Then形式、**TDD対応: テスト可能であること**）
+- 用語集（プロジェクト固有の用語定義: workflows, executor, registry等）
+- **アーキテクチャ制約**（master_system_design.mdからの転記）:
+  - Clean Architecture原則（依存方向: 外→内）
+  - ハイブリッド構造（shared/ と features/ の責務分離）
+  - TDD必須（仕様書 → テスト → 実装の順序）
+
+**品質検証**: requirements-verificationスキルによる自動検証
+
+**次フェーズ連携**:
+- **詳細仕様**: `docs/20-specifications/features/[機能名].md` への詳細化を想定
+- **TDDフロー**: テストファイル作成（`features/[機能名]/__tests__/`）への引き継ぎ準備
+- **実装ガイド**: Executor実装時の制約を明記（共通インフラはshared/から、機能間依存禁止）
+
+---
+
+## 完了確認
+
+### 最終チェックリスト
+- [ ] すべての要望がMoSCoW分類されている
+- [ ] 曖昧な表現が90%以上除去されている（「速い」→「応答時間<200ms」等）
+- [ ] すべての要件に受け入れ基準がある（Given-When-Then形式、テスト可能）
+- [ ] 要件間の矛盾がない
+- [ ] 要件定義書が `docs/00-requirements/requirements.md` に生成されている
+- [ ] 品質スコアが基準値（明確性90%、完全性85%、一貫性100%）を満たしている
+- [ ] **プロジェクト固有制約**が明記されている:
+  - [ ] TDD必須（仕様 → テスト → 実装）の順序が説明されているか
+  - [ ] ハイブリッド構造（shared/ と features/）の責務が説明されているか
+  - [ ] 用語集にworkflows, executor, registryが定義されているか
+  - [ ] 技術スタック制約（Railway, Neon, Drizzle ORM）が記載されているか
+
+### ハンドオフ準備
+次フェーズへの引き継ぎ:
+- **設計フェーズ**: `/ai:design-system` または `@spec-writer` へハンドオフ
+- **ドメインモデリング**: `@domain-modeler` との並行作業検討
+- **テスト戦略**: `@test-strategist` へ要件の引き継ぎ
+
+---
+
+## 使用例
+
+### 例1: 新規プロジェクトの要件定義
+```bash
+/ai:gather-requirements "Product Owner"
+```
+**結果**: Product Owner向けにカスタマイズされた質問セットでヒアリング、要件定義書を生成
+
+### 例2: 機能追加の要件定義
+```bash
+/ai:gather-requirements
+```
+**結果**: 汎用質問セットで要望を収集、既存要件との整合性を確認しながら要件を追加
+
+### 例3: 要件見直し
+既存の `docs/00-requirements/requirements.md` を読み込み、品質評価と改善提案を実施
+
+---
+
+## トラブルシューティング
+
+### 曖昧な回答が多い場合
+→ interview-techniquesスキルの「明確化質問パターン」を活用
+
+### 優先順位が決められない場合
+→ requirements-engineeringスキルの「トリアージフレームワーク」でリスク評価
+
+### 要件間の矛盾を発見した場合
+→ requirements-verificationスキルの検証チェックリストで体系的に解消


### PR DESCRIPTION
## 概要
`/ai:gather-requirements`コマンドを新規作成し、`master_system_design.md`のプロジェクト固有要件を完全に反映しました。要件定義フェーズがSpecification-Driven DevelopmentとTDD原則に準拠するよう設計されています。

## 変更内容

### 1. 新規コマンド作成
- **ファイル**: `.claude/commands/ai/gather-requirements.md`
- **機能**: req-analystエージェントと8つのスキルを統合した要件収集コマンド
- **特徴**:
  - フェーズ別スキル参照（Phase 1: interview-techniques + requirements-engineering）
  - プロジェクト固有制約の確認チェックリスト（7項目）
  - TDD連携準備（テストファイルパス、詳細仕様への引き継ぎ）
  - 品質基準（曖昧性0、完全性>95%）

### 2. コマンドリスト更新
- **ファイル**: `.claude/commands/ai/command_list.md`
- **変更点**:
  - `/ai:gather-requirements`の記述を5フェーズに詳細化
  - プロジェクト固有の考慮セクション追加（TDD、ハイブリッド構造、用語集）
  - 成果物を4項目に拡張（制約セクション、用語集、次フェーズ連携）
  - トリガーキーワードに「仕様駆動」追加

### 3. 要件テンプレート強化
- **ファイル**: `.claude/skills/requirements-documentation/templates/requirements-document-template.md`
- **追加内容**:
  - **技術スタック制約**（8項目: Next.js, Railway, Neon, Drizzle等）
  - **アーキテクチャ制約**（Clean Architecture原則、ハイブリッド構造の詳細、依存関係ルール）
  - **開発プロセス制約**（Specification-Driven、TDD 7ステップフロー、テストピラミッド）
  - **プロジェクト固有用語**（11用語: Workflow, Executor, Registry等）
  - **技術用語**（7用語: Neon, Railway, Nixpacks等）

## master_system_design.md との整合性

| 要件 | 参照箇所 | 反映状況 |
|------|---------|---------|
| Specification-Driven (§1.2) | コマンドPhase 1.2, テンプレート§3.3 | ✅ 完全反映 |
| TDD必須 (§2.4, §11.1) | コマンドPhase 1.2/3.1, テンプレート§3.3（7ステップ詳細化） | ✅ 完全反映 |
| Clean Architecture (§1.5, §5.1) | コマンドPhase 1.2, テンプレート§3.3 | ✅ 完全反映 |
| ハイブリッド構造 (§4.1, §5.1) | コマンドPhase 1.2/3.1, テンプレート§3.3（4層詳細化） | ✅ 完全反映 |
| プロジェクト用語 (§14) | コマンドPhase 1.2, テンプレート§8.1（11用語） | ✅ 完全反映 |
| 技術スタック (§3) | コマンドPhase 1.2, テンプレート§3.3（8項目） | ✅ 完全反映 |
| ディレクトリ構造 (§4.2-4.3) | コマンドPhase 3.1, テンプレート§3.3（TDDフロー） | ✅ 完全反映 |

## テスト
- [x] YAML構文検証 - コマンドFrontmatter正常
- [x] 相対パス確認 - すべてのスキル参照が`.claude/skills/*/SKILL.md`形式
- [x] command-arch v4.0.0原則準拠 - ハブ特化型設計、フェーズ別スキル参照
- [x] 整合性検証 - master_system_design.md要件10項目すべて反映

## 影響範囲
- **新規追加**: 1ファイル（gather-requirements.md）
- **更新**: 2ファイル（command_list.md, requirements-document-template.md）
- **破壊的変更**: なし
- **他のコマンドへの影響**: なし（独立したコマンド追加）

## 次のステップ
このテンプレートパターンを他のコマンド（`/ai:create-user-stories`, `/ai:define-use-cases`等）にも適用することで、プロジェクト全体の整合性を向上できます。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)