### PR TITLE
feat(commands): Add /ai:design-api command with hub-centric design

### DIFF
--- a/.claude/commands/ai/command_list.md
+++ b/.claude/commands/ai/command_list.md
@@ -300,14 +300,33 @@
   - `allowed-tools: Read, Write(src/core/**|docs/**)`
 
 ### `/ai:design-api`
-- **目的**: REST API設計とエンドポイント定義
-- **引数**: `[resource-name]` - リソース名
-- **使用エージェント**: @gateway-dev, @api-doc-writer
-- **スキル活用**: api-client-patterns, openapi-specification
-- **成果物**: openapi.yaml, API設計書
+- **目的**: REST API設計とOpenAPI 3.x仕様書の作成（エンドポイント定義、認証設計、スキーマ生成）
+- **引数**: `[resource-name]` - リソース名（オプション、未指定時はインタラクティブ）
+- **使用エージェント**:
+  - `.claude/agents/gateway-dev.md`: Phase 1 - API設計パターン分析、エンドポイント設計
+  - `.claude/agents/api-doc-writer.md`: Phase 2 - OpenAPI仕様書生成、ドキュメント作成
+- **スキル活用**（エージェントが必要時に参照）:
+  - **gateway-dev**: `.claude/skills/api-client-patterns/SKILL.md`, `.claude/skills/http-best-practices/SKILL.md`
+  - **api-doc-writer**: `.claude/skills/openapi-specification/SKILL.md`, `.claude/skills/swagger-ui/SKILL.md`, `.claude/skills/api-documentation-best-practices/SKILL.md`, `.claude/skills/request-response-examples/SKILL.md`
+- **フロー**:
+  1. Phase 0: 引数確認、master_system_design.md第8章参照、既存パターン確認
+  2. Phase 1: gateway-dev起動 → API設計（master_system_design.md第8章準拠）
+  3. Phase 2: api-doc-writer起動 → OpenAPI 3.x仕様書生成
+  4. Phase 3: 整合性チェック、完了報告
+- **成果物**:
+  - `docs/20-specifications/api-design-$ARGUMENTS.md`: API設計書
+  - `openapi.yaml`: OpenAPI 3.x仕様書
+  - `docs/20-specifications/api-documentation-$ARGUMENTS.md`: 詳細ドキュメント（cURL例、SDK例）
+  - `src/app/api/[resource]/route.ts`: Next.js実装ガイド（オプション）
+- **プロジェクト要件準拠**:
+  - REST API 設計原則（master_system_design.md 第8章）
+  - APIバージョニング: URL パスベース（/api/v1/...）
+  - HTTPステータスコード規約、エラーレスポンス形式、ページネーション実装
 - **設定**:
   - `model: sonnet`
-  - `allowed-tools: Read, Write`
+  - `allowed-tools: [Task, Read, Write(docs/**|openapi.yaml), Grep]`
+  - **トークン見積もり**: 約15-25K（2エージェント起動 + ドキュメント生成）
+- **トリガーキーワード**: api, design, endpoint, openapi, swagger, REST, エンドポイント設計, API仕様書
 
 ### `/ai:design-database`
 - **目的**: データベーススキーマ設計

--- a/.claude/commands/ai/design-api.md
+++ b/.claude/commands/ai/design-api.md
@@ -1,0 +1,170 @@
+---
+description: |
+  REST API設計とOpenAPI 3.x仕様書の作成（エンドポイント定義、認証設計、スキーマ生成）。
+
+  エンドポイント設計からOpenAPI仕様書まで、APIの完全な設計ドキュメントを生成します。
+
+  🤖 起動エージェント:
+  - `.claude/agents/gateway-dev.md`: Phase 1 - API設計パターン分析、エンドポイント設計
+  - `.claude/agents/api-doc-writer.md`: Phase 2 - OpenAPI仕様書生成、ドキュメント作成
+
+  📚 利用可能スキル（タスクに応じてエージェントが必要時に参照）:
+  **gateway-dev が参照:**
+  - `.claude/skills/api-client-patterns/SKILL.md`: Adapter/Facade/Anti-Corruption Layer設計
+  - `.claude/skills/http-best-practices/SKILL.md`: ステータスコード処理、べき等性、接続管理
+
+  **api-doc-writer が参照:**
+  - `.claude/skills/openapi-specification/SKILL.md`: OpenAPI 3.x仕様設計、スキーマ定義
+  - `.claude/skills/swagger-ui/SKILL.md`: インタラクティブドキュメント、API Explorer構築
+  - `.claude/skills/api-documentation-best-practices/SKILL.md`: DX設計、自己完結型ドキュメント
+  - `.claude/skills/request-response-examples/SKILL.md`: cURLサンプル、SDK例、レスポンス例
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: オプション引数1つ（未指定時はインタラクティブ）
+  - allowed-tools: エージェント起動と最小限の確認用
+    • Task: gateway-dev、api-doc-writerエージェント起動用
+    • Read: 既存API実装、プロジェクト仕様確認用
+    • Write(docs/**|openapi.yaml): API設計書、OpenAPI仕様書生成用（パス制限）
+    • Grep: 既存パターン検索、エンドポイント重複チェック用
+  - model: sonnet（標準的な設計タスク）
+
+  トリガーキーワード: api, design, endpoint, openapi, swagger, REST, エンドポイント設計, API仕様書
+argument-hint: "[resource-name]"
+allowed-tools: [Task, Read, Write(docs/**|openapi.yaml), Grep]
+model: sonnet
+---
+
+# API設計コマンド - REST API & OpenAPI仕様書生成
+
+このコマンドは、REST API設計とOpenAPI 3.x仕様書の作成を自動化します。
+
+## 起動エージェント
+
+- **gateway-dev** (`.claude/agents/gateway-dev.md`): API設計パターン分析、エンドポイント設計
+- **api-doc-writer** (`.claude/agents/api-doc-writer.md`): OpenAPI仕様書生成、ドキュメント作成
+
+## 引数
+
+- `$ARGUMENTS` または `$1`: リソース名（例: `users`, `tasks`, `projects`）
+  - 未指定時: インタラクティブモードで要件ヒアリング
+
+## 実行フロー
+
+### Phase 0: 準備
+
+1. **引数確認**: `$ARGUMENTS` でリソース名取得（未指定時はインタラクティブ）
+2. **仕様参照**: `docs/00-requirements/master_system_design.md` 第8章（REST API 設計原則）
+3. **既存パターン確認**: `src/app/api/` 配下の既存エンドポイント分析
+
+---
+
+### Phase 1: API設計 - gateway-dev起動
+
+Task ツールで `.claude/agents/gateway-dev.md` を起動:
+
+```
+リソース: $ARGUMENTS
+
+依頼:
+REST APIエンドポイント設計（master_system_design.md第8章準拠）
+
+期待成果物:
+- エンドポイント一覧（CRUD + カスタム操作）
+- リクエスト/レスポンススキーマ
+- 認証・認可設計
+- エラーハンドリング戦略
+- Next.js App Router実装ガイド
+
+保存先: docs/20-specifications/api-design-$ARGUMENTS.md
+```
+
+**gateway-dev が参照するスキル**（必要時のみ）:
+- `.claude/skills/api-client-patterns/SKILL.md`
+- `.claude/skills/http-best-practices/SKILL.md`
+
+---
+
+### Phase 2: OpenAPI仕様書生成 - api-doc-writer起動
+
+Task ツールで `.claude/agents/api-doc-writer.md` を起動:
+
+```
+入力:
+- Phase 1の設計結果（docs/20-specifications/api-design-$ARGUMENTS.md）
+
+依頼:
+OpenAPI 3.x仕様書とドキュメント生成
+
+期待成果物:
+- openapi.yaml（完全なスキーマ定義、example含む）
+- 詳細ドキュメント（cURL例、SDK例）
+- エラーレスポンス例
+- Swagger UI設定ガイド（オプション）
+
+保存先:
+- openapi.yaml（プロジェクトルート）
+- docs/20-specifications/api-documentation-$ARGUMENTS.md
+```
+
+**api-doc-writer が参照するスキル**（必要時のみ）:
+- `.claude/skills/openapi-specification/SKILL.md`
+- `.claude/skills/swagger-ui/SKILL.md`
+- `.claude/skills/api-documentation-best-practices/SKILL.md`
+- `.claude/skills/request-response-examples/SKILL.md`
+
+---
+
+### Phase 3: 検証と完了
+
+1. **整合性チェック**: openapi.yaml構文検証、master_system_design.md準拠確認
+2. **成果物確認**: 生成ファイルの存在確認
+3. **完了報告**: エンドポイント数、設計決定事項、次のアクション提示
+
+---
+
+## 使用例
+
+### 基本的な使用（引数あり）
+```bash
+/ai:design-api users
+```
+→ Usersリソースの完全なAPI設計 + OpenAPI仕様書生成
+
+### インタラクティブモード（引数なし）
+```bash
+/ai:design-api
+```
+→ リソース名、CRUD要件、認証設計を対話的に確認
+
+### 複数リソース設計
+```bash
+/ai:design-api tasks
+/ai:design-api projects
+```
+→ 各リソースごとに独立したAPI設計
+
+---
+
+## 成果物一覧
+
+| ファイル | 内容 | 生成フェーズ |
+|---------|------|-------------|
+| `docs/20-specifications/api-design-$ARGUMENTS.md` | API設計書（エンドポイント一覧、認証、エラーハンドリング） | Phase 1 |
+| `openapi.yaml` | OpenAPI 3.x仕様書（完全なスキーマ定義） | Phase 2 |
+| `docs/20-specifications/api-documentation-$ARGUMENTS.md` | 詳細ドキュメント（cURL例、SDK例） | Phase 2 |
+| `src/app/api/[resource]/route.ts` | Next.js実装ガイド（オプション） | Phase 1 |
+
+---
+
+## トリガーキーワード
+
+api, design, endpoint, openapi, swagger, REST, エンドポイント設計, API仕様書
+
+---
+
+## 参考資料
+
+- `docs/00-requirements/master_system_design.md` 第8章（REST API 設計原則）
+- `.claude/skills/api-client-patterns/SKILL.md`
+- `.claude/skills/openapi-specification/SKILL.md`
+- `.claude/skills/http-best-practices/SKILL.md`


### PR DESCRIPTION
## 概要
REST API設計とOpenAPI 3.x仕様書を自動生成する `/ai:design-api` コマンドを追加します。
gateway-dev と api-doc-writer の2エージェント連携により、包括的なAPI設計ドキュメントを生成します。

## 変更内容
- 新規コマンド作成: `.claude/commands/ai/design-api.md`（170行）
- YAML Frontmatter を詳細な複数行形式に更新
  - 🤖 起動エージェント明記（gateway-dev, api-doc-writer）
  - 📚 利用可能スキル構造化（エージェント別に整理）
  - ⚙️ コマンド設定詳細化（allowed-tools、model、トリガーキーワード）
- Phase 0-3 ワークフロー実装
  - Phase 0: 準備（引数確認、仕様参照、既存パターン確認）
  - Phase 1: gateway-dev起動 → API設計
  - Phase 2: api-doc-writer起動 → OpenAPI仕様書生成
  - Phase 3: 検証と完了
- 相対パス参照統一（`.claude/agents/`, `.claude/skills/`）
- allowed-tools にパス制限追加（`Write(docs/**|openapi.yaml)`）
- command_list.md エントリー詳細化

## 設計原則の適用
- **ハブ特化型**: コマンドはエージェント起動のハブ、詳細はスキルに委譲
- **Progressive Disclosure**: エージェントが必要時にのみスキル参照
- **最小権限**: allowed-tools にパス制限を明示
- **プロジェクト準拠**: master_system_design.md 第8章（REST API設計原則）に準拠

## 成果物
- `docs/20-specifications/api-design-$ARGUMENTS.md`: API設計書
- `openapi.yaml`: OpenAPI 3.x仕様書（完全なスキーマ定義）
- `docs/20-specifications/api-documentation-$ARGUMENTS.md`: 詳細ドキュメント
- `src/app/api/[resource]/route.ts`: Next.js実装ガイド（オプション）

## テスト
- [x] YAML構文検証（YAML Frontmatter が正しくパース可能）
- [x] 相対パス統一確認（すべて `.claude/` から始まる）
- [x] allowed-tools パス制限確認（`Write(docs/**|openapi.yaml)`）
- [x] コマンド本文の簡潔性確認（170行、ハブ特化型）
- [x] command_list.md との一貫性確認

## 品質メトリクス
- **総行数**: 170行（適切な簡潔さ）
- **YAML Frontmatter**: 34行（詳細な構造化）
- **実行フロー**: 4 Phase（Phase 0-3）
- **トークン見積もり**: 15-25K（2エージェント起動）

## 関連Issue
N/A（コマンド拡充の継続的改善）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)