### PR TITLE
fix(infra): Add installCommand to fix Railway build failure

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,8 +3,10 @@
 
 [build]
 builder = "nixpacks"
-# --ignore-scripts: better-sqlite3のネイティブビルドをスキップ（バックエンドはTurso/libsqlを使用）
-buildCommand = "pnpm install --ignore-scripts && pnpm --filter @repo/shared build && pnpm --filter @repo/backend build"
+# better-sqlite3のネイティブビルドをスキップ（バックエンドはTurso/libsqlを使用）
+# nixPacksはinstallとbuildを分けて実行するため、installCommandも指定が必要
+installCommand = "pnpm install --ignore-scripts"
+buildCommand = "pnpm --filter @repo/shared build && pnpm --filter @repo/backend build"
 
 [deploy]
 startCommand = "pnpm --filter @repo/backend start"


### PR DESCRIPTION
## 概要
Railway デプロイで `better-sqlite3` のネイティブモジュールビルドが失敗する問題を修正します。

## 問題の原因
1. **Nixpacks が install と build を分離実行**: `buildCommand` の `--ignore-scripts` は build ステップにのみ適用
2. **install ステップは自動検出**: `pnpm i --frozen-lockfile` が実行され、ネイティブモジュールビルドが試行される
3. **Python 未インストール**: Railway 環境に Python がなく、`node-gyp` が失敗

```
gyp ERR! find Python 
gyp ERR! find Python Python is not set from command line or npm configuration
gyp ERR! find Python You need to install the latest version of Python.
```

## 変更内容
- `installCommand = "pnpm install --ignore-scripts"` を追加
- `--ignore-scripts` で `better-sqlite3` のネイティブビルドをスキップ
- バックエンドは Turso/libsql のリモート接続を使用するため、ローカル SQLite は不要

## 変更タイプ

- [x] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [ ] 📝 ドキュメント (documentation)
- [ ] 🧪 テスト (test)
- [x] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト
- [x] ローカルで設定ファイルの構文確認
- [ ] Railway デプロイで動作確認（マージ後に自動実行）

## 破壊的変更
なし

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)