### PR TITLE
feat(commands): Add /ai:implement-business-logic command

### DIFF
--- a/.claude/commands/ai/command_list.md
+++ b/.claude/commands/ai/command_list.md
@@ -610,14 +610,35 @@
   - `allowed-tools: Read, Write(src/features/**), Edit`
 
 ### `/ai:implement-business-logic`
-- **目的**: ビジネスロジックの実装
-- **引数**: `[logic-name]` - ロジック名
-- **使用エージェント**: @logic-dev
-- **スキル活用**: refactoring-techniques, clean-code-practices, tdd-red-green-refactor
-- **成果物**: ビジネスロジック実装
+- **目的**: ビジネスロジック実装（TDD準拠のExecutorクラス実装）
+- **引数**: `[logic-name]` - ロジック名（例: youtube-summarize, meeting-transcribe）
+- **使用エージェント**: `.claude/agents/logic-dev.md`（ビジネスロジック実装専門）
+- **スキル活用**（logic-devエージェントがフェーズに応じて参照）:
+  - **Phase 2（TDD実装時）**:
+    - `.claude/skills/tdd-red-green-refactor/SKILL.md`: Red-Green-Refactorサイクル
+    - `.claude/skills/transaction-script/SKILL.md`: Executorパターン実装
+    - `.claude/skills/test-doubles/SKILL.md`: テストダブル選択
+  - **Phase 3（リファクタリング時）**:
+    - `.claude/skills/refactoring-techniques/SKILL.md`: コードスメル検出・改善
+    - `.claude/skills/clean-code-practices/SKILL.md`: 命名・関数設計
+- **参照仕様書**:
+  - `docs/00-requirements/master_system_design.md`: 第5章（ハイブリッドアーキテクチャ）、第6章（IWorkflowExecutor）
+- **フロー**:
+  1. Phase 1: 引数確認、仕様書・スキーマ参照
+  2. Phase 2: logic-devエージェント起動 → TDD実装（Red-Green-Refactor）
+  3. Phase 3: テスト実行、実装サマリー報告
+- **成果物**:
+  - `src/features/[logic-name]/executor.ts`: IWorkflowExecutor準拠の実装
+  - `src/features/[logic-name]/__tests__/executor.test.ts`: ユニットテスト（Vitest）
+  - `src/features/[logic-name]/schema.ts`: 入出力スキーマ（Zod）※未存在の場合
+- **品質基準**:
+  - テストカバレッジ: 80%以上
+  - 関数の長さ: 30行以下
+  - 循環的複雑度: 10以下
 - **設定**:
-  - `model: sonnet`
-  - `allowed-tools: Read, Write(src/**), Edit, Task`
+  - `model: opus`
+  - `allowed-tools: [Task, Read, Write(src/features/**), Edit, Grep, Glob, Bash(pnpm test*)]`
+- **トリガーキーワード**: business logic, executor, implement, 実装, ビジネスロジック, TDD
 
 ### `/ai:create-api-gateway`
 - **目的**: 外部API統合ゲートウェイの実装

--- a/.claude/commands/ai/implement-business-logic.md
+++ b/.claude/commands/ai/implement-business-logic.md
@@ -1,0 +1,124 @@
+---
+description: |
+  ビジネスロジック実装専門コマンド。
+  マーティン・ファウラーの思想に基づき、可読性が高くテスト容易なExecutorクラスを実装します。
+
+  🤖 起動エージェント:
+  - `.claude/agents/logic-dev.md`: ビジネスロジック実装専門エージェント（Phase 2で起動）
+
+  📚 利用可能スキル（タスクに応じてlogic-devエージェントが必要時に参照）:
+  **Phase 1（要件理解時）:** なし（仕様書・スキーマ参照のみ）
+  **Phase 2（テスト駆動実装時）:**
+    - `.claude/skills/tdd-red-green-refactor/SKILL.md`: Red-Green-Refactorサイクル
+    - `.claude/skills/transaction-script/SKILL.md`: Executorパターン実装
+    - `.claude/skills/test-doubles/SKILL.md`: テストダブル選択
+  **Phase 3（リファクタリング時）:**
+    - `.claude/skills/refactoring-techniques/SKILL.md`: コードスメル検出・改善
+    - `.claude/skills/clean-code-practices/SKILL.md`: 命名・関数設計
+
+  📋 参照仕様書:
+  - `docs/00-requirements/master_system_design.md`: 第5章（ハイブリッドアーキテクチャ）、第6章（IWorkflowExecutor）、第4章（featuresディレクトリ）
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: `[logic-name]` - 実装するロジック名（例: youtube-summarize, meeting-transcribe）
+  - allowed-tools: エージェント起動と最小限の確認・実装用
+    • Task: logic-devエージェント起動用
+    • Read: 仕様書・スキーマ・既存実装参照用
+    • Write(src/features/**): Executor・テストファイル生成用（パス制限）
+    • Edit: 既存ファイル編集用
+    • Grep, Glob: パターン検索・ファイル探索用
+    • Bash(pnpm test*): テスト実行用
+  - model: sonnet（標準的な実装タスク）
+
+  トリガーキーワード: business logic, executor, implement, 実装, ビジネスロジック, TDD
+argument-hint: "[logic-name]"
+allowed-tools: [Task, Read, Write(src/features/**), Edit, Grep, Glob, Bash(pnpm test*)]
+model: opus
+---
+
+# ビジネスロジック実装
+
+## 目的
+
+`$ARGUMENTS` のビジネスロジックを実装します。
+
+## 実行フロー
+
+### Phase 1: 準備と要件確認
+
+1. **引数の確認**
+   - `$ARGUMENTS` が指定されていない場合 → ユーザーに確認
+   - 指定されている場合 → Phase 2へ
+
+2. **関連情報の収集**
+   - `docs/20-specifications/features/$ARGUMENTS.md` の確認（存在する場合）
+   - `src/features/$ARGUMENTS/schema.ts` の確認（存在する場合）
+   - `docs/00-requirements/master_system_design.md` 第6章（IWorkflowExecutor）の確認
+
+### Phase 2: エージェント起動
+
+@.claude/agents/logic-dev.md を起動し、以下を依頼:
+
+```
+対象: $ARGUMENTS
+
+依頼内容:
+1. 機能仕様の理解（docs/20-specifications/features/ または要件確認）
+2. スキーマ定義の確認または作成（src/features/$ARGUMENTS/schema.ts）
+3. テスト駆動実装（Red-Green-Refactor）
+   - テストケース作成（__tests__/executor.test.ts）
+   - 最小限の実装（executor.ts）
+   - リファクタリング
+4. IWorkflowExecutor インターフェース準拠の確認
+5. Registry登録の確認（src/features/registry.ts）
+
+成果物:
+- src/features/$ARGUMENTS/executor.ts
+- src/features/$ARGUMENTS/__tests__/executor.test.ts
+- src/features/$ARGUMENTS/schema.ts（未存在の場合）
+
+品質基準:
+- テストカバレッジ: 80%以上
+- 関数の長さ: 30行以下
+- 循環的複雑度: 10以下
+```
+
+### Phase 3: 検証と報告
+
+1. **テスト実行**
+   ```bash
+   pnpm test src/features/$ARGUMENTS/
+   ```
+
+2. **実装サマリーの報告**
+   - 実装したファイル一覧
+   - テスト結果
+   - 適用したリファクタリング
+   - 次のステップ（Registry登録、統合テスト等）
+
+## 成果物
+
+| ファイル | 説明 |
+|---------|------|
+| `src/features/$ARGUMENTS/executor.ts` | ビジネスロジック実装（IWorkflowExecutor準拠） |
+| `src/features/$ARGUMENTS/__tests__/executor.test.ts` | ユニットテスト（Vitest） |
+| `src/features/$ARGUMENTS/schema.ts` | 入出力スキーマ（Zod）※未存在の場合 |
+
+## 使用例
+
+```bash
+# YouTube要約機能のExecutor実装
+/ai:implement-business-logic youtube-summarize
+
+# 議事録文字起こし機能のExecutor実装
+/ai:implement-business-logic meeting-transcribe
+
+# 新機能のExecutor実装（インタラクティブ）
+/ai:implement-business-logic
+```
+
+## 関連コマンド
+
+- `/ai:write-spec [feature-name]`: 詳細仕様書の作成（実装前に推奨）
+- `/ai:design-domain-model [domain-name]`: ドメインモデル設計（複雑なロジックの場合）
+- `/ai:create-tests [target]`: テスト拡充（カバレッジ向上）


### PR DESCRIPTION
## 概要
TDD準拠のビジネスロジック（Executorクラス）実装を支援する`/ai:implement-business-logic`コマンドを追加します。

## 変更内容
- **新規ファイル**: `.claude/commands/ai/implement-business-logic.md`
  - logic-devエージェントへの委譲パターン
  - フェーズ別スキル参照（TDD、リファクタリング、Clean Code）
  - master_system_design.md準拠の品質基準
- **更新ファイル**: `.claude/commands/ai/command_list.md`
  - `/ai:implement-business-logic`エントリの最適化
  - 相対パスでのエージェント・スキル参照

## master_system_design.md準拠
- 第4章（featuresディレクトリ構造）: `src/features/[logic-name]/` への出力
- 第5章（ハイブリッドアーキテクチャ）: 垂直スライス実装
- 第6章（IWorkflowExecutor）: インターフェース準拠を品質基準に明記
- 第2.4節（TDD戦略）: Red-Green-Refactorサイクル統合

## スキル参照（相対パス）
- `.claude/skills/tdd-red-green-refactor/SKILL.md`
- `.claude/skills/transaction-script/SKILL.md`
- `.claude/skills/test-doubles/SKILL.md`
- `.claude/skills/refactoring-techniques/SKILL.md`
- `.claude/skills/clean-code-practices/SKILL.md`

## テスト
- [x] コマンドファイルの構文確認
- [x] パス参照の整合性確認（エージェント・スキル）
- [x] command_list.mdの更新確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)