### PR TITLE
fix(shared): DOMライブラリをtsconfigに追加

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 概要

sharedパッケージのビルドエラーを修正。

## 変更内容

- `packages/shared/tsconfig.json`の`lib`に`DOM`を追加

## 問題

CIでsharedパッケージのビルド時に以下のエラーが発生:
```
Error: infrastructure/ai/apiKeyValidator.ts(249,7): error TS2741: Property 'onabort' is missing in type 'AbortSignal' but required in type 'AbortSignal'.
```

## 原因

`fetch`APIと`AbortSignal`の完全な型定義には`DOM`ライブラリが必要。

## 変更タイプ

- [x] 🐛 バグ修正 (bug fix)

## テスト

- [x] 型チェック実行 (`pnpm typecheck`)
- [x] ビルド確認 (`pnpm --filter @repo/shared build`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)