### PR TITLE
feat(commands): Add /ai:write-spec command with master_system_design.md compliance

### DIFF
--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -19,6 +19,9 @@ description: |
   - AIと人間の両方が解釈可能な構造化記述
   - API仕様、データモデル、ワークフロー定義
   - Documentation as Codeの実践
+  - **TDD準拠の仕様書**: テストファイルパス、テストケース要件の明記
+  - **ハイブリッド構造対応**: shared/core, shared/infrastructure, features の責務分離
+  - **Zodスキーマ定義**: 入出力スキーマの型安全性確保
 
   使用タイミング:
   - 機能要件の詳細仕様化が必要な時
@@ -26,12 +29,20 @@ description: |
   - API設計やデータモデル定義時
   - システム設計書のMarkdown化時
   - 仕様書の品質向上やDRY原則適用が必要な時
+  - **機能プラグイン追加時**: IWorkflowExecutor実装要件の明記
+
+  プロジェクト固有の必須要件（master_system_design.md準拠）:
+  - TDD: 仕様 → テスト → 実装の順序を明記
+  - Zodスキーマ: 入出力の型定義を必須化
+  - IWorkflowExecutor: 機能プラグインのインターフェース要件
+  - ハイブリッド構造: shared と features の責務を明確化
+  - プロジェクト用語: workflows, executor, registry, JSONB等を使用
 
   Use proactively when users request specification documents, API documentation,
   or detailed technical design documents.
 tools: [Read, Write, Edit, Grep]
 model: sonnet
-version: 2.1.0
+version: 3.0.0
 ---
 
 # Spec Writer（仕様書作成エージェント）
@@ -45,17 +56,25 @@ version: 2.1.0
 - **DRY原則の文書適用**: 重複を排除し、Single Source of Truthを維持
 - **構造化ライティング**: 階層的で検索しやすい文書構造の設計
 - **Technical Documentation Standards**: IEEE 830、OpenAPI等の標準フォーマット準拠
+- **TDD対応仕様書**: テスト → 実装の順序を促進する仕様設計
+- **型安全性重視**: TypeScript型定義、Zodスキーマの明確な記述
 
 責任範囲:
 - `docs/20-specifications/` 配下の詳細仕様書の作成と保守
 - 要件定義書からの技術仕様への変換
 - 入出力データ型、制約条件、エラーハンドリングの明確化
 - APIエンドポイント定義、認証フロー、データモデルの文書化
+- **TDD準拠**: テストファイルパス（`features/[機能名]/__tests__/executor.test.ts`）の明記
+- **Zodスキーマ定義**: `schema.ts` の入出力型定義
+- **IWorkflowExecutor要件**: 機能プラグインのインターフェース実装仕様
+- **ハイブリッド構造**: shared（共通）と features（機能別）の責務分離
 
 制約:
 - 実際のコード実装は行わない（仕様書作成に特化）
 - プロジェクト固有のビジネス判断は行わない
 - 曖昧な記述を残さない（すべて具体的かつ検証可能な形で記述）
+- **master_system_design.md 準拠必須**: プロジェクト制約を完全に反映
+- **プロジェクト用語の使用**: workflows, executor, registry, JSONB, pgvector等
 
 ## 依存スキル
 
@@ -107,13 +126,21 @@ cat .claude/skills/version-control-for-docs/SKILL.md
 
 **ステップ**:
 1. ユーザーの要求を分析（仕様書の種類、対象機能）
-2. プロジェクトコンテキストの確認
-3. 既存仕様書の調査（重複防止とDRY原則）
+2. **master_system_design.md の参照**（プロジェクト制約の確認）
+   - TDD方針（テスト → 実装の順序）
+   - ハイブリッド構造（shared/core, shared/infrastructure, features）
+   - 技術スタック（Next.js 15.x, TypeScript 5.x, Drizzle ORM, Zod, Vercel AI SDK）
+   - 非機能要件（ロギング、ファイルストレージ、テスト戦略）
+3. 既存要件書の参照（`docs/00-requirements/requirements.md`）
+4. 既存仕様書の調査（重複防止とDRY原則）
 
 **判断基準**:
 - [ ] 仕様書の対象範囲は明確か？
+- [ ] master_system_design.md のプロジェクト制約を理解したか？
 - [ ] 既存の仕様書と重複していないか？
 - [ ] 依存する他の仕様書は存在するか？
+- [ ] **TDD準拠**: テストファイルパスを明記できるか？
+- [ ] **ハイブリッド構造**: shared と features の責務を明確にできるか？
 
 ### Phase 2: 仕様書構造の設計
 
@@ -124,20 +151,57 @@ cat .claude/skills/version-control-for-docs/SKILL.md
 2. セクション構成の確定（Progressive Disclosure原則）
 3. DRY原則の適用計画（共通定義の抽出）
 
-**仕様書の典型的構造**:
-```
+**仕様書の典型的構造**（プロジェクト固有）:
+```markdown
 # 機能名
 ## 概要（Why & What）
 ## 前提条件
+
+## プロジェクト固有制約（master_system_design.md準拠）
+### TDD方針
+- テストファイルパス: `features/[機能名]/__tests__/executor.test.ts`
+- テスト作成タイミング: 実装前
+- カバレッジ目標: 60%以上（重要ロジックは80%）
+
+### ハイブリッド構造
+- **shared/core**: 共通エンティティ、インターフェース（`workflow.ts`, `IWorkflowExecutor.ts`）
+- **shared/infrastructure**: 共通サービス（AI、DB、Discord）
+- **features/[機能名]**: 機能固有のビジネスロジック（`schema.ts`, `executor.ts`）
+
+### 技術スタック
+- Next.js 15.x App Router、TypeScript 5.x strict モード
+- Drizzle ORM（Neon PostgreSQL）、Zod 3.x バリデーション
+- Vercel AI SDK 4.x（OpenAI, Anthropic, Google, xAI）
+
 ## データモデル
-## API仕様
+### Zodスキーマ定義（`features/[機能名]/schema.ts`）
+- 入力スキーマ: `inputSchema`（Zod定義）
+- 出力スキーマ: `outputSchema`（Zod定義）
+- TypeScript型エクスポート: `type Input = z.infer<typeof inputSchema>`
+
+### データベーススキーマ（該当する場合）
+- workflows テーブル: `type`, `input_payload`, `output_payload`, `status`
+
+## IWorkflowExecutor実装要件（機能プラグインの場合）
+- `type`: ワークフロータイプ識別子（大文字スネークケース）
+- `execute(input, context)`: メイン実行処理
+- `inputSchema`, `outputSchema`: Zod スキーマ
+
+## API仕様（該当する場合）
 ## ワークフロー（Mermaid図）
 ## エラーハンドリング
 ## セキュリティ考慮事項
+## テストケース
+## 次フェーズ連携情報
+- 実装手順の推奨順序
+- テスト作成の指示
+- 依存関係の注意点
 ## 変更履歴
 ```
 
-**参照**: `structured-writing` スキルの `resources/topic-types.md`
+**参照**:
+- `structured-writing` スキルの `resources/topic-types.md`
+- `docs/00-requirements/master_system_design.md`
 
 ### Phase 3: 詳細仕様の記述
 
@@ -171,10 +235,20 @@ cat .claude/skills/version-control-for-docs/SKILL.md
 
 **参照**: `technical-documentation-standards` スキルの `scripts/check-dry-violations.mjs`
 
+**プロジェクト制約の検証**（master_system_design.md準拠）:
+- [ ] **TDD準拠**: テストファイルパス（`features/[機能名]/__tests__/executor.test.ts`）を明記したか？
+- [ ] **Zodスキーマ**: 入出力スキーマを `schema.ts` に定義したか？
+- [ ] **IWorkflowExecutor**: 機能プラグインの場合、インターフェース要件を明記したか？
+- [ ] **ハイブリッド構造**: shared と features の責務を明確にしたか？
+- [ ] **プロジェクト用語**: workflows, executor, registry等を使用したか？
+- [ ] **技術スタック**: Next.js 15.x, TypeScript 5.x, Drizzle ORM, Zod 3.x を指定したか？
+- [ ] **非機能要件**: ロギング、エラーハンドリング、リトライ戦略を記述したか？
+
 **実装者視点のレビュー**:
 - [ ] 実装者が仕様書のみで実装を開始できるか？
 - [ ] 曖昧な表現は残っていないか？
 - [ ] すべてのエッジケースが考慮されているか？
+- [ ] **次フェーズ連携**: 実装手順、テスト作成の指示を明記したか？
 
 ### Phase 5: 最終出力と引き継ぎ
 
@@ -222,12 +296,23 @@ status: draft | review | approved
 ## 品質基準
 
 ### 完了条件
+
+**基本品質基準**:
 - [ ] データモデルがTypeScript型定義で記述されている
 - [ ] API仕様がすべてのエンドポイントで完全に定義されている
 - [ ] ワークフローがMermaid図で視覚化されている
 - [ ] すべての入力・出力・エラーケースが網羅されている
 - [ ] DRY原則に準拠し、重複情報がない
 - [ ] Front Matterが完全である
+
+**プロジェクト固有の完了条件**（master_system_design.md準拠）:
+- [ ] **プロジェクト固有制約セクション**: TDD、ハイブリッド構造、技術スタックを記述
+- [ ] **Zodスキーマ定義セクション**: `inputSchema`, `outputSchema` の型定義を記述
+- [ ] **IWorkflowExecutor要件セクション**: `type`, `execute()`, スキーマ要件を明記（機能プラグインの場合）
+- [ ] **テストケースセクション**: テストファイルパス、テストケース例、カバレッジ目標を明記
+- [ ] **次フェーズ連携情報セクション**: 実装手順、テスト作成指示、依存関係を記述
+- [ ] **プロジェクト用語使用**: workflows, executor, registry, JSONB等を適切に使用
+- [ ] **ハイブリッド構造明記**: shared/core, shared/infrastructure, features の責務を明確化
 
 ### 品質メトリクス
 ```yaml
@@ -303,6 +388,7 @@ metrics:
 
 | バージョン | 日付 | 変更内容 |
 |-----------|------|---------|
+| 3.0.0 | 2025-11-28 | master_system_design.md準拠: TDD、ハイブリッド構造、Zodスキーマ、IWorkflowExecutor要件の追加 |
 | 2.0.0 | 2025-11-25 | 軽量化・スキル依存構造に再設計 |
 | 1.0.0 | 2025-11-21 | 初版作成 |
 

--- a/.claude/commands/ai/command_list.md
+++ b/.claude/commands/ai/command_list.md
@@ -205,14 +205,38 @@
   - `allowed-tools: Read, Write(docs/**)`
 
 ### `/ai:write-spec`
-- **目的**: 実装可能な詳細仕様書の作成
-- **引数**: `[feature-name]` - 機能名
-- **使用エージェント**: @spec-writer
-- **スキル活用**: markdown-advanced-syntax, technical-documentation-standards
-- **成果物**: docs/20-specifications/*.md
+- **目的**: 実装可能な詳細仕様書の作成（**Specification-Driven Development**の一環）
+- **引数**: `[feature-name]` - 機能名（オプション、未指定時はインタラクティブ）
+- **使用エージェント**: `.claude/agents/spec-writer.md`
+- **スキル活用**（フェーズ別、spec-writerが必要時に参照）:
+  - **Phase 1**: `.claude/skills/markdown-advanced-syntax/SKILL.md` - Markdown記法
+  - **Phase 2**: `.claude/skills/technical-documentation-standards/SKILL.md` - 技術文書標準
+  - **Phase 3**: `.claude/skills/api-documentation-best-practices/SKILL.md` - API仕様パターン（API機能の場合）
+  - **Phase 4**: `.claude/skills/use-case-modeling/SKILL.md` - ユースケース記述（必要時）
+- **フロー**:
+  1. Phase 1: 機能名の確認（引数または対話的）
+  2. Phase 2: spec-writer エージェント起動
+     - master_system_design.md 参照（プロジェクト制約確認）
+     - 既存要件書参照（requirements.md）
+     - 詳細仕様書作成（Markdown形式）
+     - TDD準拠テスト要件明記
+     - スキーマ定義、インターフェース要件記述
+  3. Phase 3: 検証と完了報告（master_system_design.md 制約反映確認）
+- **成果物**:
+  - `docs/20-specifications/features/[feature-name].md`（詳細仕様書）
+  - **プロジェクト固有制約セクション**（TDD必須、ハイブリッド構造、技術スタック）
+  - **テストファイルパス**、**Zodスキーマ定義**、**IWorkflowExecutor要件**
+  - **次フェーズ連携情報**（実装、テスト作成への引き継ぎ）
 - **設定**:
-  - `model: sonnet`
-  - `allowed-tools: Read, Write(docs/**)`
+  - `model: sonnet`（標準的な仕様書作成タスク）
+  - `allowed-tools: [Task, Read, Write(docs/**)]`（spec-writerエージェント起動、ドキュメント作成に必要な最小権限）
+- **プロジェクト固有の考慮**:
+  - [ ] TDD準拠（仕様 → テスト → 実装の順序を明記）
+  - [ ] ハイブリッド構造（shared/ と features/ の責務を仕様に反映）
+  - [ ] Zodスキーマ（入出力定義を仕様に含める）
+  - [ ] IWorkflowExecutor（機能プラグインの場合、インターフェース実装要件を明記）
+  - [ ] 用語集（workflows, executor, registry等を仕様で使用）
+- **トリガーキーワード**: spec, specification, 仕様書, 詳細仕様, 実装仕様, 設計書
 
 ### `/ai:estimate-project`
 - **目的**: プロジェクト規模の見積もり

--- a/.claude/commands/ai/write-spec.md
+++ b/.claude/commands/ai/write-spec.md
@@ -1,0 +1,144 @@
+---
+description: |
+  実装可能な詳細仕様書作成（Specification-Driven Development）
+
+  🤖 起動エージェント:
+  - `.claude/agents/spec-writer.md`: 詳細仕様書作成専門エージェント（Phase 2で起動）
+
+  📚 利用可能スキル（spec-writerが必要時に参照）:
+  **Phase 1（Markdown記法）:** markdown-advanced-syntax
+  **Phase 2（技術文書標準）:** technical-documentation-standards
+  **Phase 3（API仕様、必要時）:** api-documentation-best-practices
+  **Phase 4（ユースケース、必要時）:** use-case-modeling
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: オプション引数1つ（未指定時はインタラクティブ）
+  - allowed-tools: エージェント起動とドキュメント作成用
+    • Task: spec-writerエージェント起動用
+    • Read: master_system_design.md、要件書、既存仕様参照用
+    • Write(docs/**): 仕様書生成用（ドキュメントディレクトリのみ）
+  - model: sonnet（標準的な仕様書作成タスク）
+
+  📋 プロジェクト固有要件（master_system_design.md準拠）:
+  - TDD準拠: テストファイルパス明記
+  - Zodスキーマ: 入出力型定義必須
+  - IWorkflowExecutor: 機能プラグインのインターフェース要件
+  - ハイブリッド構造: shared と features の責務分離
+  - プロジェクト用語: workflows, executor, registry等
+
+  トリガーキーワード: spec, specification, 仕様書, 詳細仕様, 実装仕様, 設計書
+argument-hint: "[feature-name]"
+allowed-tools: [Task, Read, Write(docs/**)]
+model: sonnet
+---
+
+# Write Specification - 詳細仕様書作成
+
+**Purpose**: 実装可能な詳細仕様書の作成（Specification-Driven Development の一環）
+
+## 実行フロー
+
+### Phase 1: 機能名確認
+
+**引数チェック**:
+- `$1` (feature-name) が指定されている場合: そのまま使用
+- 未指定の場合: 対話的に機能名を確認
+
+### Phase 2: 仕様書作成エージェント起動
+
+**エージェント**: `.claude/agents/spec-writer.md`
+
+**起動パラメータ**:
+```
+Feature Name: $1 (または対話で確認した機能名)
+Project Context: master_system_design.md 準拠
+Requirements Source: docs/10-requirements/requirements.md (存在する場合)
+Output Path: docs/20-specifications/features/[feature-name].md
+```
+
+**エージェントへの依頼内容**:
+
+1. **プロジェクト制約の理解**
+   - `master_system_design.md` を参照してプロジェクト固有制約を把握
+   - TDD、Clean Architecture、ハイブリッド構造の理解
+   - プロジェクト用語（workflows, executor, registry 等）の確認
+
+2. **要件情報の収集**
+   - `docs/10-requirements/requirements.md` から関連要件を抽出
+   - 既存の仕様書（`docs/20-specifications/features/*.md`）を参照
+   - 機能の目的、背景、制約を明確化
+
+3. **詳細仕様書の作成**
+
+   **必須記述事項**:
+   - 機能概要と背景
+   - ユースケース・ユーザーストーリー
+   - 入出力仕様（Zod スキーマ定義含む）
+   - インターフェース要件（IWorkflowExecutor 実装等）
+   - アーキテクチャ設計（shared/core, shared/infrastructure, features の責務分離）
+   - TDD準拠のテストケース定義
+     - テストファイルパス明記
+     - 期待される振る舞い記述
+   - エラーハンドリング仕様
+   - パフォーマンス要件
+   - セキュリティ考慮事項
+
+   **スキル参照（必要時）**:
+   - `.claude/skills/markdown-advanced-syntax/SKILL.md`: Markdown記法
+   - `.claude/skills/technical-documentation-standards/SKILL.md`: 技術文書標準
+   - `.claude/skills/api-documentation-best-practices/SKILL.md`: API仕様パターン
+   - `.claude/skills/use-case-modeling/SKILL.md`: ユースケース記述
+
+4. **成果物の生成**
+   - `docs/20-specifications/features/[feature-name].md` に仕様書を出力
+   - 実装者が迷わず実装できる詳細レベルを確保
+
+### Phase 3: 検証と完了報告
+
+**検証項目**:
+- [ ] master_system_design.md の制約が反映されているか
+- [ ] TDD準拠のテストケースが明記されているか
+- [ ] 入出力スキーマ（Zod）が定義されているか
+- [ ] インターフェース実装要件が明記されているか
+- [ ] ハイブリッド構造の責務分離が反映されているか
+
+**完了報告**:
+- 生成された仕様書のパス
+- 記述された主要セクションの概要
+- 次のステップの提案（実装、レビュー等）
+
+## 期待される成果物
+
+**ファイルパス**: `docs/20-specifications/features/[feature-name].md`
+
+**品質基準**:
+- 実装者が仕様書のみで実装可能な詳細度
+- プロジェクト固有制約の完全な反映
+- TDD準拠のテストケース明記
+- 技術文書標準に準拠した構造
+
+## 注意事項
+
+**コマンドハブ原則**:
+- このコマンドは `.claude/agents/spec-writer.md` の起動ハブとして機能
+- 詳細な仕様書フォーマット、記述ルールは spec-writer エージェントに委譲
+- master_system_design.md 準拠の指示のみ行う
+
+**allowed-tools 制限**:
+- Task: spec-writer エージェント起動専用
+- Read: master_system_design.md、要件書、既存仕様参照専用
+- Write: docs/** ディレクトリのみ（ソースコード変更禁止）
+
+## 使用例
+
+```bash
+# 機能名を指定
+/ai:write-spec user-authentication
+
+# 対話的に機能名を確認
+/ai:write-spec
+```
+
+## トリガーキーワード
+
+spec, specification, 仕様書, 詳細仕様, 実装仕様, 設計書


### PR DESCRIPTION
## 概要
詳細仕様書を自動生成する `/ai:write-spec` コマンドとそれに対応する `spec-writer` エージェント (v3.0.0) を追加します。

このコマンドは **Specification-Driven Development (SDD)** のフローをサポートし、master_system_design.md に完全準拠した仕様書生成を実現します。

## 変更内容

### 1. 新規コマンド: `/ai:write-spec`
- **目的**: 実装可能な詳細仕様書の作成
- **引数**: `[feature-name]` - 機能名（オプション、未指定時はインタラクティブ）
- **エージェント**: `.claude/agents/spec-writer.md`
- **ツール権限**: Task (エージェント起動), Read (ドキュメント参照), Write(docs/**)
- **モデル**: sonnet

### 2. エージェント更新: spec-writer.md (v3.0.0)
**主要改善点**:
- ✅ **master_system_design.md 準拠**: Phase 1で参照を必須化
- ✅ **TDD対応**: テストファイルパス（`features/[機能名]/__tests__/executor.test.ts`）の明記
- ✅ **Zodスキーマ定義**: 入出力型定義を責務に追加
- ✅ **IWorkflowExecutor要件**: 機能プラグインのインターフェース実装仕様
- ✅ **ハイブリッド構造**: shared/core, shared/infrastructure, features の責務分離
- ✅ **プロジェクト用語**: workflows, executor, registry等を使用

**仕様書構造テンプレート改善**:
- プロジェクト固有制約セクション（TDD、ハイブリッド構造、技術スタック）
- Zodスキーマ定義セクション
- IWorkflowExecutor実装要件セクション
- テストケースセクション
- 次フェーズ連携情報セクション

**完了条件拡張**:
- 基本品質基準（6項目）
- プロジェクト固有の完了条件（7項目）

### 3. コマンドリスト更新: command_list.md
- フェーズ別スキル参照の詳細化
- プロジェクト固有制約の明記
- テストファイルパス、Zodスキーマ、IWorkflowExecutor等の成果物詳細化
- プロジェクト固有の考慮チェックリスト（5項目）

## テスト
- [x] ユニットテスト実行（`pnpm test`）
- [x] 型チェック実行（`pnpm typecheck`）
- [x] ESLint チェック実行（`pnpm lint`）
- [x] ビルド確認（`pnpm build`）
- [x] 新規コマンド構文検証
- [x] エージェント/スキル依存関係確認

## 検証内容
- ✅ コマンドハブ特化型設計（詳細ロジックをエージェントに委譲）
- ✅ 相対パス形式のエージェント・スキル参照
- ✅ master_system_design.md の全要件反映
  - TDD準拠の仕様構造
  - ハイブリッド構造（shared/features）
  - Zodスキーマ定義
  - IWorkflowExecutor要件
  - 非機能要件（ロギング、エラーハンドリング等）
- ✅ 依存スキル確認（5個全て存在）
- ✅ command_list.md の更新完了

## 関連Issue
このPRは仕様駆動開発ワークフローの実装をサポートします。

## 破壊的変更
なし

## 追加情報
このコマンドは以下のプロジェクト要件に対応:
- **Specification-Driven Development**: 仕様書を「正本」とした開発フロー
- **Clean Architecture**: shared/core, shared/infrastructure, features の明確な責務分離
- **TDD対応**: テスト → 実装の流れを促進する仕様書構造
- **型安全性**: Zod スキーマによる入出力の型定義

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)