### PR TITLE
feat(commands): Add /ai:create-schema command for Zod schema definition

### DIFF
--- a/.claude/commands/ai/command_list.md
+++ b/.claude/commands/ai/command_list.md
@@ -630,14 +630,30 @@
   - `allowed-tools: Read, Write(src/infrastructure/**), Edit`
 
 ### `/ai:create-schema`
-- **目的**: Zodスキーマ定義の作成
-- **引数**: `[schema-name]` - スキーマ名
-- **使用エージェント**: @schema-def
-- **スキル活用**: zod-validation, type-safety-patterns, input-sanitization
-- **成果物**: schema.ts
+- **目的**: Zodスキーマ定義の作成（Zod 3.x + TypeScript 5.x準拠）
+- **引数**: `[schema-name]` - スキーマ名（例: user, auth/login-request）（オプション、未指定時はインタラクティブ）
+- **使用エージェント**:
+  - `.claude/agents/schema-def.md`: スキーマ定義専門エージェント（Zod設計、型推論、バリデーション）
+- **フロー**:
+  1. Phase 1: 対象スキーマ確認、既存スキーマ・ドメインモデル分析
+  2. Phase 2: schema-def起動 → Zodスキーマ設計（基本スキーマ、カスタムバリデーション、型推論）
+  3. Phase 3: セキュリティ・サニタイゼーション（XSS/SQLi/コマンドインジェクション防止）
+  4. Phase 4: テスト作成（スキーマテスト、エッジケース、エラーメッセージ検証）
+  5. Phase 5: 統合・ドキュメント化（型エクスポート、API/フォーム連携）
+- **成果物**:
+  - `features/[feature]/schema.ts`（Zodスキーマ定義）
+  - `features/[feature]/schema.test.ts`（スキーマテスト）
+  - 型エクスポート（`z.infer<typeof schema>`）
+- **参照スキル**:
+  - **Phase 2**: `.claude/skills/zod-validation/SKILL.md`, `.claude/skills/type-safety-patterns/SKILL.md`
+  - **Phase 3**: `.claude/skills/input-sanitization/SKILL.md`
+  - **Phase 5（必要時）**: `.claude/skills/api-contract-design/SKILL.md`, `.claude/skills/form-validation/SKILL.md`
+- **設計書参照**:
+  - `docs/00-requirements/master_system_design.md`: 第2.1節（入力バリデーション原則）
 - **設定**:
-  - `model: sonnet`
-  - `allowed-tools: Read, Write(src/**/*.schema.ts), Edit`
+  - `model: sonnet`（構造化スキーマ設計タスク）
+  - `allowed-tools: [Task, Read, Write(src/**/*.schema.ts|features/**/*.schema.ts), Edit, Grep, Glob]`
+- **トリガーキーワード**: schema, zod, validation, バリデーション, スキーマ, 型定義, input validation
 
 ### `/ai:optimize-prompts`
 - **目的**: AIプロンプトの最適化

--- a/.claude/commands/ai/create-schema.md
+++ b/.claude/commands/ai/create-schema.md
@@ -1,0 +1,104 @@
+---
+description: |
+  Zodスキーマ定義の作成（Zod 3.x + TypeScript 5.x準拠）。
+
+  型安全なランタイムバリデーション、入力サニタイゼーション、型推論を含む完全なスキーマ設計を実行します。
+
+  🤖 起動エージェント:
+  - `.claude/agents/schema-def.md`: スキーマ定義専門エージェント（Phase 1で起動）
+
+  📚 利用可能スキル（フェーズ別、schema-defエージェントが必要時に参照）:
+  **Phase 1（要件理解時）:** なし（既存スキーマ・ドメインモデル分析のみ）
+  **Phase 2（スキーマ設計時）:** zod-validation（必須）, type-safety-patterns（必須）
+  **Phase 3（セキュリティ時）:** input-sanitization（必須）
+  **Phase 4（テスト時）:** なし（TDDパターン適用）
+  **Phase 5（統合時）:** api-contract-design（API連携時）, form-validation（フォーム連携時）
+
+  ⚙️ このコマンドの設定:
+  - argument-hint: オプション引数1つ（未指定時はインタラクティブ）
+  - allowed-tools: エージェント起動と最小限のスキーマ生成用
+    • Task: schema-defエージェント起動用
+    • Read: 既存スキーマ・ドメインモデル確認用
+    • Write(src/**/*.schema.ts|features/**/*.schema.ts): スキーマファイル生成用（パス制限）
+    • Edit: 既存スキーマファイル編集用
+    • Grep, Glob: 既存パターン検索・重複チェック用
+  - model: sonnet（構造化スキーマ設計タスク）
+
+  トリガーキーワード: schema, zod, validation, バリデーション, スキーマ, 型定義, input validation
+argument-hint: "[schema-name]"
+allowed-tools: [Task, Read, Write(src/**/*.schema.ts|features/**/*.schema.ts), Edit, Grep, Glob]
+model: sonnet
+---
+
+# Zodスキーマ作成コマンド
+
+## Phase 1: 準備とコンテキスト収集
+
+**対象スキーマ**: `$ARGUMENTS`（未指定時はインタラクティブに質問）
+
+**必須参照**:
+- `docs/00-requirements/master_system_design.md` 第2.1節（入力バリデーション原則）
+- `src/shared/schemas/`（既存スキーマパターン）
+- `features/*/schema.ts`（機能別スキーマ）
+
+---
+
+## Phase 2: schema-defエージェント起動
+
+`.claude/agents/schema-def.md` を以下のパラメータで起動:
+
+**入力情報**:
+- 対象: `$ARGUMENTS` または対話的に決定
+- 技術スタック: Zod 3.x + TypeScript 5.x（strictMode）
+- スキーマ配置: `features/*/schema.ts` または `src/shared/schemas/`
+
+**実行依頼内容**:
+1. 要件理解（ドメインモデル・既存スキーマ分析）
+2. Zodスキーマ設計（基本スキーマ、カスタムバリデーション、型推論）
+3. セキュリティ・サニタイゼーション（XSS/SQLi/コマンドインジェクション防止）
+4. テスト作成（スキーマテスト、エッジケース、エラーメッセージ検証）
+5. 統合・ドキュメント化（型エクスポート、API/フォーム連携）
+
+**エージェントが参照するスキル**（Progressive Disclosure方式）:
+- `.claude/skills/zod-validation/SKILL.md`（Phase 2: スキーマ設計時）
+- `.claude/skills/type-safety-patterns/SKILL.md`（Phase 2: 型安全設計時）
+- `.claude/skills/input-sanitization/SKILL.md`（Phase 3: セキュリティ時）
+- その他必要に応じて: api-contract-design, form-validation, data-transformation
+
+---
+
+## Phase 3: 成果物の確認
+
+**期待される成果物**:
+- `features/[feature]/schema.ts`（Zodスキーマ定義）
+- `features/[feature]/schema.test.ts`（スキーマテスト）
+- 型エクスポート（`z.infer<typeof schema>`）
+
+**設計原則準拠チェック**（master_system_design.md 第2.1節）:
+- ✅ 入力値サニタイゼーション適用
+- ✅ カスタムエラーメッセージ（日本語対応）
+- ✅ エラーコード 1000-5999 範囲
+- ✅ 型推論による静的型安全性
+- ✅ ランタイムバリデーション
+
+---
+
+**使用例**:
+
+```bash
+# 基本スキーマ作成
+/ai:create-schema user
+
+# 機能固有スキーマ
+/ai:create-schema auth/login-request
+
+# APIレスポンススキーマ
+/ai:create-schema api/product-response
+
+# インタラクティブモード
+/ai:create-schema
+```
+
+**関連コマンド**:
+- `/ai:design-api` - API設計（スキーマ連携）
+- `/ai:create-component` - フォームコンポーネント作成（スキーマ連携）


### PR DESCRIPTION
## 概要
Zodスキーマ定義を作成する `/ai:create-schema` コマンドを追加します。
schema-defエージェントを起動し、型安全なバリデーションスキーマを設計・実装します。

## 変更内容
- **新規コマンド追加**: `.claude/commands/ai/create-schema.md`
  - schema-def エージェント統合
  - フェーズ別スキル参照（zod-validation, type-safety-patterns, input-sanitization）
  - Progressive Disclosure ワークフロー
  - master_system_design.md 第2.1節準拠チェック

- **コマンドリスト更新**: `.claude/commands/ai/command_list.md`
  - エージェント・スキルの相対パス記載
  - 5フェーズフロー詳細
  - 設計書参照追加

## コマンド仕様

| 項目 | 内容 |
|------|------|
| コマンド | `/ai:create-schema [schema-name]` |
| エージェント | `.claude/agents/schema-def.md` |
| スキル | zod-validation, type-safety-patterns, input-sanitization |
| モデル | sonnet |
| 成果物 | `features/*/schema.ts`, `features/*/schema.test.ts` |

## テスト
- [x] コマンドファイル構文確認
- [x] command_list.md フォーマット確認
- [x] 相対パス記載確認

## 関連
- エージェント: `.claude/agents/schema-def.md`
- スキル: `.claude/skills/zod-validation/SKILL.md`, `.claude/skills/type-safety-patterns/SKILL.md`, `.claude/skills/input-sanitization/SKILL.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)