### PR TITLE
docs(workflow): add Task Agent workflow planning documentation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -88,7 +88,9 @@
       "Skill(ai:create-component)",
       "Skill(ai:write-spec)",
       "Skill(ai:design-database)",
-      "Skill"
+      "Skill",
+      "mcp__context7__resolve-library-id",
+      "mcp__context7__query-docs"
     ],
     "deny": [],
     "ask": []

--- a/docs/30-workflows/unassigned-task/task-agent-00-index.md
+++ b/docs/30-workflows/unassigned-task/task-agent-00-index.md
@@ -1,0 +1,205 @@
+# エージェント機能 - タスク一覧とインデックス
+
+## 概要
+
+Claude CodeのClaude Agent SDKを使用したエージェント機能をアプリケーションに統合するためのタスク群。
+
+## 機能概要
+
+- サイドバーに「エージェント」メニューを追加
+- `.claude/skills/`配下のスキルを一覧表示し、必要なスキルを選択的にインポート
+- インポートしたスキルを管理・検索・フィルタリング
+- **Claude Agent SDK（`@anthropic-ai/claude-agent-sdk`）** を使用してスキルを実行
+  - ユーザーのClaude Codeサブスクリプションを自動利用
+  - Hooksシステムによる危険なコマンドのブロック
+  - Permission Controlによる宣言的権限ルール
+  - Permission Dialogによるユーザー承認フロー
+- エージェントとのチャット形式対話とストリーミング出力表示
+- HTMLプレビュー等のカスタム実行環境で成果物をリアルタイム確認
+
+## タスク一覧
+
+| #   | タスクID  | タスク名                       | 規模   | 優先度 |
+| --- | --------- | ------------------------------ | ------ | ------ |
+| 01  | AGENT-001 | エージェントダッシュボード基盤 | 中規模 | 高     |
+| 02  | AGENT-002 | スキル管理UI                   | 中規模 | 高     |
+| 03  | AGENT-003 | スキル管理バックエンド         | 中規模 | 高     |
+| 04  | AGENT-004 | エージェント実行UI             | 大規模 | 高     |
+| 05  | AGENT-005 | Claude Agent SDK統合           | 大規模 | 高     |
+| 06  | AGENT-006 | カスタム実行環境UI             | 大規模 | 中     |
+| 07  | AGENT-007 | 実行環境管理バックエンド       | 中規模 | 中     |
+
+## 依存関係マップ
+
+```
+レイヤー1（起点）
+└── task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    │
+レイヤー2（01完了後、並行実行可能）
+├── task-agent-02-skill-management-ui.md (AGENT-002)
+│
+└── task-agent-03-skill-management-backend.md (AGENT-003) ※02と並行可能
+    │
+    │
+レイヤー3（02,03完了後、並行実行可能）
+├── task-agent-04-execution-ui.md (AGENT-004)
+│
+└── task-agent-05-claude-code-integration.md (AGENT-005) ※04と並行可能
+    │
+    │
+レイヤー4（04,05完了後、並行実行可能）
+├── task-agent-06-custom-environment-ui.md (AGENT-006)
+│
+└── task-agent-07-environment-backend.md (AGENT-007) ※06と並行可能
+```
+
+## 並行実行グループ
+
+効率的に実装を進めるため、以下のグループで並行実行が可能です。
+
+### グループA（基盤）
+
+| タスク    | 依存 | 並行可能 |
+| --------- | ---- | -------- |
+| AGENT-001 | なし | -        |
+
+### グループB（スキル管理）
+
+| タスク    | 依存      | 並行可能        |
+| --------- | --------- | --------------- |
+| AGENT-002 | AGENT-001 | AGENT-003と並行 |
+| AGENT-003 | AGENT-001 | AGENT-002と並行 |
+
+### グループC（エージェント実行）
+
+| タスク    | 依存                 | 並行可能        |
+| --------- | -------------------- | --------------- |
+| AGENT-004 | AGENT-002, AGENT-003 | AGENT-005と並行 |
+| AGENT-005 | AGENT-003            | AGENT-004と並行 |
+
+### グループD（カスタム環境）
+
+| タスク    | 依存                 | 並行可能        |
+| --------- | -------------------- | --------------- |
+| AGENT-006 | AGENT-004, AGENT-005 | AGENT-007と並行 |
+| AGENT-007 | AGENT-005            | AGENT-006と並行 |
+
+## 推奨実行順序
+
+```
+Week 1:  AGENT-001
+Week 2:  AGENT-002 ║ AGENT-003 （並行）
+Week 3:  AGENT-004 ║ AGENT-005 （並行）
+Week 4:  AGENT-006 ║ AGENT-007 （並行）
+```
+
+## ファイル一覧
+
+| ファイル名                                  | 内容                           |
+| ------------------------------------------- | ------------------------------ |
+| `task-agent-00-index.md`                    | 本インデックス                 |
+| `task-agent-01-dashboard-foundation.md`     | エージェントダッシュボード基盤 |
+| `task-agent-02-skill-management-ui.md`      | スキル管理UI                   |
+| `task-agent-03-skill-management-backend.md` | スキル管理バックエンド         |
+| `task-agent-04-execution-ui.md`             | エージェント実行UI             |
+| `task-agent-05-claude-code-integration.md`  | Claude Agent SDK統合           |
+| `task-agent-06-custom-environment-ui.md`    | カスタム実行環境UI             |
+| `task-agent-07-environment-backend.md`      | 実行環境管理バックエンド       |
+
+## 成果物サマリー
+
+### フロントエンド（Renderer Process）
+
+| コンポーネント         | タスク     | パス                                           |
+| ---------------------- | ---------- | ---------------------------------------------- |
+| AgentView              | 01         | `views/AgentView/`                             |
+| agentSlice             | 01, 03, 04 | `store/slices/agentSlice.ts`                   |
+| SkillImportDialog      | 02         | `components/organisms/SkillImportDialog/`      |
+| SkillList              | 02         | `components/organisms/SkillList/`              |
+| SkillCard              | 02         | `components/molecules/SkillCard/`              |
+| SkillDetailPanel       | 02         | `components/organisms/SkillDetailPanel/`       |
+| AgentChatInterface     | 04         | `components/organisms/AgentChatInterface/`     |
+| AgentMessageInput      | 04         | `components/molecules/AgentMessageInput/`      |
+| PermissionDialog       | 04         | `components/organisms/PermissionDialog/`       |
+| SplitLayout            | 06         | `components/organisms/SplitLayout/`            |
+| HTMLPreviewEnvironment | 06         | `components/organisms/HTMLPreviewEnvironment/` |
+
+### バックエンド（Main Process）
+
+| サービス              | タスク | パス                                       |
+| --------------------- | ------ | ------------------------------------------ |
+| SkillScanner          | 03     | `services/skill/SkillScanner.ts`           |
+| SkillParser           | 03     | `services/skill/SkillParser.ts`            |
+| SkillImportManager    | 03     | `services/skill/SkillImportManager.ts`     |
+| SkillService          | 03     | `services/skill/SkillService.ts`           |
+| AgentExecutor         | 05     | `services/agent/AgentExecutor.ts`          |
+| ExecutionManager      | 05     | `services/agent/ExecutionManager.ts`       |
+| HooksFactory          | 05     | `services/agent/HooksFactory.ts`           |
+| PermissionRulesConfig | 05     | `services/agent/PermissionRules.ts`        |
+| ContentExtractor      | 07     | `services/environment/ContentExtractor.ts` |
+| ContentSanitizer      | 07     | `services/environment/ContentSanitizer.ts` |
+
+### 共有型定義
+
+| 型                    | タスク | パス                                 |
+| --------------------- | ------ | ------------------------------------ |
+| Skill                 | 02, 03 | `packages/shared/src/types/agent.ts` |
+| AgentMessage          | 04     | `packages/shared/src/types/agent.ts` |
+| PermissionRequest     | 04, 05 | `packages/shared/src/types/agent.ts` |
+| PermissionResponse    | 04, 05 | `packages/shared/src/types/agent.ts` |
+| AgentExecutionRequest | 05     | `packages/shared/src/types/agent.ts` |
+| AgentStreamMessage    | 05     | `packages/shared/src/types/agent.ts` |
+| AgentExecutionStatus  | 04, 05 | `packages/shared/src/types/agent.ts` |
+| PermissionRules       | 05     | `packages/shared/src/types/agent.ts` |
+| PreviewContent        | 06, 07 | `packages/shared/src/types/agent.ts` |
+
+## IPCチャネル一覧
+
+### スキル管理（AGENT-003）
+
+| チャネル                      | 方向   | 説明                         |
+| ----------------------------- | ------ | ---------------------------- |
+| `agent:scan-available-skills` | invoke | 利用可能スキル一覧取得       |
+| `agent:get-imported-skills`   | invoke | インポート済みスキル一覧取得 |
+| `agent:import-skills`         | invoke | スキルインポート             |
+| `agent:remove-skill`          | invoke | スキル削除                   |
+| `agent:get-skill-detail`      | invoke | スキル詳細取得               |
+
+### エージェント実行（AGENT-004, AGENT-005）
+
+| チャネル               | 方向            | 説明                           |
+| ---------------------- | --------------- | ------------------------------ |
+| `agent:start`          | Renderer → Main | SDK query() API実行開始        |
+| `agent:stop`           | Renderer → Main | 実行停止（AbortSignal）        |
+| `agent:stop-all`       | Renderer → Main | 全実行停止                     |
+| `agent:stream`         | Main → Renderer | SDKメッセージストリーム        |
+| `agent:status`         | Main → Renderer | 実行状態変更通知               |
+| `agent:permission`     | Main → Renderer | 権限確認要求（ダイアログ表示） |
+| `agent:permission:res` | Renderer → Main | 権限確認応答（許可/拒否）      |
+
+### カスタム環境（AGENT-007）
+
+| チャネル                    | 方向   | 説明                     |
+| --------------------------- | ------ | ------------------------ |
+| `agent:extract-content`     | invoke | コンテンツ抽出           |
+| `agent:get-preview-content` | invoke | プレビューコンテンツ取得 |
+
+## 開始方法
+
+1. `task-agent-01-dashboard-foundation.md`を読み、Phase 1から開始
+2. `/ai:task-specification-creator`スキルを使用してワークフローを管理
+3. Phase完了ごとに`artifacts.json`を更新
+4. 並行実行可能なタスクは複数開発者で分担可能
+
+## 関連ドキュメント
+
+- `.claude/skills/skill-list.md` - 既存スキル一覧
+- `.claude/skills/claude-agent-sdk/` - Claude Agent SDKスキル（SDK統合参照）
+  - `references/query-api.md` - query() API
+  - `references/hooks-system.md` - Hooksシステム
+  - `references/permission-control.md` - Permission Control
+  - `references/electron-ipc.md` - Electron IPC統合
+- `apps/desktop/src/renderer/store/` - Zustand store構造
+- `apps/desktop/src/main/ipc/` - IPC実装パターン
+- `apps/desktop/src/preload/channels.ts` - チャネル定義

--- a/docs/30-workflows/unassigned-task/task-agent-01-dashboard-foundation.md
+++ b/docs/30-workflows/unassigned-task/task-agent-01-dashboard-foundation.md
@@ -1,0 +1,449 @@
+# エージェントダッシュボード基盤 - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                           |
+| ------------ | ------------------------------ |
+| タスクID     | AGENT-001                      |
+| タスク名     | エージェントダッシュボード基盤 |
+| 分類         | 要件                           |
+| 対象機能     | エージェント機能               |
+| 優先度       | 高                             |
+| 見積もり規模 | 中規模                         |
+| ステータス   | 未実施                         |
+| 発見元       | ユーザー要求                   |
+| 発見日       | 2026-01-09                     |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001/本タスク) ← 起点
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002)
+    │
+    └──► task-agent-03-skill-management-backend.md (AGENT-003) ※02と並行可能
+              │
+              └──► task-agent-04-execution-ui.md (AGENT-004)
+                        │
+                        └──► ...
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                           |
+| ------------------------ | -------------------------------------------------------------- |
+| 直接依存                 | なし（起点タスク）                                             |
+| 並行実行可能             | なし                                                           |
+| 本タスク完了後に開始可能 | AGENT-002（スキル管理UI）, AGENT-003（スキル管理バックエンド） |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+Claude CodeのClaude Agent SDKを使用したエージェント機能をアプリケーションに統合するため、専用のダッシュボード画面が必要。現状はダッシュボード、エディタ、チャット、グラフ、設定の5つのビューのみ存在し、エージェント管理機能がない。
+
+### 1.2 問題点・課題
+
+- エージェント（スキル）を管理・実行するUIが存在しない
+- AppDockにエージェント用のナビゲーション項目がない
+- エージェント状態を管理するZustand sliceがない
+- エージェント関連のIPCチャネルが定義されていない
+
+### 1.3 放置した場合の影響
+
+- エージェント機能の統合が不可能
+- ユーザーがスキルベースのエージェントを活用できない
+- アプリケーションの拡張性が制限される
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+エージェント機能のためのフロントエンド基盤を構築し、ユーザーがエージェント画面にアクセスできるようにする。
+
+### 2.2 最終ゴール
+
+- サイドバー（AppDock）に「Agent」メニュー項目が表示される
+- 「Agent」をクリックするとAgentViewが表示される
+- agentSliceでエージェント状態が管理される
+- エージェント関連のIPCチャネルが定義されている
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- ViewType定義への「agent」追加
+- AppDockへのエージェントメニュー項目追加
+- AgentView基本コンポーネントの実装
+- agentSlice（Zustand）の実装
+- IPC_CHANNELS定義の追加
+- ルーティング設定の更新
+
+#### 含まないもの
+
+- スキル一覧表示機能（別タスク: AGENT-002）
+- エージェント実行機能（別タスク: AGENT-003）
+- カスタム実行環境（別タスク: AGENT-004）
+- バックエンド実装（別タスク: AGENT-005〜008）
+
+### 2.4 成果物
+
+| 成果物       | パス                                                               |
+| ------------ | ------------------------------------------------------------------ |
+| ViewType更新 | `apps/desktop/src/renderer/store/slices/navigationSlice.ts`        |
+| AgentView    | `apps/desktop/src/renderer/views/AgentView/index.tsx`              |
+| agentSlice   | `apps/desktop/src/renderer/store/slices/agentSlice.ts`             |
+| AppDock更新  | `apps/desktop/src/renderer/components/organisms/AppDock/index.tsx` |
+| IPCチャネル  | `apps/desktop/src/preload/channels.ts`                             |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- 既存のZustand store構造を理解している
+- 既存のViewパターンを理解している
+- IPC通信パターンを理解している
+
+### 3.2 依存タスク
+
+なし（最初に実行するタスク）
+
+### 3.3 必要な知識・スキル
+
+- React/TypeScript
+- Zustand状態管理
+- Electron IPC通信
+- Atomic Design
+
+### 3.4 推奨アプローチ
+
+1. ViewType定義を拡張
+2. agentSliceを作成
+3. AgentViewの基本骨格を実装
+4. AppDockにナビゲーション項目を追加
+5. IPCチャネルを定義
+6. App.tsxのルーティングを更新
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+**実行方法**: 各スキルのSKILL.mdを読み込み、スキルを参照して実行
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: エージェントダッシュボード基盤
+
+Scenario: AppDockにエージェントメニューが表示される
+  Given ユーザーがアプリケーションにログインしている
+  When メインダッシュボード画面を表示する
+  Then AppDockに「Agent」アイコンが表示される
+  And アイコンにホバーすると「Agent」ラベルが表示される
+
+Scenario: エージェント画面に遷移できる
+  Given ユーザーがメインダッシュボード画面を表示している
+  When AppDockの「Agent」アイコンをクリックする
+  Then AgentViewが表示される
+  And currentViewが「agent」に更新される
+
+Scenario: キーボードショートカットでエージェント画面に遷移できる
+  Given ユーザーがアプリケーションを操作している
+  When Cmd+5（Mac）またはCtrl+5（Win/Linux）を押下する
+  Then AgentViewが表示される
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] スコープが明確に定義されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由             |
+| ----------------- | ------------------------------------------- | -------------------- |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | UIコンポーネント設計 |
+
+#### 設計内容
+
+**1. ViewType拡張**
+
+```typescript
+// navigationSlice.ts
+export type ViewType =
+  | "dashboard"
+  | "editor"
+  | "chat"
+  | "graph"
+  | "settings"
+  | "agent";
+```
+
+**2. agentSlice構造**
+
+```typescript
+// agentSlice.ts
+export interface AgentSlice {
+  // スキル一覧
+  skills: Skill[];
+  selectedSkill: Skill | null;
+
+  // 実行状態
+  isExecuting: boolean;
+  executionOutput: string[];
+  executionError: string | null;
+
+  // フィルタリング
+  skillFilter: string;
+  skillCategory: string | null;
+
+  // アクション
+  setSkills: (skills: Skill[]) => void;
+  selectSkill: (skill: Skill | null) => void;
+  setExecuting: (isExecuting: boolean) => void;
+  appendOutput: (output: string) => void;
+  setError: (error: string | null) => void;
+  clearExecution: () => void;
+  setSkillFilter: (filter: string) => void;
+  setSkillCategory: (category: string | null) => void;
+}
+
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  triggers: string[];
+  anchors: Anchor[];
+  category?: string;
+}
+
+export interface Anchor {
+  source: string;
+  application: string;
+  purpose: string;
+}
+```
+
+**3. IPCチャネル定義**
+
+```typescript
+// channels.ts に追加
+// Agent関連
+AGENT_GET_SKILLS: "agent:get-skills",
+AGENT_GET_SKILL_DETAIL: "agent:get-skill-detail",
+AGENT_EXECUTE: "agent:execute",
+AGENT_STOP: "agent:stop",
+AGENT_STREAM_CHUNK: "agent:stream-chunk",
+AGENT_STREAM_END: "agent:stream-end",
+AGENT_STREAM_ERROR: "agent:stream-error",
+```
+
+**4. AppDock更新**
+
+```typescript
+// AppDock/index.tsx navItemsに追加
+{ id: "agent", icon: "bot", label: "Agent", shortcut: "Cmd+5" },
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] コンポーネント構造が設計されている
+- [ ] IPCチャネルが設計されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### 完了条件
+
+- [ ] 設計が既存パターンと整合している
+- [ ] 重大な設計問題がない
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// agentSlice.test.ts
+describe("agentSlice", () => {
+  it("should set skills", () => {});
+  it("should select skill", () => {});
+  it("should set executing state", () => {});
+  it("should append output", () => {});
+  it("should clear execution", () => {});
+});
+
+// AgentView.test.tsx
+describe("AgentView", () => {
+  it("should render without crashing", () => {});
+  it("should display loading state when skills are loading", () => {});
+  it("should display empty state when no skills", () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] agentSliceのユニットテストがある
+- [ ] AgentViewのコンポーネントテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名        | パス                                      | 選定理由           |
+| --------------- | ----------------------------------------- | ------------------ |
+| domain-modeling | `.claude/skills/domain-modeling/SKILL.md` | ドメインモデル設計 |
+
+#### 実装ファイル
+
+1. `apps/desktop/src/renderer/store/slices/agentSlice.ts`
+2. `apps/desktop/src/renderer/views/AgentView/index.tsx`
+3. `apps/desktop/src/renderer/components/organisms/AppDock/index.tsx`（更新）
+4. `apps/desktop/src/renderer/store/slices/navigationSlice.ts`（更新）
+5. `apps/desktop/src/preload/channels.ts`（更新）
+6. `apps/desktop/src/renderer/App.tsx`（更新）
+
+#### 完了条件
+
+- [ ] agentSliceが実装されている
+- [ ] AgentViewが表示される
+- [ ] AppDockにAgentアイコンが表示される
+- [ ] ナビゲーションが動作する
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] AppDockに「Agent」メニュー項目が表示される
+- [ ] 「Agent」クリックでAgentViewに遷移する
+- [ ] Cmd+5/Ctrl+5でAgentViewに遷移する
+- [ ] agentSliceで状態管理ができる
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### ドキュメント要件
+
+- [ ] コンポーネントにJSDocコメントがある
+- [ ] 実装ガイドが作成されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/renderer/store/slices/agentSlice.test.ts
+
+# コンポーネントテスト
+pnpm --filter @repo/desktop test src/renderer/views/AgentView/
+```
+
+### 検証手順
+
+1. アプリを起動
+2. AppDockに「Agent」アイコンが表示されることを確認
+3. アイコンをクリックしてAgentViewに遷移することを確認
+4. Cmd+5でAgentViewに遷移することを確認
+
+---
+
+## 7. リスクと対策
+
+| リスク                     | 影響度 | 発生確率 | 対策                             |
+| -------------------------- | ------ | -------- | -------------------------------- |
+| 既存ナビゲーションとの競合 | 中     | 低       | 既存パターンに厳密に従う         |
+| Store永続化の問題          | 中     | 低       | partializeで適切にフィルタリング |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `apps/desktop/src/renderer/store/index.ts` - Store構造
+- `apps/desktop/src/renderer/views/DashboardView/index.tsx` - View実装例
+- `apps/desktop/src/renderer/components/organisms/AppDock/index.tsx` - AppDock実装
+- `apps/desktop/src/preload/channels.ts` - IPCチャネル定義
+
+### 参考資料
+
+- [Zustand Documentation](https://docs.pmnd.rs/zustand/getting-started/introduction)
+- [Electron IPC](https://www.electronjs.org/docs/latest/tutorial/ipc)
+
+---
+
+## 9. 備考
+
+### 補足事項
+
+- 本タスクはエージェント機能シリーズの最初のタスク
+- 後続タスク（AGENT-002〜008）の基盤となる
+- アイコンは`bot`（Lucide Icons）を使用

--- a/docs/30-workflows/unassigned-task/task-agent-02-skill-management-ui.md
+++ b/docs/30-workflows/unassigned-task/task-agent-02-skill-management-ui.md
@@ -1,0 +1,521 @@
+# スキル管理UI - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容             |
+| ------------ | ---------------- |
+| タスクID     | AGENT-002        |
+| タスク名     | スキル管理UI     |
+| 分類         | 要件             |
+| 対象機能     | エージェント機能 |
+| 優先度       | 高               |
+| 見積もり規模 | 中規模           |
+| ステータス   | 未実施           |
+| 発見元       | ユーザー要求     |
+| 発見日       | 2026-01-09       |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002/本タスク)
+    │
+    └──► task-agent-03-skill-management-backend.md (AGENT-003) ※本タスクと並行可能
+              │
+              └──► task-agent-04-execution-ui.md (AGENT-004)
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                         |
+| ------------------------ | ------------------------------------------------------------ |
+| 直接依存                 | AGENT-001（エージェントダッシュボード基盤）                  |
+| 並行実行可能             | AGENT-003（スキル管理バックエンド）※モックデータで並行開発可 |
+| 本タスク完了後に開始可能 | AGENT-004（エージェント実行UI）                              |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+Claude Codeの`.claude/skills/`ディレクトリに存在するスキルをユーザーが視覚的に確認・選択・管理できるUIが必要。現状、スキルはCLI経由でのみアクセス可能で、GUIからの管理機能がない。
+
+### 1.2 問題点・課題
+
+- スキルの一覧を確認するUIがない
+- スキルの詳細情報（Trigger、Anchor、説明）を表示する手段がない
+- スキルを検索・フィルタリングする機能がない
+- スキルを選択して実行する導線がない
+
+### 1.3 放置した場合の影響
+
+- ユーザーが利用可能なスキルを把握できない
+- スキル選択が困難になり、エージェント機能の利用率が低下
+- スキル管理のためにCLIへ戻る必要があり、UXが悪化
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+AgentView内にスキルインポート・一覧・検索・詳細表示機能を実装し、ユーザーが必要なスキルを選択的にインポートして管理・実行できるようにする。
+
+### 2.2 最終ゴール
+
+- `.claude/skills/`から利用可能なスキルを一覧表示し、インポートするスキルを選択できる
+- インポート済みスキルがカード形式で表示される
+- スキルを名前・Triggerキーワードで検索できる
+- スキルをカテゴリでフィルタリングできる
+- スキルをクリックすると詳細パネルが表示される
+- 詳細パネルから実行画面へ遷移できる
+- インポートしたスキル設定が永続化される
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- SkillImportDialogコンポーネント（スキルインポート選択ダイアログ）
+- SkillListコンポーネント（インポート済みカード一覧）
+- SkillCardコンポーネント（個別カード）
+- SkillDetailPanelコンポーネント（詳細表示）
+- SkillSearchBarコンポーネント（検索バー）
+- SkillCategoryFilterコンポーネント（カテゴリフィルター）
+- スキルインポート/削除のIPC呼び出し
+- インポート設定の永続化
+
+#### 含まないもの
+
+- スキル実行機能（別タスク: AGENT-004）
+- スキル編集機能（スコープ外）
+- スキル新規作成機能（スコープ外）
+- バックエンド実装（別タスク: AGENT-003）
+
+### 2.4 成果物
+
+| 成果物              | パス                                                                           |
+| ------------------- | ------------------------------------------------------------------------------ |
+| SkillImportDialog   | `apps/desktop/src/renderer/components/organisms/SkillImportDialog/index.tsx`   |
+| SkillList           | `apps/desktop/src/renderer/components/organisms/SkillList/index.tsx`           |
+| SkillCard           | `apps/desktop/src/renderer/components/molecules/SkillCard/index.tsx`           |
+| SkillDetailPanel    | `apps/desktop/src/renderer/components/organisms/SkillDetailPanel/index.tsx`    |
+| SkillSearchBar      | `apps/desktop/src/renderer/components/molecules/SkillSearchBar/index.tsx`      |
+| SkillCategoryFilter | `apps/desktop/src/renderer/components/molecules/SkillCategoryFilter/index.tsx` |
+| AgentView更新       | `apps/desktop/src/renderer/views/AgentView/index.tsx`                          |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-001（エージェントダッシュボード基盤）が完了している
+- AGENT-005（スキル管理バックエンド）が完了している、またはモックデータで開発
+
+### 3.2 依存タスク
+
+- AGENT-001: エージェントダッシュボード基盤
+- AGENT-005: スキル管理バックエンド（並行開発可能、モック使用）
+
+### 3.3 必要な知識・スキル
+
+- React/TypeScript
+- Atomic Design（molecules/organisms）
+- Tailwind CSS
+- Zustand状態管理
+
+### 3.4 推奨アプローチ
+
+1. Skill型定義を共有パッケージに追加
+2. モックデータでUIコンポーネントを先行開発
+3. SkillCardから実装開始（最小単位）
+4. SkillListでカード一覧を構成
+5. 検索・フィルター機能を追加
+6. SkillDetailPanelを実装
+7. AgentViewに統合
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: スキル管理UI
+
+Scenario: スキルインポートダイアログを開く
+  Given ユーザーがAgentViewを開いている
+  When 「スキルをインポート」ボタンをクリックする
+  Then スキルインポートダイアログが表示される
+  And .claude/skills/配下の利用可能なスキル一覧が表示される
+
+Scenario: スキルを選択してインポートする
+  Given スキルインポートダイアログが表示されている
+  And 3つのスキルにチェックを入れている
+  When 「インポート」ボタンをクリックする
+  Then 選択した3つのスキルがインポートされる
+  And AgentViewのスキル一覧に追加される
+  And インポート設定が永続化される
+
+Scenario: インポート済みスキル一覧が表示される
+  Given ユーザーがAgentViewを開いている
+  And 5件のスキルがインポート済みである
+  When 画面が読み込まれる
+  Then インポート済みスキルがカード形式で一覧表示される
+  And 各カードにスキル名と説明が表示される
+
+Scenario: スキルを名前で検索できる
+  Given ユーザーがスキル一覧を表示している
+  When 検索バーに「tdd」と入力する
+  Then 名前またはTriggerに「tdd」を含むスキルのみ表示される
+
+Scenario: スキルをカテゴリでフィルタリングできる
+  Given ユーザーがスキル一覧を表示している
+  When カテゴリフィルターで「テスト」を選択する
+  Then テストカテゴリのスキルのみ表示される
+
+Scenario: スキル詳細を表示できる
+  Given ユーザーがスキル一覧を表示している
+  When スキルカードをクリックする
+  Then 右側にスキル詳細パネルが表示される
+  And スキル名、説明、Trigger、Anchorsが表示される
+
+Scenario: スキル詳細から実行画面へ遷移できる
+  Given ユーザーがスキル詳細パネルを表示している
+  When 「実行」ボタンをクリックする
+  Then エージェント実行画面に遷移する
+  And 選択したスキルが実行対象として設定される
+
+Scenario: インポート済みスキルを削除できる
+  Given ユーザーがスキル詳細パネルを表示している
+  When 「削除」ボタンをクリックする
+  And 確認ダイアログで「はい」を選択する
+  Then スキルがインポート一覧から削除される
+  And 設定が永続化される
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] UIワイヤーフレームが作成されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由                         |
+| ----------------- | ------------------------------------------- | -------------------------------- |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | レスポンシブUIコンポーネント設計 |
+| domain-modeling   | `.claude/skills/domain-modeling/SKILL.md`   | Skillドメインモデル設計          |
+
+#### 設計内容
+
+**1. Skill型定義（packages/shared）**
+
+```typescript
+// packages/shared/src/types/agent.ts
+export interface Skill {
+  id: string; // ユニーク識別子（パスのハッシュ）
+  name: string; // スキル名（SKILL.md解析）
+  slug: string; // ディレクトリ名
+  description: string; // 概要説明
+  path: string; // .claude/skills/xxx/SKILL.md
+  triggers: string[]; // Triggerキーワード
+  anchors: Anchor[]; // Anchor一覧
+  category?: string; // カテゴリ（推論または手動設定）
+  lastUpdated?: string; // 最終更新日
+}
+
+export interface Anchor {
+  source: string; // 参考文献名
+  application: string; // 適用方法
+  purpose: string; // 目的
+}
+
+export interface SkillExecutionRequest {
+  skillId: string;
+  args?: string;
+  workingDirectory?: string;
+}
+
+export interface SkillExecutionResult {
+  success: boolean;
+  output: string[];
+  error?: string;
+  exitCode?: number;
+}
+```
+
+**2. コンポーネント構造**
+
+```
+AgentView
+├── SkillSearchBar (molecule)
+├── SkillCategoryFilter (molecule)
+├── SkillList (organism)
+│   └── SkillCard[] (molecule)
+└── SkillDetailPanel (organism)
+    ├── SkillHeader
+    ├── SkillDescription
+    ├── SkillTriggers
+    ├── SkillAnchors
+    └── ExecuteButton
+```
+
+**3. レイアウト設計**
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Agent Dashboard                                              │
+├──────────────────────────────────────────────────────────────┤
+│ [🔍 Search skills...        ] [Category ▼]                   │
+├────────────────────────────────────┬─────────────────────────┤
+│ ┌──────────┐ ┌──────────┐ ┌──────┐│ Skill Details           │
+│ │ Skill 1  │ │ Skill 2  │ │ ...  ││                         │
+│ │ desc...  │ │ desc...  │ │      ││ Name: tdd-principles    │
+│ └──────────┘ └──────────┘ └──────┘│ Description: ...        │
+│ ┌──────────┐ ┌──────────┐         │ Triggers: tdd, test...  │
+│ │ Skill 4  │ │ Skill 5  │         │ Anchors:                │
+│ │ desc...  │ │ desc...  │         │  - Clean Code           │
+│ └──────────┘ └──────────┘         │  - TDD by Example       │
+│                                   │                         │
+│                                   │ [🚀 Execute]            │
+└────────────────────────────────────┴─────────────────────────┘
+```
+
+**4. SkillCardコンポーネント**
+
+```typescript
+interface SkillCardProps {
+  skill: Skill;
+  isSelected: boolean;
+  onClick: () => void;
+}
+```
+
+**5. agentSlice更新**
+
+```typescript
+// agentSlice.ts に追加
+isLoadingSkills: boolean;
+skillLoadError: string | null;
+fetchSkills: () => Promise<void>;
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+- UIワイヤーフレーム
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] コンポーネント構造が設計されている
+- [ ] レイアウトが設計されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由             |
+| -------------------- | ---------------------------------------------- | -------------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック     |
+| accessibility-wcag   | `.claude/skills/accessibility-wcag/SKILL.md`   | アクセシビリティ確認 |
+
+#### 完了条件
+
+- [ ] Atomic Design原則に従っている
+- [ ] アクセシビリティ要件を満たしている
+- [ ] レスポンシブ設計されている
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// SkillCard.test.tsx
+describe("SkillCard", () => {
+  it("should display skill name and description", () => {});
+  it("should highlight when selected", () => {});
+  it("should call onClick when clicked", () => {});
+  it("should display trigger badges", () => {});
+});
+
+// SkillList.test.tsx
+describe("SkillList", () => {
+  it("should render skill cards", () => {});
+  it("should display loading state", () => {});
+  it("should display empty state when no skills", () => {});
+  it("should filter skills by search term", () => {});
+  it("should filter skills by category", () => {});
+});
+
+// SkillDetailPanel.test.tsx
+describe("SkillDetailPanel", () => {
+  it("should display skill details", () => {});
+  it("should display anchors list", () => {});
+  it("should call onExecute when button clicked", () => {});
+});
+
+// SkillSearchBar.test.tsx
+describe("SkillSearchBar", () => {
+  it("should update filter on input", () => {});
+  it("should debounce input", () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 各コンポーネントのユニットテストがある
+- [ ] フィルタリングロジックのテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由           |
+| ----------------- | ------------------------------------------- | ------------------ |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | レスポンシブUI実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`
+2. `apps/desktop/src/renderer/components/molecules/SkillCard/index.tsx`
+3. `apps/desktop/src/renderer/components/molecules/SkillSearchBar/index.tsx`
+4. `apps/desktop/src/renderer/components/molecules/SkillCategoryFilter/index.tsx`
+5. `apps/desktop/src/renderer/components/organisms/SkillList/index.tsx`
+6. `apps/desktop/src/renderer/components/organisms/SkillDetailPanel/index.tsx`
+7. `apps/desktop/src/renderer/views/AgentView/index.tsx`（更新）
+8. `apps/desktop/src/renderer/store/slices/agentSlice.ts`（更新）
+
+#### 完了条件
+
+- [ ] 全コンポーネントが実装されている
+- [ ] スキル一覧が表示される
+- [ ] 検索・フィルタリングが動作する
+- [ ] 詳細パネルが表示される
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] スキル一覧がカード形式で表示される
+- [ ] スキルを名前・Triggerで検索できる
+- [ ] スキルをカテゴリでフィルタリングできる
+- [ ] スキル詳細パネルが表示される
+- [ ] 「実行」ボタンから実行画面へ遷移できる
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+- [ ] WCAGアクセシビリティ基準を満たす
+
+### ドキュメント要件
+
+- [ ] コンポーネントにJSDocコメントがある
+- [ ] Storybookストーリーがある（任意）
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/renderer/components/molecules/SkillCard/
+pnpm --filter @repo/desktop test src/renderer/components/organisms/SkillList/
+pnpm --filter @repo/desktop test src/renderer/components/organisms/SkillDetailPanel/
+```
+
+### 検証手順
+
+1. AgentViewを開く
+2. スキル一覧が表示されることを確認
+3. 検索バーに文字を入力してフィルタリングされることを確認
+4. カテゴリフィルターでフィルタリングされることを確認
+5. スキルカードをクリックして詳細パネルが表示されることを確認
+6. 「実行」ボタンをクリックして実行画面へ遷移することを確認
+
+---
+
+## 7. リスクと対策
+
+| リスク                                 | 影響度 | 発生確率 | 対策                           |
+| -------------------------------------- | ------ | -------- | ------------------------------ |
+| スキルが大量にある場合のパフォーマンス | 中     | 中       | 仮想スクロール実装を検討       |
+| SKILL.md形式の不統一                   | 中     | 高       | 堅牢なパーサーと fallback 実装 |
+| モバイル表示での詳細パネル             | 低     | 中       | モーダル表示に切り替え         |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `.claude/skills/skill-list.md` - 既存スキル一覧
+- `apps/desktop/src/renderer/components/` - 既存コンポーネント参照
+- `apps/desktop/src/renderer/views/DashboardView/` - 類似ビュー実装例
+
+### 参考資料
+
+- [Tailwind CSS](https://tailwindcss.com/docs)
+- [Lucide Icons](https://lucide.dev/icons/)
+
+---
+
+## 9. 備考
+
+### 補足事項
+
+- スキルカードのデザインはGlassPanelスタイルを踏襲
+- カテゴリは自動推論（Triggerキーワードベース）+ 手動オーバーライド
+- 検索はdebounce 300ms で実装

--- a/docs/30-workflows/unassigned-task/task-agent-03-skill-management-backend.md
+++ b/docs/30-workflows/unassigned-task/task-agent-03-skill-management-backend.md
@@ -1,0 +1,601 @@
+# スキル管理バックエンド - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                   |
+| ------------ | ---------------------- |
+| タスクID     | AGENT-003              |
+| タスク名     | スキル管理バックエンド |
+| 分類         | 要件                   |
+| 対象機能     | エージェント機能       |
+| 優先度       | 高                     |
+| 見積もり規模 | 中規模                 |
+| ステータス   | 未実施                 |
+| 発見元       | ユーザー要求           |
+| 発見日       | 2026-01-09             |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002) ※本タスクと並行可能
+    │
+    └──► task-agent-03-skill-management-backend.md (AGENT-003/本タスク)
+              │
+              └──► task-agent-04-execution-ui.md (AGENT-004)
+                        │
+              └──► task-agent-05-claude-code-integration.md (AGENT-005) ※04と並行可能
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                          |
+| ------------------------ | ------------------------------------------------------------- |
+| 直接依存                 | AGENT-001（エージェントダッシュボード基盤）                   |
+| 並行実行可能             | AGENT-002（スキル管理UI）※フロントはモックで並行開発可        |
+| 本タスク完了後に開始可能 | AGENT-004（エージェント実行UI）, AGENT-005（Claude Code統合） |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+フロントエンドからスキル情報を取得するためのバックエンド（Main Process）実装が必要。`.claude/skills/`ディレクトリ内のスキルを読み込み、SKILL.mdを解析してメタデータを抽出し、IPC経由でRendererに提供する。
+
+### 1.2 問題点・課題
+
+- スキルディレクトリを読み込むMain Process側の実装がない
+- SKILL.mdファイルを解析するパーサーがない
+- エージェント関連のIPCハンドラーが存在しない
+- スキルメタデータのキャッシュ機構がない
+
+### 1.3 放置した場合の影響
+
+- フロントエンドがスキル情報を取得できない
+- エージェント機能全体が動作不能
+- スキル管理UIが機能しない
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+Main ProcessでClaude Codeのスキルを読み込み・解析し、ユーザーが選択したスキルをインポート・管理する機能を実装する。インポート設定は永続化され、アプリ再起動後も維持される。
+
+### 2.2 最終ゴール
+
+- `.claude/skills/`ディレクトリから利用可能なスキル一覧を取得できる
+- SKILL.mdを解析してメタデータ（名前、説明、Trigger、Anchor）を抽出できる
+- ユーザーが選択したスキルをインポート・削除できる
+- インポート設定がローカルストレージに永続化される
+- IPC経由でスキル一覧・詳細・インポート管理ができる
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- スキルディレクトリスキャナー（利用可能スキル一覧取得）
+- SKILL.mdパーサー
+- スキルインポート管理サービス
+- インポート設定の永続化（electron-store）
+- IPCハンドラー
+  - `agent:scan-available-skills` - 利用可能スキル一覧取得
+  - `agent:get-imported-skills` - インポート済みスキル一覧取得
+  - `agent:import-skills` - スキルインポート
+  - `agent:remove-skill` - スキル削除
+  - `agent:get-skill-detail` - スキル詳細取得
+- スキルメタデータキャッシュ
+- スキルパス設定（設定可能）
+
+#### 含まないもの
+
+- スキル実行機能（別タスク: AGENT-005）
+- 実行環境管理（別タスク: AGENT-007）
+- スキル編集・作成機能（スコープ外）
+
+### 2.4 成果物
+
+| 成果物             | パス                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| SkillScanner       | `apps/desktop/src/main/services/skill/SkillScanner.ts`       |
+| SkillParser        | `apps/desktop/src/main/services/skill/SkillParser.ts`        |
+| SkillImportManager | `apps/desktop/src/main/services/skill/SkillImportManager.ts` |
+| SkillService       | `apps/desktop/src/main/services/skill/SkillService.ts`       |
+| agentHandlers      | `apps/desktop/src/main/ipc/agentHandlers.ts`                 |
+| IPCチャネル更新    | `apps/desktop/src/preload/channels.ts`                       |
+| 型定義             | `packages/shared/src/types/agent.ts`                         |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-001（エージェントダッシュボード基盤）でIPCチャネルが定義されている
+- `.claude/skills/`ディレクトリの構造を理解している
+
+### 3.2 依存タスク
+
+- AGENT-001: エージェントダッシュボード基盤（IPCチャネル定義）
+
+### 3.3 必要な知識・スキル
+
+- Node.js / TypeScript
+- ファイルシステム操作
+- Markdown解析
+- Electron IPC
+
+### 3.4 推奨アプローチ
+
+1. 型定義をpackages/sharedに追加
+2. SkillScannerを実装（ディレクトリスキャン）
+3. SkillParserを実装（SKILL.md解析）
+4. SkillServiceで統合（キャッシュ含む）
+5. agentHandlersでIPC公開
+6. Preloadのホワイトリスト更新
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: スキル管理バックエンド
+
+Scenario: 利用可能なスキル一覧を取得できる
+  Given アプリケーションが起動している
+  And .claude/skills/ ディレクトリに10個のスキルが存在する
+  When Rendererがagent:scan-available-skillsを呼び出す
+  Then 10個のスキルメタデータが返される
+  And 各スキルにはid, name, description, path, triggersが含まれる
+
+Scenario: スキルをインポートできる
+  Given 利用可能なスキル一覧が取得済みである
+  And スキルIDの配列を指定する
+  When Rendererがagent:import-skills { skillIds }を呼び出す
+  Then 指定したスキルがインポートされる
+  And インポート設定がelectron-storeに永続化される
+
+Scenario: インポート済みスキル一覧を取得できる
+  Given 3つのスキルがインポート済みである
+  When Rendererがagent:get-imported-skillsを呼び出す
+  Then インポート済みの3つのスキルのみ返される
+
+Scenario: インポート済みスキルを削除できる
+  Given スキルがインポート済みである
+  When Rendererがagent:remove-skill { skillId }を呼び出す
+  Then スキルがインポート一覧から削除される
+  And 設定が永続化される
+
+Scenario: スキル詳細を取得できる
+  Given スキルがインポート済みである
+  When Rendererがagent:get-skill-detail { skillId }を呼び出す
+  Then 指定したスキルの詳細情報が返される
+  And anchorsの配列が含まれる
+
+Scenario: SKILL.mdがないディレクトリは除外される
+  Given .claude/skills/に無効なディレクトリがある（SKILL.mdなし）
+  When 利用可能スキル一覧を取得する
+  Then 無効なディレクトリは結果に含まれない
+
+Scenario: アプリ再起動後もインポート設定が維持される
+  Given 5つのスキルがインポート済みである
+  When アプリケーションを再起動する
+  And インポート済みスキル一覧を取得する
+  Then 同じ5つのスキルが返される
+
+Scenario: スキルパスを設定できる
+  Given 設定画面でスキルパスを変更する
+  When 利用可能スキル一覧を取得する
+  Then 指定されたパスからスキルが読み込まれる
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] SKILL.mdのフォーマット仕様が明確化されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名           | パス                                         | 選定理由                 |
+| ------------------ | -------------------------------------------- | ------------------------ |
+| domain-modeling    | `.claude/skills/domain-modeling/SKILL.md`    | スキルドメインモデル設計 |
+| transaction-script | `.claude/skills/transaction-script/SKILL.md` | サービス層設計           |
+
+#### 設計内容
+
+**1. 型定義（packages/shared）**
+
+```typescript
+// packages/shared/src/types/agent.ts
+
+export interface Skill {
+  id: string; // パスから生成したハッシュ
+  name: string; // SKILL.md内の# タイトル
+  slug: string; // ディレクトリ名
+  description: string; // ## 概要 セクション
+  path: string; // SKILL.mdへの絶対パス
+  triggers: string[]; // Trigger: キーワード
+  anchors: Anchor[]; // Anchors セクション
+  category?: string; // カテゴリ（推論）
+  environment?: EnvironmentConfig;
+  lastModified: Date;
+}
+
+export interface Anchor {
+  source: string; // 文献名
+  application: string; // 適用方法
+  purpose: string; // 目的
+}
+
+export interface SkillScanResult {
+  skills: Skill[];
+  errors: SkillScanError[];
+  scannedAt: Date;
+}
+
+export interface SkillScanError {
+  path: string;
+  error: string;
+}
+```
+
+**2. SKILL.md解析仕様**
+
+```markdown
+# スキル名
+
+<!-- ↑ name として抽出 -->
+
+## 概要
+
+<!-- description として抽出 -->
+
+## Anchors
+
+<!-- テーブル形式で解析 -->
+
+| Source     | Application | Purpose |
+| ---------- | ----------- | ------- |
+| Clean Code | ...         | ...     |
+
+## Trigger
+
+<!-- キーワードリストとして解析 -->
+
+keyword1, keyword2, keyword3
+
+## Environment
+
+<!-- 実行環境設定 -->
+
+| Type | AutoRefresh | Debounce |
+| ---- | ----------- | -------- |
+| html | true        | 500ms    |
+```
+
+**3. クラス設計**
+
+```typescript
+// SkillScanner.ts
+export class SkillScanner {
+  constructor(private basePath: string) {}
+
+  async scanDirectory(): Promise<string[]> {
+    // .claude/skills/ 配下のディレクトリを列挙
+    // SKILL.md が存在するディレクトリのみ返す
+  }
+}
+
+// SkillParser.ts
+export class SkillParser {
+  async parse(skillMdPath: string): Promise<Skill> {
+    // SKILL.md を読み込み、Skill オブジェクトに変換
+  }
+
+  private parseAnchors(content: string): Anchor[] {}
+  private parseTriggers(content: string): string[] {}
+  private parseEnvironment(content: string): EnvironmentConfig | undefined {}
+}
+
+// SkillService.ts
+export class SkillService {
+  private cache: Map<string, Skill> = new Map();
+  private lastScanTime: Date | null = null;
+
+  constructor(
+    private scanner: SkillScanner,
+    private parser: SkillParser,
+  ) {}
+
+  async getAllSkills(forceRefresh = false): Promise<SkillScanResult> {}
+  async getSkillById(id: string): Promise<Skill | null> {}
+  clearCache(): void {}
+}
+```
+
+**4. IPCハンドラー設計**
+
+```typescript
+// agentHandlers.ts
+export function registerAgentHandlers(): void {
+  // agent:get-skills
+  ipcMain.handle(IPC_CHANNELS.AGENT_GET_SKILLS, async () => {
+    return skillService.getAllSkills();
+  });
+
+  // agent:get-skill-detail
+  ipcMain.handle(
+    IPC_CHANNELS.AGENT_GET_SKILL_DETAIL,
+    async (_e, { skillId }) => {
+      return skillService.getSkillById(skillId);
+    },
+  );
+
+  // agent:refresh-skills
+  ipcMain.handle(IPC_CHANNELS.AGENT_REFRESH_SKILLS, async () => {
+    skillService.clearCache();
+    return skillService.getAllSkills(true);
+  });
+}
+```
+
+**5. IPCチャネル定義**
+
+```typescript
+// channels.ts に追加
+AGENT_GET_SKILLS: "agent:get-skills",
+AGENT_GET_SKILL_DETAIL: "agent:get-skill-detail",
+AGENT_REFRESH_SKILLS: "agent:refresh-skills",
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+- クラス図
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] クラス設計が完成している
+- [ ] SKILL.md解析仕様が定義されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### 完了条件
+
+- [ ] 既存のMain Processパターンと整合している
+- [ ] セキュリティ（パストラバーサル対策）が考慮されている
+- [ ] エラーハンドリングが設計されている
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// SkillScanner.test.ts
+describe("SkillScanner", () => {
+  it("should find directories with SKILL.md", async () => {});
+  it("should ignore directories without SKILL.md", async () => {});
+  it("should handle empty directory", async () => {});
+  it("should handle non-existent base path", async () => {});
+});
+
+// SkillParser.test.ts
+describe("SkillParser", () => {
+  it("should parse skill name from h1", async () => {});
+  it("should parse description from 概要 section", async () => {});
+  it("should parse anchors table", async () => {});
+  it("should parse trigger keywords", async () => {});
+  it("should parse environment config", async () => {});
+  it("should handle missing sections gracefully", async () => {});
+  it("should generate consistent id from path", async () => {});
+});
+
+// SkillService.test.ts
+describe("SkillService", () => {
+  it("should return all skills", async () => {});
+  it("should cache skills after first fetch", async () => {});
+  it("should force refresh when requested", async () => {});
+  it("should return skill by id", async () => {});
+  it("should return null for unknown id", async () => {});
+  it("should collect errors for invalid skills", async () => {});
+});
+
+// agentHandlers.test.ts
+describe("agentHandlers", () => {
+  it("should handle agent:get-skills", async () => {});
+  it("should handle agent:get-skill-detail", async () => {});
+  it("should handle agent:refresh-skills", async () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 各クラス/関数のユニットテストがある
+- [ ] IPCハンドラーのテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名        | パス                                      | 選定理由     |
+| --------------- | ----------------------------------------- | ------------ |
+| domain-modeling | `.claude/skills/domain-modeling/SKILL.md` | サービス実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`
+2. `apps/desktop/src/main/services/skill/SkillScanner.ts`
+3. `apps/desktop/src/main/services/skill/SkillParser.ts`
+4. `apps/desktop/src/main/services/skill/SkillService.ts`
+5. `apps/desktop/src/main/services/skill/index.ts`
+6. `apps/desktop/src/main/ipc/agentHandlers.ts`
+7. `apps/desktop/src/main/ipc/index.ts`（更新：ハンドラー登録）
+8. `apps/desktop/src/preload/channels.ts`（更新：ホワイトリスト）
+
+#### 完了条件
+
+- [ ] 全クラスが実装されている
+- [ ] IPCハンドラーが動作する
+- [ ] キャッシュが機能する
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] スキル一覧を取得できる
+- [ ] スキル詳細を取得できる
+- [ ] SKILL.mdが正しく解析される
+- [ ] キャッシュが機能する
+- [ ] キャッシュを更新できる
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### セキュリティ要件
+
+- [ ] パストラバーサル攻撃が防止されている
+- [ ] エラーメッセージから機密情報が漏洩しない
+
+### ドキュメント要件
+
+- [ ] SKILL.md解析仕様が文書化されている
+- [ ] 実装ガイドが作成されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/main/services/skill/
+pnpm --filter @repo/desktop test src/main/ipc/agentHandlers.test.ts
+```
+
+### 検証手順
+
+1. アプリを起動
+2. DevToolsからIPC呼び出しを確認
+   ```javascript
+   await window.electronAPI.invoke("agent:get-skills");
+   ```
+3. スキル一覧が返されることを確認
+4. スキル詳細が返されることを確認
+5. キャッシュ動作を確認（2回目の呼び出しが高速）
+
+---
+
+## 7. リスクと対策
+
+| リスク                       | 影響度 | 発生確率 | 対策                                   |
+| ---------------------------- | ------ | -------- | -------------------------------------- |
+| SKILL.md形式の不統一         | 中     | 高       | 堅牢なパーサー、fallback値、エラー収集 |
+| 大量スキルでのパフォーマンス | 中     | 低       | キャッシュ、遅延読み込み               |
+| パストラバーサル攻撃         | 高     | 低       | ベースパス検証、パス正規化             |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `.claude/skills/skill-list.md` - 既存スキル一覧
+- `apps/desktop/src/main/ipc/` - 既存IPCハンドラー参照
+- `apps/desktop/src/preload/channels.ts` - チャネル定義
+
+### 参考資料
+
+- [marked](https://marked.js.org/) - Markdownパーサー候補
+- [gray-matter](https://github.com/jonschlinkert/gray-matter) - Front-matter解析
+
+---
+
+## 9. 備考
+
+### SKILL.md解析の堅牢性
+
+```typescript
+// 解析失敗時のfallback
+const defaultSkill: Partial<Skill> = {
+  name: "Unknown Skill",
+  description: "Description not available",
+  triggers: [],
+  anchors: [],
+};
+```
+
+### キャッシュ戦略
+
+- 初回読み込み時に全スキルをキャッシュ
+- TTL: 設定可能（デフォルト: 無制限、手動更新のみ）
+- ファイル変更監視は将来検討（複雑さのため初期実装では除外）
+
+### スキルパス設定
+
+```typescript
+// 環境変数または設定ファイルから取得
+const skillBasePath =
+  process.env.SKILL_PATH || path.join(homedir(), ".claude", "skills");
+```

--- a/docs/30-workflows/unassigned-task/task-agent-04-execution-ui.md
+++ b/docs/30-workflows/unassigned-task/task-agent-04-execution-ui.md
@@ -1,0 +1,685 @@
+# エージェント実行UI - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容               |
+| ------------ | ------------------ |
+| タスクID     | AGENT-004          |
+| タスク名     | エージェント実行UI |
+| 分類         | 要件               |
+| 対象機能     | エージェント機能   |
+| 優先度       | 高                 |
+| 見積もり規模 | 大規模             |
+| ステータス   | 未実施             |
+| 発見元       | ユーザー要求       |
+| 発見日       | 2026-01-09         |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002)
+    │
+    └──► task-agent-03-skill-management-backend.md (AGENT-003)
+              │
+              ├──► task-agent-04-execution-ui.md (AGENT-004/本タスク)
+              │
+              └──► task-agent-05-claude-code-integration.md (AGENT-005) ※本タスクと並行可能
+                        │
+                        ├──► task-agent-06-custom-environment-ui.md (AGENT-006)
+                        │
+                        └──► task-agent-07-environment-backend.md (AGENT-007)
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                           |
+| ------------------------ | -------------------------------------------------------------- |
+| 直接依存                 | AGENT-002（スキル管理UI）, AGENT-003（スキル管理バックエンド） |
+| 並行実行可能             | AGENT-005（Claude Code統合）※バックエンドはモックで並行開発可  |
+| 本タスク完了後に開始可能 | AGENT-006（カスタム実行環境UI）                                |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+Claude Codeのスキルを実行し、エージェントとの対話を行うためのUIが必要。ユーザーはスキルを選択後、そのスキルに基づいたエージェントとチャット形式で対話し、タスクを実行したい。
+
+### 1.2 問題点・課題
+
+- スキルを実行するUIがない
+- エージェントとの対話（チャット）インターフェースがない
+- 実行中の状態（ストリーミング出力）を表示する機能がない
+- 実行のキャンセル・中断機能がない
+- 権限確認ダイアログ（Permission Dialog）がない
+
+### 1.3 放置した場合の影響
+
+- スキルベースのエージェント機能が利用できない
+- CLI経由でのみスキル実行が可能となり、GUIの価値が低下
+- ユーザーエクスペリエンスの大幅な劣化
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+選択したスキルに基づいてClaude Codeエージェントを実行し、ストリーミング出力を表示し、ユーザーと対話できるUIを提供する。
+
+### 2.2 最終ゴール
+
+- スキル選択後、実行画面に遷移できる
+- ユーザーがメッセージを入力してエージェントに送信できる
+- エージェントの出力がストリーミングで表示される
+- 実行をキャンセルできる
+- 実行履歴が保持される
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- AgentExecutionViewコンポーネント
+- AgentChatInterfaceコンポーネント（チャット形式のUI）
+- AgentOutputStreamコンポーネント（ストリーミング出力表示）
+- PermissionDialogコンポーネント（権限確認ダイアログ）
+- 実行制御ボタン（実行、キャンセル、クリア）
+- 実行状態管理（agentSlice拡張）
+- IPC通信（ストリーミング対応、Permission対応）
+
+#### 含まないもの
+
+- カスタム実行環境（別タスク: AGENT-006）
+- バックエンドのClaude Code統合（別タスク: AGENT-005）
+- 実行履歴の永続化（別タスク候補）
+
+### 2.4 成果物
+
+| 成果物                 | パス                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| AgentExecutionView     | `apps/desktop/src/renderer/views/AgentExecutionView/index.tsx`                    |
+| AgentChatInterface     | `apps/desktop/src/renderer/components/organisms/AgentChatInterface/index.tsx`     |
+| AgentOutputStream      | `apps/desktop/src/renderer/components/molecules/AgentOutputStream/index.tsx`      |
+| AgentMessageInput      | `apps/desktop/src/renderer/components/molecules/AgentMessageInput/index.tsx`      |
+| AgentExecutionControls | `apps/desktop/src/renderer/components/molecules/AgentExecutionControls/index.tsx` |
+| PermissionDialog       | `apps/desktop/src/renderer/components/organisms/PermissionDialog/index.tsx`       |
+| agentSlice更新         | `apps/desktop/src/renderer/store/slices/agentSlice.ts`                            |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-001（エージェントダッシュボード基盤）が完了している
+- AGENT-002（スキル管理UI）が完了している
+- AGENT-006（Claude Code統合）が完了している、またはモックで開発
+
+### 3.2 依存タスク
+
+- AGENT-001: エージェントダッシュボード基盤
+- AGENT-002: スキル管理UI
+- AGENT-006: Claude Code統合（並行開発可能、モック使用）
+
+### 3.3 必要な知識・スキル
+
+- React/TypeScript
+- Electron IPC（ストリーミング通信）
+- Zustand状態管理
+- チャットUI実装
+
+### 3.4 推奨アプローチ
+
+1. 実行状態の型定義を拡張
+2. AgentMessageInputから実装（入力UI）
+3. AgentOutputStreamを実装（出力表示）
+4. AgentChatInterfaceで統合
+5. AgentExecutionControlsを実装
+6. AgentExecutionViewで全体統合
+7. ストリーミングIPC通信の接続
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: エージェント実行UI
+
+Scenario: スキル選択後に実行画面に遷移する
+  Given ユーザーがスキル詳細パネルを表示している
+  When 「実行」ボタンをクリックする
+  Then AgentExecutionViewが表示される
+  And 選択したスキルが上部に表示される
+
+Scenario: メッセージを送信できる
+  Given ユーザーが実行画面を表示している
+  And メッセージ入力欄にテキストを入力している
+  When 送信ボタンをクリックする（またはEnterキーを押す）
+  Then メッセージがチャット履歴に表示される
+  And エージェントへのリクエストが送信される
+
+Scenario: エージェントの出力がストリーミング表示される
+  Given ユーザーがメッセージを送信した
+  When エージェントが応答を生成している
+  Then 出力がリアルタイムで表示される
+  And ローディングインジケーターが表示される
+
+Scenario: 実行をキャンセルできる
+  Given エージェントが実行中である
+  When 「キャンセル」ボタンをクリックする
+  Then 実行が中断される
+  And 「実行がキャンセルされました」と表示される
+
+Scenario: チャット履歴をクリアできる
+  Given チャット履歴にメッセージがある
+  When 「クリア」ボタンをクリックする
+  Then 確認ダイアログが表示される
+  And 「はい」を選択するとチャット履歴がクリアされる
+
+Scenario: エラーが発生した場合にエラーメッセージが表示される
+  Given ユーザーがメッセージを送信した
+  When エージェント実行中にエラーが発生する
+  Then エラーメッセージがチャット履歴に表示される
+  And 実行状態が停止に変わる
+
+Scenario: 権限確認ダイアログが表示される
+  Given エージェントが実行中である
+  When askルールに該当するツールが呼び出される
+  Then PermissionDialogが表示される
+  And ツール名と引数が表示される
+
+Scenario: 権限確認ダイアログで許可できる
+  Given PermissionDialogが表示されている
+  When 「許可」ボタンをクリックする
+  Then ダイアログが閉じる
+  And エージェントの実行が続行される
+
+Scenario: 権限確認ダイアログで拒否できる
+  Given PermissionDialogが表示されている
+  When 「拒否」ボタンをクリックする
+  Then ダイアログが閉じる
+  And エージェントにツール使用が拒否されたことが通知される
+
+Scenario: 権限確認ダイアログで選択を記憶できる
+  Given PermissionDialogが表示されている
+  When 「このツールの選択を記憶する」にチェックを入れる
+  And 「許可」または「拒否」をクリックする
+  Then 同一ツールの次回以降の確認がスキップされる
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] UI/UXフローが定義されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由           |
+| ----------------- | ------------------------------------------- | ------------------ |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | チャットUI設計     |
+| domain-modeling   | `.claude/skills/domain-modeling/SKILL.md`   | 実行状態モデル設計 |
+
+#### 設計内容
+
+**1. 実行状態の型定義**
+
+```typescript
+// packages/shared/src/types/agent.ts に追加
+
+export type AgentExecutionStatus =
+  | "idle" // 待機中
+  | "executing" // 実行中
+  | "streaming" // ストリーミング受信中
+  | "awaiting_permission" // 権限確認待ち
+  | "completed" // 完了
+  | "cancelled" // キャンセル
+  | "error"; // エラー
+
+export interface AgentMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: Date;
+  isStreaming?: boolean;
+}
+
+// Permission Request（AGENT-005から受信）
+export interface PermissionRequest {
+  executionId: string;
+  requestId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  reason?: string;
+}
+
+// Permission Response（AGENT-005へ送信）
+export interface PermissionResponse {
+  requestId: string;
+  approved: boolean;
+  rememberChoice?: boolean;
+}
+
+export interface AgentExecutionState {
+  status: AgentExecutionStatus;
+  currentSkill: Skill | null;
+  messages: AgentMessage[];
+  currentStreamingMessage: string;
+  error: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  pendingPermission: PermissionRequest | null; // 保留中の権限確認
+  rememberedChoices: Map<string, boolean>; // 記憶された選択（toolName → approved）
+}
+```
+
+**2. agentSlice拡張**
+
+```typescript
+// agentSlice.ts 拡張
+export interface AgentSlice {
+  // 既存のフィールド...
+
+  // 実行状態
+  executionState: AgentExecutionState;
+
+  // アクション
+  startExecution: (skill: Skill) => void;
+  stopExecution: () => void;
+  addMessage: (message: AgentMessage) => void;
+  appendStreamingContent: (content: string) => void;
+  finalizeStreamingMessage: () => void;
+  setExecutionError: (error: string) => void;
+  clearMessages: () => void;
+  resetExecutionState: () => void;
+
+  // Permission関連アクション
+  setPermissionRequest: (request: PermissionRequest | null) => void;
+  respondToPermission: (response: PermissionResponse) => void;
+  rememberPermissionChoice: (toolName: string, approved: boolean) => void;
+  getRememberedChoice: (toolName: string) => boolean | undefined;
+  clearRememberedChoices: () => void;
+}
+```
+
+**3. コンポーネント構造**
+
+```
+AgentExecutionView
+├── SkillHeader (選択中のスキル表示)
+├── AgentChatInterface (organism)
+│   ├── AgentMessageList
+│   │   └── AgentMessageItem[]
+│   └── AgentOutputStream (ストリーミング表示)
+├── AgentMessageInput (molecule)
+│   ├── TextArea
+│   └── SendButton
+├── AgentExecutionControls (molecule)
+│   ├── ExecuteButton
+│   ├── CancelButton
+│   └── ClearButton
+└── PermissionDialog (organism) ← NEW
+    ├── ToolInfo (ツール名・引数表示)
+    ├── RememberChoiceCheckbox
+    ├── ApproveButton
+    └── DenyButton
+```
+
+**PermissionDialogコンポーネント設計**
+
+```typescript
+// PermissionDialog/index.tsx
+interface PermissionDialogProps {
+  request: PermissionRequest | null;
+  onApprove: (rememberChoice: boolean) => void;
+  onDeny: (rememberChoice: boolean) => void;
+}
+
+export const PermissionDialog: React.FC<PermissionDialogProps> = ({
+  request,
+  onApprove,
+  onDeny,
+}) => {
+  const [rememberChoice, setRememberChoice] = useState(false);
+
+  if (!request) return null;
+
+  return (
+    <Dialog open={true}>
+      <DialogHeader>
+        <DialogTitle>権限の確認</DialogTitle>
+      </DialogHeader>
+      <DialogContent>
+        <p>エージェントが以下のツールを使用しようとしています：</p>
+        <ToolInfo toolName={request.toolName} args={request.args} />
+        <Checkbox
+          checked={rememberChoice}
+          onChange={setRememberChoice}
+          label="このツールの選択を記憶する"
+        />
+      </DialogContent>
+      <DialogFooter>
+        <Button variant="secondary" onClick={() => onDeny(rememberChoice)}>
+          拒否
+        </Button>
+        <Button variant="primary" onClick={() => onApprove(rememberChoice)}>
+          許可
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+};
+```
+
+**4. レイアウト設計**
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ← Back   tdd-principles                          [⚙️ Settings]│
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│ ┌────────────────────────────────────────────────────────┐  │
+│ │ 👤 User                                                 │  │
+│ │ TDDでユーザー認証機能を実装してください                 │  │
+│ └────────────────────────────────────────────────────────┘  │
+│                                                              │
+│ ┌────────────────────────────────────────────────────────┐  │
+│ │ 🤖 Agent                                                │  │
+│ │ TDDの原則に従って、まずはテストを作成します...         │  │
+│ │ █ (streaming)                                           │  │
+│ └────────────────────────────────────────────────────────┘  │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│ [メッセージを入力...                              ] [Send]   │
+├──────────────────────────────────────────────────────────────┤
+│                    [Cancel] [Clear]                          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**5. IPC通信フロー**
+
+```
+Renderer                    Main Process              Claude Agent SDK
+   │                            │                           │
+   │─── agent:start ───────────►│                           │
+   │    { skillId, prompt }     │──── query() ─────────────►│
+   │                            │                           │
+   │◄── agent:stream ───────────│◄─── message ─────────────│
+   │    { type, content }       │                           │
+   │◄── agent:stream ───────────│◄─── message ─────────────│
+   │    { type, content }       │                           │
+   │                            │                           │
+   │                         Permission Request Flow        │
+   │                            │◄─── PermissionRequest ────│
+   │◄── agent:permission ───────│    (ask rule triggered)   │
+   │    { toolName, args }      │                           │
+   │                            │       (User approves)     │
+   │─── agent:permission:res ──►│───── proceed: true ──────►│
+   │    { approved: true }      │                           │
+   │                            │                           │
+   │◄── agent:status ───────────│◄─── completed ───────────│
+   │    { status: "completed" } │                           │
+   │                            │                           │
+   │─── agent:stop ────────────►│                           │
+   │                            │──── abort() ─────────────►│
+   │◄── agent:status ───────────│                           │
+   │    { status: "cancelled" } │                           │
+```
+
+**IPCチャネル一覧**
+
+| チャネル               | 方向            | 説明                       |
+| ---------------------- | --------------- | -------------------------- |
+| `agent:start`          | Renderer → Main | エージェント実行開始       |
+| `agent:stop`           | Renderer → Main | 実行停止（AbortSignal）    |
+| `agent:stream`         | Main → Renderer | ストリーミングメッセージ   |
+| `agent:status`         | Main → Renderer | 実行状態変更通知           |
+| `agent:permission`     | Main → Renderer | 権限確認要求（ダイアログ） |
+| `agent:permission:res` | Renderer → Main | 権限確認応答（許可/拒否）  |
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+- シーケンス図
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] コンポーネント構造が設計されている
+- [ ] IPC通信フローが設計されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### 完了条件
+
+- [ ] 既存ChatViewとの整合性が確認されている
+- [ ] ストリーミング処理の設計が適切
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// agentSlice.test.ts - 実行状態関連
+describe("agentSlice execution", () => {
+  it("should start execution with skill", () => {});
+  it("should stop execution", () => {});
+  it("should add user message", () => {});
+  it("should append streaming content", () => {});
+  it("should finalize streaming message", () => {});
+  it("should set execution error", () => {});
+  it("should clear messages", () => {});
+});
+
+// AgentChatInterface.test.tsx
+describe("AgentChatInterface", () => {
+  it("should display messages", () => {});
+  it("should display streaming content", () => {});
+  it("should scroll to bottom on new message", () => {});
+});
+
+// AgentMessageInput.test.tsx
+describe("AgentMessageInput", () => {
+  it("should call onSend when button clicked", () => {});
+  it("should call onSend when Enter pressed", () => {});
+  it("should be disabled when executing", () => {});
+  it("should clear input after send", () => {});
+});
+
+// AgentExecutionControls.test.tsx
+describe("AgentExecutionControls", () => {
+  it("should show cancel button when executing", () => {});
+  it("should call onCancel when cancel clicked", () => {});
+  it("should call onClear when clear clicked after confirmation", () => {});
+});
+
+// PermissionDialog.test.tsx
+describe("PermissionDialog", () => {
+  it("should not render when request is null", () => {});
+  it("should display tool name and args", () => {});
+  it("should call onApprove when approve clicked", () => {});
+  it("should call onDeny when deny clicked", () => {});
+  it("should pass rememberChoice flag on approve", () => {});
+  it("should pass rememberChoice flag on deny", () => {});
+});
+
+// agentSlice.test.ts - Permission関連
+describe("agentSlice permission", () => {
+  it("should set pending permission request", () => {});
+  it("should clear pending permission on respond", () => {});
+  it("should remember permission choice", () => {});
+  it("should return remembered choice for tool", () => {});
+  it("should clear all remembered choices", () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 実行状態管理のテストがある
+- [ ] 各コンポーネントのテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由       |
+| ----------------- | ------------------------------------------- | -------------- |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | チャットUI実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`（更新）
+2. `apps/desktop/src/renderer/store/slices/agentSlice.ts`（更新）
+3. `apps/desktop/src/renderer/components/molecules/AgentMessageInput/index.tsx`
+4. `apps/desktop/src/renderer/components/molecules/AgentOutputStream/index.tsx`
+5. `apps/desktop/src/renderer/components/molecules/AgentExecutionControls/index.tsx`
+6. `apps/desktop/src/renderer/components/organisms/AgentChatInterface/index.tsx`
+7. `apps/desktop/src/renderer/components/organisms/PermissionDialog/index.tsx`
+8. `apps/desktop/src/renderer/views/AgentExecutionView/index.tsx`
+9. `apps/desktop/src/renderer/views/AgentView/index.tsx`（ルーティング追加）
+
+#### 完了条件
+
+- [ ] 全コンポーネントが実装されている
+- [ ] チャットUIが動作する
+- [ ] ストリーミング表示が動作する
+- [ ] 実行制御が動作する
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] スキル選択後に実行画面に遷移できる
+- [ ] メッセージを送信できる
+- [ ] エージェントの出力がストリーミング表示される
+- [ ] 実行をキャンセルできる
+- [ ] チャット履歴をクリアできる
+- [ ] エラー時にエラーメッセージが表示される
+- [ ] Permission Dialogが表示される（askルールのツール使用時）
+- [ ] Permission Dialogで許可/拒否を選択できる
+- [ ] Permission Dialogで選択を記憶できる
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### ドキュメント要件
+
+- [ ] コンポーネントにJSDocコメントがある
+- [ ] 実装ガイドが作成されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/renderer/store/slices/agentSlice.test.ts
+pnpm --filter @repo/desktop test src/renderer/components/organisms/AgentChatInterface/
+pnpm --filter @repo/desktop test src/renderer/views/AgentExecutionView/
+```
+
+### 検証手順
+
+1. AgentViewでスキルを選択
+2. 「実行」ボタンをクリック
+3. 実行画面が表示されることを確認
+4. メッセージを入力して送信
+5. ストリーミング出力が表示されることを確認
+6. 「キャンセル」ボタンで実行が中断されることを確認
+7. 「クリア」ボタンで履歴がクリアされることを確認
+
+---
+
+## 7. リスクと対策
+
+| リスク                           | 影響度 | 発生確率 | 対策                                   |
+| -------------------------------- | ------ | -------- | -------------------------------------- |
+| ストリーミングの遅延・途切れ     | 高     | 中       | 再接続ロジック、タイムアウト処理       |
+| 長時間実行時のメモリリーク       | 中     | 中       | メッセージ数上限、古いメッセージの削除 |
+| キャンセル時のクリーンアップ失敗 | 中     | 低       | プロセス強制終了、リソース解放の徹底   |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `apps/desktop/src/renderer/views/ChatView/` - 既存チャットUI参照
+- `apps/desktop/src/renderer/components/organisms/ChatInput/` - 既存入力コンポーネント
+- `apps/desktop/src/preload/channels.ts` - IPC通信パターン
+
+### 参考資料
+
+- [React Streaming Patterns](https://react.dev/reference/react/useSyncExternalStore)
+- 既存のLLMストリーミング実装（`llmSlice.ts`、`llmHandlers.ts`）
+
+---
+
+## 9. 備考
+
+### 補足事項
+
+- 既存のChatViewとの共通化を検討（将来的にリファクタリング）
+- メッセージはMarkdown形式で表示（コードハイライト対応）
+- ストリーミング表示はカーソルブリンクアニメーション付き

--- a/docs/30-workflows/unassigned-task/task-agent-05-claude-code-integration.md
+++ b/docs/30-workflows/unassigned-task/task-agent-05-claude-code-integration.md
@@ -1,0 +1,1021 @@
+# Claude Agent SDK統合 - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                 |
+| ------------ | -------------------- |
+| タスクID     | AGENT-005            |
+| タスク名     | Claude Agent SDK統合 |
+| 分類         | 要件                 |
+| 対象機能     | エージェント機能     |
+| 優先度       | 高                   |
+| 見積もり規模 | 大規模               |
+| ステータス   | 未実施               |
+| 発見元       | ユーザー要求         |
+| 発見日       | 2026-01-09           |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002) ─┐
+    │                                                      │
+    └──► task-agent-03-skill-management-backend.md ────────┼──► task-agent-04-execution-ui.md
+         (AGENT-003) ※02と並行可能                         │    (AGENT-004)
+                │                                          │
+                └──► task-agent-05-claude-code-integration ┘    ※04と並行可能
+                     (AGENT-005/本タスク) ※04と並行可能
+                          │
+                          └──► task-agent-06-custom-environment-ui.md (AGENT-006)
+                                    │
+                                    └──► task-agent-07-environment-backend.md (AGENT-007)
+                                         ※06と並行可能
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                       |
+| ------------------------ | ---------------------------------------------------------- |
+| 直接依存                 | AGENT-003（スキル管理バックエンド）                        |
+| 並行実行可能             | AGENT-004（エージェント実行UI）                            |
+| 本タスク完了後に開始可能 | AGENT-006（カスタム実行環境UI）, AGENT-007（実行環境管理） |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+エージェント機能の中核として、**Claude Agent SDK（`@anthropic-ai/claude-agent-sdk`）** を使用して、**ユーザーのClaude Codeサブスクリプション**を活用したスキルベースのタスク実行機能を実装する。
+
+Claude Agent SDKは、Claude Codeの認証・サブスクリプションを自動的に利用するため、Anthropic APIキーを直接管理する必要がない。SDKの`query()` APIを使用することで、ストリーミング出力、Hooksシステム、Permission Controlを統合的に扱える。
+
+### 1.2 問題点・課題
+
+- Claude Agent SDKを統合する機能がない
+- Hooksシステム（PreToolUse/PostToolUse/PermissionRequest）がない
+- Permission Control（権限制御）の仕組みがない
+- ストリーミング出力をIPC経由で転送する機能がない
+- 実行の中断・キャンセル機能がない
+- Permission Dialog（ユーザー承認UI）との連携がない
+
+### 1.3 放置した場合の影響
+
+- エージェント機能が動作しない
+- スキルベースのタスク実行が不可能
+- ユーザーのClaude Code契約を活用した機能が提供できない
+- 危険なツール使用を制御できない
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+Claude Agent SDKの`query()` APIをElectronアプリに統合し、Hooksシステム、Permission Control、ストリーミング出力、Permission Dialogを実装する。
+
+### 2.2 最終ゴール
+
+- Claude Agent SDK `query()` APIでエージェントを実行できる
+- Hooksシステムで危険なツール使用をブロックできる
+- Permission Controlで宣言的に権限ルールを定義できる
+- Permission Dialogでユーザー承認を求められる
+- 実行結果がストリーミングでRendererに転送される
+- AbortSignalで実行をキャンセルできる
+- 複数の実行を管理できる
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- AgentExecutorサービス（SDK `query()` API統合）
+- ExecutionManagerサービス（複数実行管理）
+- Hooksシステム（PreToolUse/PostToolUse/PermissionRequest）
+- Permission Control設定
+- Permission Dialog IPC連携
+- ストリーミングIPC通信
+- AbortController/Signal統合
+- agentHandlers拡張
+
+#### 含まないもの
+
+- フロントエンドUI（別タスク: AGENT-004）
+- カスタム実行環境（別タスク: AGENT-006, AGENT-007）
+- Permission DialogのUI実装（AGENT-004で実装）
+
+### 2.4 成果物
+
+| 成果物                | パス                                                       |
+| --------------------- | ---------------------------------------------------------- |
+| AgentExecutor         | `apps/desktop/src/main/services/agent/AgentExecutor.ts`    |
+| ExecutionManager      | `apps/desktop/src/main/services/agent/ExecutionManager.ts` |
+| PermissionRulesConfig | `apps/desktop/src/main/services/agent/PermissionRules.ts`  |
+| HooksFactory          | `apps/desktop/src/main/services/agent/HooksFactory.ts`     |
+| agentHandlers更新     | `apps/desktop/src/main/ipc/agentHandlers.ts`               |
+| IPCチャネル更新       | `apps/desktop/src/preload/channels.ts`                     |
+| 型定義更新            | `packages/shared/src/types/agent.ts`                       |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-003（スキル管理バックエンド）が完了している
+- Claude Code（ローカル認証済み）がインストールされている
+- `@anthropic-ai/claude-agent-sdk` パッケージを理解している
+
+### 3.2 依存タスク
+
+- AGENT-001: エージェントダッシュボード基盤
+- AGENT-003: スキル管理バックエンド
+- AGENT-004: Permission Dialog UI（並行開発可能、IPC仕様は本タスクで定義）
+
+### 3.3 必要な知識・スキル
+
+- Claude Agent SDK `query()` API
+- SDK Hooksシステム（PreToolUse/PostToolUse/PermissionRequest）
+- Permission Control（4層権限システム）
+- AsyncIterator/ストリーミング処理
+- AbortController/AbortSignal
+- Electron IPC
+
+### 3.4 推奨アプローチ
+
+1. 型定義を拡張（SDKMessage、実行状態、Permission関連）
+2. HooksFactoryを実装（Hook生成、IPC連携）
+3. PermissionRulesConfigを実装（宣言的権限ルール）
+4. AgentExecutorを実装（SDK `query()` API統合）
+5. ExecutionManagerを実装（複数実行管理）
+6. ストリーミングIPC通信を実装
+7. agentHandlersを拡張
+8. AbortController/Signalでキャンセル機能を実装
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: Claude Agent SDK統合
+
+Scenario: SDK query() APIでエージェントを実行できる
+  Given スキルが選択されている
+  And ユーザーがメッセージを入力している
+  When agent:startを呼び出す
+  Then SDK query() APIが呼び出される
+  And スキルコンテキストがsettingSourcesで渡される
+
+Scenario: ストリーミングメッセージを受信できる
+  Given エージェントが実行中である
+  When SDKがメッセージを生成する
+  Then agent:streamイベントがRendererに送信される
+  And SDKMessage型のデータが含まれる
+
+Scenario: 危険なツール使用をブロックできる
+  Given エージェントが実行中である
+  And PreToolUse Hookが設定されている
+  When 危険なBashコマンドが実行されようとする
+  Then PreToolUse Hookがproceed: falseを返す
+  And ツール使用がブロックされる
+
+Scenario: Permission Dialogでユーザー承認を求められる
+  Given エージェントが実行中である
+  And PermissionRequest Hookが設定されている
+  When 権限確認が必要なツールが呼び出される
+  Then agent:permissionイベントがRendererに送信される
+  And Rendererからagent:permission:resで応答を受信する
+
+Scenario: 実行をキャンセルできる
+  Given エージェントが実行中である
+  When agent:stopを呼び出す
+  Then AbortControllerがabort()される
+  And 実行がキャンセルされる
+
+Scenario: エラーを処理できる
+  Given エージェントを実行している
+  When SDK実行でエラーが発生する
+  Then agent:streamイベントでerrorタイプが送信される
+  And エラーメッセージが含まれる
+
+Scenario: 複数の実行を管理できる
+  Given 実行Aが進行中である
+  When 新しい実行Bを開始する
+  Then 実行Aと実行Bが独立して管理される
+  And 各実行のストリームがexecutionIdで区別される
+
+Scenario: 宣言的権限ルールで制御できる
+  Given Permission Rulesが設定されている
+  When deny/allow/askルールに該当するツールが呼ばれる
+  Then ルールに従って権限判定が行われる
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] Claude Code CLIの呼び出し仕様が明確化されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名         | パス                                       | 選定理由        |
+| ---------------- | ------------------------------------------ | --------------- |
+| domain-modeling  | `.claude/skills/domain-modeling/SKILL.md`  | 実行モデル設計  |
+| claude-agent-sdk | `.claude/skills/claude-agent-sdk/SKILL.md` | SDK統合パターン |
+
+#### 設計内容
+
+**1. 型定義拡張**
+
+```typescript
+// packages/shared/src/types/agent.ts に追加
+
+// SDK実行リクエスト
+export interface AgentExecutionRequest {
+  executionId: string; // UUID
+  skillId: string;
+  skillPath: string;
+  prompt: string;
+  workingDirectory?: string;
+  tools?: string[]; // 許可するツール
+  permissionMode?: "auto" | "ask" | "deny" | "default";
+}
+
+// SDKメッセージ型（ストリーミング用）
+export interface AgentStreamMessage {
+  executionId: string;
+  type: "assistant" | "user" | "result" | "tool_use" | "status" | "error";
+  content: unknown;
+  timestamp: number;
+}
+
+// Permission Request（UIダイアログ用）
+export interface PermissionRequest {
+  executionId: string;
+  requestId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  reason?: string;
+}
+
+// Permission Response（UIからの応答）
+export interface PermissionResponse {
+  requestId: string;
+  approved: boolean;
+  rememberChoice?: boolean;
+}
+
+// 実行状態
+export interface AgentExecutionStatus {
+  executionId: string;
+  status: "running" | "completed" | "cancelled" | "error";
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+// Permission Rule型
+export interface PermissionRule {
+  tool: string | string[];
+  paths?: string[];
+  commands?: string[];
+}
+
+export interface PermissionRules {
+  allow?: PermissionRule[];
+  deny?: PermissionRule[];
+  ask?: PermissionRule[];
+}
+```
+
+**2. HooksFactory設計**
+
+```typescript
+// HooksFactory.ts
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import type { BrowserWindow } from "electron";
+import { IPC_CHANNELS } from "../../../preload/channels";
+
+export class HooksFactory {
+  constructor(
+    private mainWindow: BrowserWindow,
+    private executionId: string,
+    private permissionResolver: PermissionResolver,
+  ) {}
+
+  createHooks(): Options["hooks"] {
+    return {
+      // ツール実行前: 危険なコマンドをブロック
+      PreToolUse: async (input, toolUseID, { signal }) => {
+        // 危険なBashコマンドをブロック
+        if (input.toolName === "Bash") {
+          const dangerousPatterns = ["rm -rf", "sudo", "chmod 777", "dd if="];
+          const command = input.args.command as string;
+
+          for (const pattern of dangerousPatterns) {
+            if (command?.includes(pattern)) {
+              return {
+                proceed: false,
+                message: `危険なコマンド "${pattern}" は許可されていません`,
+              };
+            }
+          }
+        }
+        return { proceed: true };
+      },
+
+      // ツール実行後: ステータス更新
+      PostToolUse: async (input, toolUseID, { signal }) => {
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+          executionId: this.executionId,
+          type: "tool_completed",
+          tool: input.toolName,
+          timestamp: Date.now(),
+        });
+        return {};
+      },
+
+      // 権限リクエスト: UIダイアログ表示
+      PermissionRequest: async (input, toolUseID, { signal }) => {
+        const requestId = `perm_${Date.now()}`;
+
+        // Rendererに権限確認を要求
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_PERMISSION, {
+          executionId: this.executionId,
+          requestId,
+          toolName: input.toolName,
+          args: input.args,
+        } as PermissionRequest);
+
+        // Rendererからの応答を待つ
+        const response = await this.permissionResolver.waitForResponse(
+          requestId,
+          signal,
+        );
+
+        return { proceed: response.approved };
+      },
+
+      // セッション開始
+      SessionStart: async (input, toolUseID, { signal }) => {
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+          executionId: this.executionId,
+          type: "session_started",
+          timestamp: Date.now(),
+        });
+        return {};
+      },
+
+      // セッション終了
+      SessionEnd: async (input, toolUseID, { signal }) => {
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+          executionId: this.executionId,
+          type: "session_ended",
+          timestamp: Date.now(),
+        });
+        return {};
+      },
+    };
+  }
+}
+
+// Permission応答を解決するクラス
+export class PermissionResolver {
+  private pendingRequests = new Map<
+    string,
+    {
+      resolve: (response: PermissionResponse) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+
+  waitForResponse(
+    requestId: string,
+    signal: AbortSignal,
+  ): Promise<PermissionResponse> {
+    return new Promise((resolve, reject) => {
+      if (signal.aborted) {
+        reject(new Error("Aborted"));
+        return;
+      }
+
+      this.pendingRequests.set(requestId, { resolve, reject });
+
+      signal.addEventListener("abort", () => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error("Aborted"));
+      });
+    });
+  }
+
+  resolveRequest(response: PermissionResponse): void {
+    const pending = this.pendingRequests.get(response.requestId);
+    if (pending) {
+      pending.resolve(response);
+      this.pendingRequests.delete(response.requestId);
+    }
+  }
+}
+```
+
+**3. PermissionRulesConfig設計**
+
+```typescript
+// PermissionRules.ts
+
+export const DEFAULT_PERMISSION_RULES: PermissionRules = {
+  // 自動許可: 読み取り系ツール
+  allow: [{ tool: "Read" }, { tool: "Grep" }, { tool: "Glob" }],
+  // 拒否: 危険なコマンド
+  deny: [
+    { tool: "Bash", commands: ["rm -rf", "sudo", "chmod 777", "dd if="] },
+    { tool: "Write", paths: ["/etc/**", "/usr/**", "/var/**"] },
+  ],
+  // 確認必要: 書き込み系
+  ask: [{ tool: "Write" }, { tool: "Edit" }, { tool: "Bash" }],
+};
+
+export function createPermissionOptions(
+  rules: PermissionRules,
+  projectRoot: string,
+): Options["permissions"] {
+  return {
+    allow: rules.allow?.map((rule) => ({
+      ...rule,
+      paths: rule.paths?.map((p) => p.replace("${projectRoot}", projectRoot)),
+    })),
+    deny: rules.deny?.map((rule) => ({
+      ...rule,
+      paths: rule.paths?.map((p) => p.replace("${projectRoot}", projectRoot)),
+    })),
+    ask: rules.ask?.map((rule) => ({
+      ...rule,
+      paths: rule.paths?.map((p) => p.replace("${projectRoot}", projectRoot)),
+    })),
+  };
+}
+```
+
+**4. AgentExecutor設計**
+
+```typescript
+// AgentExecutor.ts
+import {
+  query,
+  type Options,
+  type Conversation,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { BrowserWindow } from "electron";
+import { HooksFactory, PermissionResolver } from "./HooksFactory";
+import {
+  createPermissionOptions,
+  DEFAULT_PERMISSION_RULES,
+} from "./PermissionRules";
+import { IPC_CHANNELS } from "../../../preload/channels";
+
+export class AgentExecutor {
+  private abortController: AbortController;
+  private conversation: Conversation | null = null;
+  private readonly permissionResolver: PermissionResolver;
+
+  constructor(
+    private request: AgentExecutionRequest,
+    private mainWindow: BrowserWindow,
+    private permissionRules: PermissionRules = DEFAULT_PERMISSION_RULES,
+  ) {
+    this.abortController = new AbortController();
+    this.permissionResolver = new PermissionResolver();
+  }
+
+  async start(): Promise<void> {
+    const hooksFactory = new HooksFactory(
+      this.mainWindow,
+      this.request.executionId,
+      this.permissionResolver,
+    );
+
+    const options: Options = {
+      tools: this.request.tools || [
+        "Read",
+        "Edit",
+        "Write",
+        "Bash",
+        "Glob",
+        "Grep",
+      ],
+      permissionMode: this.request.permissionMode || "default",
+      permissions: createPermissionOptions(
+        this.permissionRules,
+        this.request.workingDirectory || process.cwd(),
+      ),
+      hooks: hooksFactory.createHooks(),
+      signal: this.abortController.signal,
+      settingSources: ["user", "project"], // スキル設定を読み込む
+    };
+
+    try {
+      this.conversation = query({
+        prompt: this.request.prompt,
+        options,
+      });
+
+      // ストリーミング処理
+      for await (const message of this.conversation.stream()) {
+        if (this.abortController.signal.aborted) break;
+
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STREAM, {
+          executionId: this.request.executionId,
+          type: message.type,
+          content: message.message || message,
+          timestamp: Date.now(),
+        } as AgentStreamMessage);
+      }
+
+      // 完了通知
+      this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+        executionId: this.request.executionId,
+        status: "completed",
+        completedAt: Date.now(),
+      });
+    } catch (error) {
+      if (this.abortController.signal.aborted) {
+        // キャンセルによる終了
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+          executionId: this.request.executionId,
+          status: "cancelled",
+          completedAt: Date.now(),
+        });
+      } else {
+        // エラーによる終了
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STREAM, {
+          executionId: this.request.executionId,
+          type: "error",
+          content: { message: (error as Error).message },
+          timestamp: Date.now(),
+        });
+        this.mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, {
+          executionId: this.request.executionId,
+          status: "error",
+          error: (error as Error).message,
+          completedAt: Date.now(),
+        });
+      }
+    }
+  }
+
+  stop(): void {
+    this.abortController.abort();
+  }
+
+  resolvePermission(response: PermissionResponse): void {
+    this.permissionResolver.resolveRequest(response);
+  }
+}
+```
+
+**5. ExecutionManager設計**
+
+```typescript
+// ExecutionManager.ts
+import { v4 as uuidv4 } from "uuid";
+import type { BrowserWindow } from "electron";
+import { AgentExecutor } from "./AgentExecutor";
+import type { AgentExecutionRequest, PermissionResponse } from "@repo/shared";
+
+export class ExecutionManager {
+  private executions: Map<string, AgentExecutor> = new Map();
+
+  async startExecution(
+    request: AgentExecutionRequest,
+    mainWindow: BrowserWindow,
+  ): Promise<string> {
+    const executionId = request.executionId || uuidv4();
+    const fullRequest = { ...request, executionId };
+
+    const executor = new AgentExecutor(fullRequest, mainWindow);
+
+    this.executions.set(executionId, executor);
+
+    // 非同期で実行開始（awaitしない）
+    executor.start().finally(() => {
+      this.executions.delete(executionId);
+    });
+
+    return executionId;
+  }
+
+  stopExecution(executionId: string): boolean {
+    const executor = this.executions.get(executionId);
+    if (executor) {
+      executor.stop();
+      return true;
+    }
+    return false;
+  }
+
+  stopAllExecutions(): void {
+    this.executions.forEach((executor) => executor.stop());
+  }
+
+  getActiveExecutions(): string[] {
+    return Array.from(this.executions.keys());
+  }
+
+  resolvePermission(
+    executionId: string,
+    response: PermissionResponse,
+  ): boolean {
+    const executor = this.executions.get(executionId);
+    if (executor) {
+      executor.resolvePermission(response);
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+**6. IPCチャネル定義**
+
+```typescript
+// channels.ts に追加
+AGENT_START: "agent:start",
+AGENT_STOP: "agent:stop",
+AGENT_STOP_ALL: "agent:stop-all",
+AGENT_GET_ACTIVE_EXECUTIONS: "agent:get-active-executions",
+AGENT_STREAM: "agent:stream",
+AGENT_STATUS: "agent:status",
+AGENT_PERMISSION: "agent:permission",        // Main → Renderer（権限確認要求）
+AGENT_PERMISSION_RES: "agent:permission:res", // Renderer → Main（権限確認応答）
+```
+
+**7. agentHandlers拡張**
+
+```typescript
+// agentHandlers.ts に追加
+import { ipcMain } from "electron";
+import type { BrowserWindow } from "electron";
+import { ExecutionManager } from "../services/agent/ExecutionManager";
+import { IPC_CHANNELS } from "../../preload/channels";
+import type { AgentExecutionRequest, PermissionResponse } from "@repo/shared";
+
+export function registerAgentExecutionHandlers(
+  mainWindow: BrowserWindow,
+  executionManager: ExecutionManager,
+): void {
+  // エージェント実行開始
+  ipcMain.handle(
+    IPC_CHANNELS.AGENT_START,
+    async (_e, request: AgentExecutionRequest) => {
+      return executionManager.startExecution(request, mainWindow);
+    },
+  );
+
+  // 実行停止
+  ipcMain.handle(IPC_CHANNELS.AGENT_STOP, async (_e, { executionId }) => {
+    return executionManager.stopExecution(executionId);
+  });
+
+  // 全実行停止
+  ipcMain.handle(IPC_CHANNELS.AGENT_STOP_ALL, async () => {
+    executionManager.stopAllExecutions();
+    return true;
+  });
+
+  // アクティブ実行一覧
+  ipcMain.handle(IPC_CHANNELS.AGENT_GET_ACTIVE_EXECUTIONS, async () => {
+    return executionManager.getActiveExecutions();
+  });
+
+  // Permission応答（Rendererからの応答を受け取る）
+  ipcMain.handle(
+    IPC_CHANNELS.AGENT_PERMISSION_RES,
+    async (
+      _e,
+      {
+        executionId,
+        response,
+      }: { executionId: string; response: PermissionResponse },
+    ) => {
+      return executionManager.resolvePermission(executionId, response);
+    },
+  );
+}
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+- シーケンス図
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] クラス設計が完成している
+- [ ] IPC通信フローが設計されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### セキュリティレビュー項目
+
+- [ ] コマンドインジェクション対策
+- [ ] 環境変数の安全な受け渡し
+- [ ] プロセス終了時のクリーンアップ
+
+#### 完了条件
+
+- [ ] セキュリティレビューが完了している
+- [ ] 既存パターンと整合している
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// HooksFactory.test.ts
+describe("HooksFactory", () => {
+  it("should create hooks object with all required hooks", () => {});
+  it("PreToolUse should block dangerous bash commands", async () => {});
+  it("PreToolUse should allow safe commands", async () => {});
+  it("PostToolUse should send status via IPC", async () => {});
+  it("PermissionRequest should send request and wait for response", async () => {});
+  it("PermissionRequest should handle abort signal", async () => {});
+});
+
+// PermissionResolver.test.ts
+describe("PermissionResolver", () => {
+  it("should resolve pending request", async () => {});
+  it("should reject on abort signal", async () => {});
+  it("should handle multiple pending requests", async () => {});
+});
+
+// AgentExecutor.test.ts
+describe("AgentExecutor", () => {
+  it("should call SDK query() with correct options", async () => {});
+  it("should stream messages via IPC", async () => {});
+  it("should send completion status on success", async () => {});
+  it("should send cancelled status on abort", async () => {});
+  it("should send error status on exception", async () => {});
+  it("should apply permission rules correctly", async () => {});
+});
+
+// ExecutionManager.test.ts
+describe("ExecutionManager", () => {
+  it("should start execution and return id", async () => {});
+  it("should track active executions", async () => {});
+  it("should stop specific execution", async () => {});
+  it("should stop all executions", async () => {});
+  it("should remove execution on completion", async () => {});
+  it("should handle multiple concurrent executions", async () => {});
+  it("should resolve permission for specific execution", async () => {});
+});
+
+// agentHandlers.test.ts (execution)
+describe("agentHandlers execution", () => {
+  it("should handle agent:start", async () => {});
+  it("should handle agent:stop", async () => {});
+  it("should handle agent:stop-all", async () => {});
+  it("should handle agent:get-active-executions", async () => {});
+  it("should handle agent:permission:res", async () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 各クラスのユニットテストがある
+- [ ] IPCハンドラーのテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名            | パス                                          | 選定理由         |
+| ------------------- | --------------------------------------------- | ---------------- |
+| multi-agent-systems | `.claude/skills/multi-agent-systems/SKILL.md` | プロセス管理実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`（更新）
+2. `apps/desktop/src/main/services/agent/HooksFactory.ts`
+3. `apps/desktop/src/main/services/agent/PermissionRules.ts`
+4. `apps/desktop/src/main/services/agent/AgentExecutor.ts`
+5. `apps/desktop/src/main/services/agent/ExecutionManager.ts`
+6. `apps/desktop/src/main/services/agent/index.ts`
+7. `apps/desktop/src/main/ipc/agentHandlers.ts`（更新）
+8. `apps/desktop/src/preload/channels.ts`（更新）
+9. `apps/desktop/src/main/index.ts`（ExecutionManager初期化）
+
+#### 完了条件
+
+- [ ] 全クラスが実装されている
+- [ ] SDK `query()` APIでエージェントが実行できる
+- [ ] Hooksシステムが動作する
+- [ ] Permission Controlが動作する
+- [ ] ストリーミングが動作する
+- [ ] AbortSignalでキャンセルが動作する
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] SDK `query()` APIでエージェントを実行できる
+- [ ] Hooksシステムで危険なツール使用をブロックできる
+- [ ] Permission Controlで宣言的に権限ルールを定義できる
+- [ ] Permission Dialogでユーザー承認を求められる
+- [ ] ストリーミング出力を受信できる
+- [ ] AbortSignalで実行をキャンセルできる
+- [ ] 複数の実行を管理できる
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### セキュリティ要件
+
+- [ ] 危険なBashコマンドがPreToolUseでブロックされる
+- [ ] システムディレクトリへの書き込みがdenyルールで禁止される
+- [ ] 書き込み系ツールがaskルールで確認を要求する
+- [ ] AbortSignalが適切にチェックされる
+
+### ドキュメント要件
+
+- [ ] Claude Agent SDK統合仕様が文書化されている
+- [ ] Hooksシステム実装ガイドが作成されている
+- [ ] Permission Control設定ガイドが作成されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/main/services/agent/
+```
+
+### 検証手順
+
+1. アプリを起動
+2. スキルを選択
+3. メッセージを送信してagent:startを呼び出す
+4. SDK `query()` APIが呼び出されることを確認
+5. ストリーミング出力（agent:stream）がRendererに届くことを確認
+6. 危険なBashコマンド実行時にPreToolUseでブロックされることを確認
+7. askルールのツール使用時にPermission Dialog（agent:permission）が表示されることを確認
+8. Permission Dialogで承認/拒否した結果がエージェントに反映されることを確認
+9. キャンセルボタンで実行がAbortSignalで中断されることを確認
+10. 複数実行を同時に開始して独立管理されることを確認
+
+---
+
+## 7. リスクと対策
+
+| リスク                              | 影響度 | 発生確率 | 対策                                                 |
+| ----------------------------------- | ------ | -------- | ---------------------------------------------------- |
+| Claude Codeの認証が未完了           | 高     | 中       | 起動時チェック、認証ガイド表示                       |
+| Permission Dialog応答のタイムアウト | 中     | 中       | タイムアウト設定、デフォルト拒否                     |
+| ストリーミングの途切れ              | 中     | 低       | エラーハンドリング、再試行ロジック                   |
+| AbortSignalの伝播漏れ               | 中     | 低       | signal.abortedの定期チェック、Hook内でのチェック実装 |
+| 複数実行時のPermission競合          | 中     | 低       | executionIdによる分離、requestIdによる一意識別       |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- Claude Agent SDK スキル: `.claude/skills/claude-agent-sdk/`
+  - `references/query-api.md` - query() API
+  - `references/hooks-system.md` - Hooksシステム
+  - `references/permission-control.md` - Permission Control
+  - `references/electron-ipc.md` - Electron IPC統合
+  - `assets/agent-handler-template.ts` - IPCハンドラーテンプレート
+- `apps/desktop/src/main/ipc/` - 既存IPCハンドラー
+
+### 参考資料
+
+- [Claude Agent SDK](https://github.com/anthropics/claude-code) - `@anthropic-ai/claude-agent-sdk`
+- [AbortController MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+- [AsyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+
+---
+
+## 9. 備考
+
+### 実行モデル：Claude Agent SDK
+
+本機能は、**Claude Agent SDK（`@anthropic-ai/claude-agent-sdk`）** を使用します：
+
+- SDKはローカルのClaude Code認証を自動的に利用する
+- ユーザーのClaude Codeサブスクリプション（Pro/Team/Enterprise）を使用
+- アプリはAnthropicAPIキーを直接管理しない
+- `query()` APIでストリーミング、Hooks、Permission Controlを統合的に扱う
+
+### SDK `query()` API 基本形式
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const conversation = query({
+  prompt: "ユーザーメッセージ",
+  options: {
+    tools: ["Read", "Edit", "Write", "Bash"],
+    permissionMode: "default",
+    permissions: { allow: [...], deny: [...], ask: [...] },
+    hooks: { PreToolUse, PostToolUse, PermissionRequest },
+    signal: abortController.signal,
+    settingSources: ["user", "project"],
+  },
+});
+
+for await (const message of conversation.stream()) {
+  // ストリーミング処理
+}
+```
+
+### 前提条件
+
+- Claude Code（ローカル認証済み）がインストールされていること
+- 有効なClaude Code契約（Pro/Team/Enterprise）があること
+- `@anthropic-ai/claude-agent-sdk` パッケージがインストールされていること
+
+### Hooksシステムの注意点
+
+- `signal.aborted`を定期的にチェックすること
+- 非同期処理には適切なタイムアウトを設定すること
+- PreToolUseで危険なコマンドを確実にブロックすること
+
+### Permission Controlの注意点
+
+- 最小権限の原則に従うこと（deny-allから開始）
+- プロジェクトディレクトリ外への書き込みを禁止すること
+- 本番環境では`bypassPermissions`を使用しないこと
+
+### Permission Dialog連携
+
+- AGENT-004でPermission Dialog UIを実装
+- Main→Renderer: `agent:permission` イベントで権限確認を要求
+- Renderer→Main: `agent:permission:res` で承認/拒否を応答
+- `rememberChoice`オプションで同一ツールの次回以降の判定を記憶可能
+
+### 将来の拡張
+
+- カスタムPermission Rules UI（設定画面から編集）
+- 実行履歴の永続化
+- 複数のPermissionプリセット対応

--- a/docs/30-workflows/unassigned-task/task-agent-06-custom-environment-ui.md
+++ b/docs/30-workflows/unassigned-task/task-agent-06-custom-environment-ui.md
@@ -1,0 +1,566 @@
+# カスタム実行環境UI - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容               |
+| ------------ | ------------------ |
+| タスクID     | AGENT-006          |
+| タスク名     | カスタム実行環境UI |
+| 分類         | 要件               |
+| 対象機能     | エージェント機能   |
+| 優先度       | 中                 |
+| 見積もり規模 | 大規模             |
+| ステータス   | 未実施             |
+| 発見元       | ユーザー要求       |
+| 発見日       | 2026-01-09         |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002)
+    │
+    └──► task-agent-03-skill-management-backend.md (AGENT-003)
+              │
+              ├──► task-agent-04-execution-ui.md (AGENT-004)
+              │
+              └──► task-agent-05-claude-code-integration.md (AGENT-005)
+                        │
+                        ├──► task-agent-06-custom-environment-ui.md (AGENT-006/本タスク)
+                        │
+                        └──► task-agent-07-environment-backend.md (AGENT-007) ※本タスクと並行可能
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                                                                   |
+| ------------------------ | ---------------------------------------------------------------------- |
+| 直接依存                 | AGENT-004（エージェント実行UI）, AGENT-005（Claude Code統合）          |
+| 並行実行可能             | AGENT-007（実行環境管理バックエンド）※バックエンドはモックで並行開発可 |
+| 本タスク完了後に開始可能 | なし（最終タスク）                                                     |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+エージェントが生成した成果物（HTMLスライド、コード、ドキュメント等）をリアルタイムでプレビュー・検証するための専用実行環境が必要。例えば、HTMLスライド作成スキルを使用した場合、生成されたHTMLをその場でプレビューできる環境が求められる。
+
+### 1.2 問題点・課題
+
+- 生成されたHTMLをプレビューする機能がない
+- スキルごとに異なる実行環境（HTML、Markdown、コード実行等）を提供する仕組みがない
+- エージェントの出力結果を視覚的に確認する手段がチャット表示のみ
+
+### 1.3 放置した場合の影響
+
+- 生成物の確認のために外部ツールへの切り替えが必要
+- 開発フローが断片化し、生産性が低下
+- エージェント機能の価値が大幅に減少
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+スキルの種類に応じたカスタム実行環境（HTMLプレビュー、Markdownプレビュー等）を提供し、エージェントの出力結果をリアルタイムで確認できるようにする。
+
+### 2.2 最終ゴール
+
+- スキル設定に基づいて適切な実行環境が自動選択される
+- HTMLプレビュー環境でHTMLコンテンツを表示できる
+- プレビューがリアルタイムで更新される
+- プレビューと チャットが分割表示される
+- 将来的な環境拡張が容易な設計
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- ExecutionEnvironmentコンテナコンポーネント
+- HTMLPreviewEnvironmentコンポーネント
+- MarkdownPreviewEnvironmentコンポーネント（基本実装）
+- 環境切り替えロジック
+- 分割レイアウト（チャット + プレビュー）
+- 環境設定のスキルメタデータ定義
+
+#### 含まないもの
+
+- コード実行環境（サンドボックス必要、将来タスク）
+- ターミナルエミュレータ（将来タスク）
+- バックエンド実行環境管理（別タスク: AGENT-007）
+
+### 2.4 成果物
+
+| 成果物                     | パス                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| ExecutionEnvironment       | `apps/desktop/src/renderer/components/organisms/ExecutionEnvironment/index.tsx`       |
+| HTMLPreviewEnvironment     | `apps/desktop/src/renderer/components/organisms/HTMLPreviewEnvironment/index.tsx`     |
+| MarkdownPreviewEnvironment | `apps/desktop/src/renderer/components/organisms/MarkdownPreviewEnvironment/index.tsx` |
+| EnvironmentSelector        | `apps/desktop/src/renderer/components/molecules/EnvironmentSelector/index.tsx`        |
+| SplitLayout                | `apps/desktop/src/renderer/components/organisms/SplitLayout/index.tsx`                |
+| AgentExecutionView更新     | `apps/desktop/src/renderer/views/AgentExecutionView/index.tsx`                        |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-001（エージェントダッシュボード基盤）が完了している
+- AGENT-002（スキル管理UI）が完了している
+- AGENT-003（エージェント実行UI）が完了している
+
+### 3.2 依存タスク
+
+- AGENT-001: エージェントダッシュボード基盤
+- AGENT-002: スキル管理UI
+- AGENT-003: エージェント実行UI
+- AGENT-007: 実行環境管理バックエンド（並行開発可能）
+
+### 3.3 必要な知識・スキル
+
+- React/TypeScript
+- Electron webview / iframe セキュリティ
+- サンドボックス化
+- 分割レイアウト実装
+
+### 3.4 推奨アプローチ
+
+1. 環境タイプの型定義
+2. SplitLayoutコンポーネント実装
+3. ExecutionEnvironmentコンテナ実装
+4. HTMLPreviewEnvironment実装（iframe + sandbox）
+5. MarkdownPreviewEnvironment実装
+6. AgentExecutionViewへの統合
+7. スキルメタデータへの環境設定追加
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+```gherkin
+Feature: カスタム実行環境UI
+
+Scenario: HTMLスキルでHTMLプレビューが表示される
+  Given ユーザーがHTMLスライド作成スキルを選択している
+  When エージェントがHTMLコンテンツを生成する
+  Then 右側パネルにHTMLプレビューが表示される
+  And プレビューはサンドボックス化されている
+
+Scenario: プレビューがリアルタイムで更新される
+  Given ユーザーがHTMLプレビュー環境を使用している
+  When エージェントが追加のHTMLコンテンツを生成する
+  Then プレビューが自動的に更新される
+
+Scenario: チャットとプレビューが分割表示される
+  Given ユーザーがカスタム環境対応スキルを実行している
+  When 実行画面が表示される
+  Then 画面が左右に分割される
+  And 左側にチャット、右側にプレビューが表示される
+
+Scenario: 分割比率を調整できる
+  Given 分割レイアウトが表示されている
+  When 分割バーをドラッグする
+  Then 左右のパネル比率が変更される
+
+Scenario: 環境を手動で切り替えられる
+  Given 複数の環境タイプがサポートされている
+  When 環境セレクターで別の環境を選択する
+  Then 右側パネルの環境が切り替わる
+
+Scenario: プレビュー内でスクリプトが隔離されている
+  Given HTMLプレビューが表示されている
+  When HTMLに悪意のあるスクリプトが含まれている
+  Then スクリプトは親ウィンドウにアクセスできない
+  And アラートやリダイレクトは抑制される
+```
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] セキュリティ要件が定義されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由           |
+| ----------------- | ------------------------------------------- | ------------------ |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | 分割レイアウト設計 |
+| domain-modeling   | `.claude/skills/domain-modeling/SKILL.md`   | 環境モデル設計     |
+
+#### 設計内容
+
+**1. 環境タイプの型定義**
+
+```typescript
+// packages/shared/src/types/agent.ts に追加
+
+export type EnvironmentType =
+  | "none" // プレビューなし
+  | "html" // HTMLプレビュー
+  | "markdown" // Markdownプレビュー
+  | "terminal" // ターミナル（将来）
+  | "code"; // コード実行（将来）
+
+export interface EnvironmentConfig {
+  type: EnvironmentType;
+  autoRefresh: boolean;
+  refreshDebounce: number; // ms
+  sandboxFlags?: string[]; // iframe sandbox flags
+}
+
+export interface Skill {
+  // 既存フィールド...
+  environment?: EnvironmentConfig; // 追加
+}
+
+export interface PreviewContent {
+  type: EnvironmentType;
+  content: string;
+  timestamp: Date;
+}
+```
+
+**2. agentSlice拡張**
+
+```typescript
+// agentSlice.ts 追加
+export interface AgentSlice {
+  // 既存フィールド...
+
+  // プレビュー状態
+  previewContent: PreviewContent | null;
+  selectedEnvironment: EnvironmentType;
+  splitRatio: number; // 0-100 (左パネル比率)
+
+  // アクション
+  setPreviewContent: (content: PreviewContent) => void;
+  setSelectedEnvironment: (type: EnvironmentType) => void;
+  setSplitRatio: (ratio: number) => void;
+  clearPreview: () => void;
+}
+```
+
+**3. コンポーネント構造**
+
+```
+AgentExecutionView
+├── SplitLayout (organism)
+│   ├── LeftPanel
+│   │   └── AgentChatInterface (existing)
+│   ├── Divider (ドラッグ可能)
+│   └── RightPanel
+│       ├── EnvironmentSelector (molecule)
+│       └── ExecutionEnvironment (organism)
+│           ├── HTMLPreviewEnvironment
+│           ├── MarkdownPreviewEnvironment
+│           └── (future environments...)
+```
+
+**4. レイアウト設計**
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ ← Back   slide-creator                           [⚙️ Settings]   │
+├─────────────────────────────┬──┬─────────────────────────────────┤
+│                             │  │ [HTML ▼] [↻ Refresh] [⛶ Full]  │
+│ ┌─────────────────────────┐ │  │ ┌─────────────────────────────┐ │
+│ │ 👤 User                  │ │  │ │                             │ │
+│ │ スライドを作成して      │ │  │ │     HTML Preview            │ │
+│ └─────────────────────────┘ │◄►│ │                             │ │
+│ ┌─────────────────────────┐ │  │ │   <h1>Title</h1>            │ │
+│ │ 🤖 Agent                 │ │  │ │   <p>Content...</p>         │ │
+│ │ HTMLスライドを生成中... │ │  │ │                             │ │
+│ └─────────────────────────┘ │  │ └─────────────────────────────┘ │
+│                             │  │                                 │
+├─────────────────────────────┴──┴─────────────────────────────────┤
+│ [メッセージを入力...                              ] [Send]        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**5. HTMLプレビューのセキュリティ**
+
+```typescript
+// HTMLPreviewEnvironment
+const sandboxFlags = [
+  "allow-same-origin", // CSSが動作するために必要
+  // 'allow-scripts',   // スクリプト無効化
+  // 'allow-popups',    // ポップアップ禁止
+  // 'allow-top-navigation', // トップナビゲーション禁止
+];
+
+// Content Security Policy
+const csp = `
+  default-src 'self';
+  script-src 'none';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https:;
+`;
+```
+
+**6. スキルへの環境設定追加**
+
+```markdown
+<!-- SKILL.md に追加 -->
+
+## Environment
+
+| Type | AutoRefresh | Debounce |
+| ---- | ----------- | -------- |
+| html | true        | 500ms    |
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+- セキュリティ設計書
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] セキュリティ設計が完成している
+- [ ] コンポーネント構造が設計されている
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### セキュリティレビュー項目
+
+- [ ] iframe sandboxフラグが適切
+- [ ] CSPが適切に設定されている
+- [ ] XSS対策が考慮されている
+- [ ] 親ウィンドウへのアクセスが制限されている
+
+#### 完了条件
+
+- [ ] セキュリティレビューが完了している
+- [ ] 拡張性が確保されている
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// SplitLayout.test.tsx
+describe("SplitLayout", () => {
+  it("should render left and right panels", () => {});
+  it("should handle divider drag", () => {});
+  it("should respect min/max ratios", () => {});
+  it("should persist ratio to store", () => {});
+});
+
+// ExecutionEnvironment.test.tsx
+describe("ExecutionEnvironment", () => {
+  it("should render correct environment based on type", () => {});
+  it("should show placeholder when no content", () => {});
+});
+
+// HTMLPreviewEnvironment.test.tsx
+describe("HTMLPreviewEnvironment", () => {
+  it("should render HTML content in iframe", () => {});
+  it("should apply sandbox flags", () => {});
+  it("should update on content change", () => {});
+  it("should debounce updates", () => {});
+});
+
+// EnvironmentSelector.test.tsx
+describe("EnvironmentSelector", () => {
+  it("should display current environment", () => {});
+  it("should show available environments", () => {});
+  it("should call onChange when selected", () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 各コンポーネントのテストがある
+- [ ] セキュリティテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名          | パス                                        | 選定理由           |
+| ----------------- | ------------------------------------------- | ------------------ |
+| responsive-design | `.claude/skills/responsive-design/SKILL.md` | 分割レイアウト実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`（更新）
+2. `apps/desktop/src/renderer/store/slices/agentSlice.ts`（更新）
+3. `apps/desktop/src/renderer/components/organisms/SplitLayout/index.tsx`
+4. `apps/desktop/src/renderer/components/molecules/EnvironmentSelector/index.tsx`
+5. `apps/desktop/src/renderer/components/organisms/ExecutionEnvironment/index.tsx`
+6. `apps/desktop/src/renderer/components/organisms/HTMLPreviewEnvironment/index.tsx`
+7. `apps/desktop/src/renderer/components/organisms/MarkdownPreviewEnvironment/index.tsx`
+8. `apps/desktop/src/renderer/views/AgentExecutionView/index.tsx`（更新）
+
+#### 完了条件
+
+- [ ] 全コンポーネントが実装されている
+- [ ] 分割レイアウトが動作する
+- [ ] HTMLプレビューが表示される
+- [ ] セキュリティ対策が実装されている
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] HTMLプレビューが表示される
+- [ ] プレビューがリアルタイムで更新される
+- [ ] チャットとプレビューが分割表示される
+- [ ] 分割比率を調整できる
+- [ ] 環境を手動で切り替えられる
+
+### セキュリティ要件
+
+- [ ] iframe sandboxが適用されている
+- [ ] スクリプト実行が無効化されている
+- [ ] 親ウィンドウへのアクセスが制限されている
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### ドキュメント要件
+
+- [ ] セキュリティガイドラインが文書化されている
+- [ ] 新規環境追加手順が文書化されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/renderer/components/organisms/SplitLayout/
+pnpm --filter @repo/desktop test src/renderer/components/organisms/HTMLPreviewEnvironment/
+```
+
+### 検証手順
+
+1. HTMLスキルを選択して実行
+2. エージェントにHTMLを生成させる
+3. 右側パネルにプレビューが表示されることを確認
+4. 分割バーをドラッグして比率変更を確認
+5. 環境セレクターで切り替えを確認
+6. DevToolsでiframe sandboxが適用されていることを確認
+
+### セキュリティ検証
+
+```html
+<!-- テスト用悪意のあるHTML -->
+<script>
+  alert("XSS");
+</script>
+<script>
+  window.parent.location = "https://evil.com";
+</script>
+<a href="javascript:alert('XSS')">Click</a>
+```
+
+上記が実行されないことを確認する。
+
+---
+
+## 7. リスクと対策
+
+| リスク                         | 影響度 | 発生確率 | 対策                             |
+| ------------------------------ | ------ | -------- | -------------------------------- |
+| XSS攻撃                        | 高     | 中       | sandbox + CSP + スクリプト無効化 |
+| iframe内のリソース読み込み失敗 | 中     | 中       | data URLまたはblob URLを使用     |
+| 大量HTMLでのパフォーマンス低下 | 中     | 中       | debounce + 仮想化検討            |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- [MDN: iframe sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox)
+- [Electron Security](https://www.electronjs.org/docs/latest/tutorial/security)
+
+### 参考資料
+
+- [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+- [react-split-pane](https://github.com/tomkp/react-split-pane)
+
+---
+
+## 9. 備考
+
+### 補足事項
+
+- 初期実装はHTML/Markdownのみ対応
+- コード実行環境は将来タスクとして分離（サンドボックス実装が複雑）
+- プレビュー内でのインタラクション（クリック等）は基本的に無効化
+- フルスクリーン表示機能は追加検討
+
+### 将来の拡張候補
+
+| 環境タイプ | 概要                         | 優先度 |
+| ---------- | ---------------------------- | ------ |
+| terminal   | ターミナルエミュレータ       | 中     |
+| code       | コード実行（サンドボックス） | 低     |
+| diagram    | Mermaid/PlantUML表示         | 低     |
+| pdf        | PDF表示                      | 低     |

--- a/docs/30-workflows/unassigned-task/task-agent-07-environment-backend.md
+++ b/docs/30-workflows/unassigned-task/task-agent-07-environment-backend.md
@@ -1,0 +1,692 @@
+# 実行環境管理バックエンド - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                     |
+| ------------ | ------------------------ |
+| タスクID     | AGENT-007                |
+| タスク名     | 実行環境管理バックエンド |
+| 分類         | 要件                     |
+| 対象機能     | エージェント機能         |
+| 優先度       | 中                       |
+| 見積もり規模 | 中規模                   |
+| ステータス   | 未実施                   |
+| 発見元       | ユーザー要求             |
+| 発見日       | 2026-01-09               |
+
+---
+
+## 依存関係と並行実行
+
+### 依存関係マップ
+
+```
+task-agent-01-dashboard-foundation.md (AGENT-001)
+    │
+    ├──► task-agent-02-skill-management-ui.md (AGENT-002) ─┐
+    │                                                      │
+    └──► task-agent-03-skill-management-backend.md ────────┼──► task-agent-04-execution-ui.md
+         (AGENT-003) ※02と並行可能                         │    (AGENT-004)
+                │                                          │
+                └──► task-agent-05-claude-code-integration ┘    ※04と並行可能
+                     (AGENT-005) ※04と並行可能
+                          │
+                          └──► task-agent-06-custom-environment-ui.md (AGENT-006)
+                                    │
+                                    └──► task-agent-07-environment-backend.md (AGENT-007/本タスク)
+                                         ※06と並行可能
+```
+
+### 本タスクの位置づけ
+
+| 項目                     | 内容                            |
+| ------------------------ | ------------------------------- |
+| 直接依存                 | AGENT-005（Claude Code統合）    |
+| 並行実行可能             | AGENT-006（カスタム実行環境UI） |
+| 本タスク完了後に開始可能 | なし（最終タスク）              |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+カスタム実行環境（HTMLプレビュー等）をサポートするために、エージェント出力からプレビュー用コンテンツを抽出・管理するバックエンド機能が必要。エージェントがHTMLを生成した場合、それを安全にRendererに転送しプレビュー表示できるようにする。
+
+### 1.2 問題点・課題
+
+- エージェント出力からHTML/Markdownコンテンツを抽出する機能がない
+- コンテンツをサニタイズして安全に転送する仕組みがない
+- 一時ファイルとしてコンテンツを保存・管理する機能がない
+
+### 1.3 放置した場合の影響
+
+- カスタム実行環境UI（AGENT-006）が完全に機能しない
+- HTMLプレビュー等の価値提案が実現できない
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+エージェント出力からプレビュー用コンテンツを抽出し、安全にRendererへ転送するバックエンド機能を実装する。
+
+### 2.2 最終ゴール
+
+- エージェント出力からコードブロック（HTML、Markdown等）を抽出できる
+- 抽出したコンテンツをサニタイズして安全に転送できる
+- 一時ファイルとしてコンテンツを保存できる
+- IPC経由でプレビュー用コンテンツを取得できる
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- ContentExtractorサービス（コードブロック抽出）
+- ContentSanitizerサービス（セキュリティ処理）
+- TempFileManagerサービス（一時ファイル管理）
+- agentHandlers拡張
+- IPCチャネル追加
+
+#### 含まないもの
+
+- フロントエンドUI（別タスク: AGENT-006）
+- コード実行サンドボックス（将来タスク）
+
+### 2.4 成果物
+
+| 成果物             | パス                                                               |
+| ------------------ | ------------------------------------------------------------------ |
+| ContentExtractor   | `apps/desktop/src/main/services/environment/ContentExtractor.ts`   |
+| ContentSanitizer   | `apps/desktop/src/main/services/environment/ContentSanitizer.ts`   |
+| TempFileManager    | `apps/desktop/src/main/services/environment/TempFileManager.ts`    |
+| EnvironmentService | `apps/desktop/src/main/services/environment/EnvironmentService.ts` |
+| agentHandlers更新  | `apps/desktop/src/main/ipc/agentHandlers.ts`                       |
+| IPCチャネル更新    | `apps/desktop/src/preload/channels.ts`                             |
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- AGENT-005（Claude Code統合）が完了している
+- セキュリティ要件を理解している
+
+### 3.2 依存タスク
+
+- AGENT-005: Claude Code統合
+
+### 3.3 必要な知識・スキル
+
+- Node.js / TypeScript
+- HTML/Markdownパース
+- セキュリティ（XSS対策）
+- ファイルシステム操作
+
+### 3.4 推奨アプローチ
+
+1. 型定義を追加
+2. ContentExtractorを実装（Markdown解析）
+3. ContentSanitizerを実装（HTML安全化）
+4. TempFileManagerを実装
+5. EnvironmentServiceで統合
+6. agentHandlersを拡張
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+Phase 1-13の標準フローに従って実装する。
+
+### Phase 1: 要件定義
+
+#### 使用スキル
+
+| スキル名                    | パス                                                  | 選定理由                                |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| acceptance-criteria-writing | `.claude/skills/acceptance-criteria-writing/SKILL.md` | Given-When-Then形式で受け入れ基準を定義 |
+
+#### 受け入れ基準（Given-When-Then）
+
+````gherkin
+Feature: 実行環境管理バックエンド
+
+Scenario: HTMLコードブロックを抽出できる
+  Given エージェント出力に以下が含まれる:
+    ```html
+    <div>Hello World</div>
+    ```
+  When ContentExtractorで処理する
+  Then HTML部分が抽出される
+  And タイプが "html" と判定される
+
+Scenario: 複数のコードブロックを抽出できる
+  Given エージェント出力に複数のコードブロックがある
+  When ContentExtractorで処理する
+  Then すべてのコードブロックが抽出される
+  And 各コードブロックに順序番号が付与される
+
+Scenario: HTMLがサニタイズされる
+  Given 抽出されたHTMLに<script>タグが含まれる
+  When ContentSanitizerで処理する
+  Then <script>タグが除去される
+  And onclick等のイベントハンドラが除去される
+
+Scenario: 一時ファイルとして保存できる
+  Given 抽出されたコンテンツがある
+  When TempFileManagerで保存する
+  Then 一時ディレクトリにファイルが作成される
+  And ファイルパスが返される
+
+Scenario: 一時ファイルが適切にクリーンアップされる
+  Given 一時ファイルが作成されている
+  When アプリケーションが終了する
+  Then 一時ファイルが削除される
+
+Scenario: IPC経由でプレビューコンテンツを取得できる
+  Given エージェント出力が処理済みである
+  When agent:get-preview-contentを呼び出す
+  Then 抽出・サニタイズ済みのコンテンツが返される
+````
+
+#### 成果物
+
+- `outputs/phase-1/requirements.md`
+
+#### 完了条件
+
+- [ ] 受け入れ基準がGiven-When-Then形式で定義されている
+- [ ] セキュリティ要件が明確化されている
+
+---
+
+### Phase 2: 設計
+
+#### 使用スキル
+
+| スキル名        | パス                                      | 選定理由             |
+| --------------- | ----------------------------------------- | -------------------- |
+| domain-modeling | `.claude/skills/domain-modeling/SKILL.md` | コンテンツモデル設計 |
+
+#### 設計内容
+
+**1. 型定義**
+
+```typescript
+// packages/shared/src/types/agent.ts に追加
+
+export type ContentType = "html" | "markdown" | "css" | "javascript" | "text";
+
+export interface ExtractedContent {
+  id: string;
+  type: ContentType;
+  content: string;
+  language?: string; // コードブロックの言語指定
+  order: number; // 出現順序
+  extractedAt: Date;
+}
+
+export interface SanitizedContent {
+  id: string;
+  type: ContentType;
+  originalContent: string;
+  sanitizedContent: string;
+  removedElements: string[]; // 除去された要素のリスト
+  sanitizedAt: Date;
+}
+
+export interface PreviewContent {
+  executionId: string;
+  contents: SanitizedContent[];
+  tempFilePath?: string;
+  createdAt: Date;
+}
+```
+
+**2. ContentExtractor設計**
+
+````typescript
+// ContentExtractor.ts
+export class ContentExtractor {
+  // Markdownコードブロックを抽出
+  // ```html ... ``` 形式を検出
+  extractCodeBlocks(text: string): ExtractedContent[] {
+    const regex = /```(\w+)?\n([\s\S]*?)```/g;
+    const contents: ExtractedContent[] = [];
+    let match;
+    let order = 0;
+
+    while ((match = regex.exec(text)) !== null) {
+      const language = match[1] || "text";
+      const content = match[2];
+
+      contents.push({
+        id: uuidv4(),
+        type: this.detectContentType(language),
+        content: content.trim(),
+        language,
+        order: order++,
+        extractedAt: new Date(),
+      });
+    }
+
+    return contents;
+  }
+
+  // 最後のHTML/Markdownブロックを取得（プレビュー用）
+  getPreviewableContent(contents: ExtractedContent[]): ExtractedContent | null {
+    const previewable = contents.filter((c) =>
+      ["html", "markdown"].includes(c.type),
+    );
+    return previewable[previewable.length - 1] || null;
+  }
+
+  private detectContentType(language: string): ContentType {
+    const mapping: Record<string, ContentType> = {
+      html: "html",
+      htm: "html",
+      markdown: "markdown",
+      md: "markdown",
+      css: "css",
+      javascript: "javascript",
+      js: "javascript",
+    };
+    return mapping[language.toLowerCase()] || "text";
+  }
+}
+````
+
+**3. ContentSanitizer設計**
+
+```typescript
+// ContentSanitizer.ts
+import DOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+
+export class ContentSanitizer {
+  private purify: DOMPurify.DOMPurifyI;
+
+  constructor() {
+    const window = new JSDOM("").window;
+    this.purify = DOMPurify(window);
+  }
+
+  sanitizeHtml(content: ExtractedContent): SanitizedContent {
+    const removedElements: string[] = [];
+
+    // DOMPurify設定
+    this.purify.addHook("uponSanitizeElement", (node) => {
+      if (node.nodeName === "SCRIPT") {
+        removedElements.push("script");
+      }
+    });
+
+    const sanitized = this.purify.sanitize(content.content, {
+      FORBID_TAGS: ["script", "style", "iframe", "object", "embed"],
+      FORBID_ATTR: ["onclick", "onerror", "onload", "onmouseover"],
+      ALLOW_DATA_ATTR: false,
+    });
+
+    this.purify.removeAllHooks();
+
+    return {
+      id: content.id,
+      type: content.type,
+      originalContent: content.content,
+      sanitizedContent: sanitized,
+      removedElements,
+      sanitizedAt: new Date(),
+    };
+  }
+
+  sanitize(content: ExtractedContent): SanitizedContent {
+    if (content.type === "html") {
+      return this.sanitizeHtml(content);
+    }
+
+    // Markdown等はそのまま（フロントエンドで安全にレンダリング）
+    return {
+      id: content.id,
+      type: content.type,
+      originalContent: content.content,
+      sanitizedContent: content.content,
+      removedElements: [],
+      sanitizedAt: new Date(),
+    };
+  }
+}
+```
+
+**4. TempFileManager設計**
+
+```typescript
+// TempFileManager.ts
+import { app } from "electron";
+import path from "path";
+import fs from "fs/promises";
+
+export class TempFileManager {
+  private tempDir: string;
+  private files: Set<string> = new Set();
+
+  constructor() {
+    this.tempDir = path.join(app.getPath("temp"), "ai-workflow-orchestrator");
+  }
+
+  async initialize(): Promise<void> {
+    await fs.mkdir(this.tempDir, { recursive: true });
+  }
+
+  async saveContent(content: SanitizedContent): Promise<string> {
+    const ext = this.getExtension(content.type);
+    const filename = `preview-${content.id}${ext}`;
+    const filepath = path.join(this.tempDir, filename);
+
+    await fs.writeFile(filepath, content.sanitizedContent, "utf-8");
+    this.files.add(filepath);
+
+    return filepath;
+  }
+
+  async cleanup(): Promise<void> {
+    for (const filepath of this.files) {
+      try {
+        await fs.unlink(filepath);
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+    this.files.clear();
+  }
+
+  async cleanupFile(filepath: string): Promise<void> {
+    if (this.files.has(filepath)) {
+      await fs.unlink(filepath);
+      this.files.delete(filepath);
+    }
+  }
+
+  private getExtension(type: ContentType): string {
+    const mapping: Record<ContentType, string> = {
+      html: ".html",
+      markdown: ".md",
+      css: ".css",
+      javascript: ".js",
+      text: ".txt",
+    };
+    return mapping[type];
+  }
+}
+```
+
+**5. IPCチャネル定義**
+
+```typescript
+// channels.ts に追加
+AGENT_EXTRACT_CONTENT: "agent:extract-content",
+AGENT_GET_PREVIEW_CONTENT: "agent:get-preview-content",
+AGENT_CLEANUP_TEMP_FILES: "agent:cleanup-temp-files",
+```
+
+**6. agentHandlers拡張**
+
+```typescript
+// agentHandlers.ts に追加
+export function registerEnvironmentHandlers(
+  environmentService: EnvironmentService,
+): void {
+  ipcMain.handle(IPC_CHANNELS.AGENT_EXTRACT_CONTENT, async (_e, { text }) => {
+    return environmentService.extractAndSanitize(text);
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.AGENT_GET_PREVIEW_CONTENT,
+    async (_e, { executionId }) => {
+      return environmentService.getPreviewContent(executionId);
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.AGENT_CLEANUP_TEMP_FILES, async () => {
+    await environmentService.cleanupTempFiles();
+    return true;
+  });
+}
+```
+
+#### 成果物
+
+- `outputs/phase-2/design.md`
+
+#### 完了条件
+
+- [ ] 型定義が完成している
+- [ ] クラス設計が完成している
+- [ ] セキュリティ設計が完成している
+
+---
+
+### Phase 3: 設計レビューゲート
+
+#### 使用スキル
+
+| スキル名             | パス                                           | 選定理由         |
+| -------------------- | ---------------------------------------------- | ---------------- |
+| code-smell-detection | `.claude/skills/code-smell-detection/SKILL.md` | 設計品質チェック |
+
+#### セキュリティレビュー項目
+
+- [ ] XSS対策が適切
+- [ ] 一時ファイルのパーミッション
+- [ ] クリーンアップの確実性
+
+#### 完了条件
+
+- [ ] セキュリティレビューが完了している
+- [ ] 既存パターンと整合している
+
+---
+
+### Phase 4: テスト作成
+
+#### 使用スキル
+
+| スキル名       | パス                                     | 選定理由        |
+| -------------- | ---------------------------------------- | --------------- |
+| tdd-principles | `.claude/skills/tdd-principles/SKILL.md` | TDDでテスト先行 |
+
+#### テストケース
+
+```typescript
+// ContentExtractor.test.ts
+describe("ContentExtractor", () => {
+  it("should extract html code block", () => {});
+  it("should extract markdown code block", () => {});
+  it("should extract multiple code blocks", () => {});
+  it("should handle code blocks without language", () => {});
+  it("should return empty array for text without code blocks", () => {});
+  it("should detect content type correctly", () => {});
+});
+
+// ContentSanitizer.test.ts
+describe("ContentSanitizer", () => {
+  it("should remove script tags", () => {});
+  it("should remove onclick handlers", () => {});
+  it("should remove iframe tags", () => {});
+  it("should preserve safe html", () => {});
+  it("should track removed elements", () => {});
+  it("should pass through non-html content", () => {});
+});
+
+// TempFileManager.test.ts
+describe("TempFileManager", () => {
+  it("should create temp directory", async () => {});
+  it("should save content to file", async () => {});
+  it("should cleanup all files", async () => {});
+  it("should cleanup specific file", async () => {});
+  it("should use correct file extension", async () => {});
+});
+
+// EnvironmentService.test.ts
+describe("EnvironmentService", () => {
+  it("should extract and sanitize content", async () => {});
+  it("should save preview content", async () => {});
+  it("should retrieve preview content", async () => {});
+});
+```
+
+#### 完了条件
+
+- [ ] 各クラスのユニットテストがある
+- [ ] セキュリティテストがある
+- [ ] すべてのテストが失敗状態（Red）
+
+---
+
+### Phase 5: 実装
+
+#### 使用スキル
+
+| スキル名        | パス                                      | 選定理由     |
+| --------------- | ----------------------------------------- | ------------ |
+| domain-modeling | `.claude/skills/domain-modeling/SKILL.md` | サービス実装 |
+
+#### 実装ファイル
+
+1. `packages/shared/src/types/agent.ts`（更新）
+2. `apps/desktop/src/main/services/environment/ContentExtractor.ts`
+3. `apps/desktop/src/main/services/environment/ContentSanitizer.ts`
+4. `apps/desktop/src/main/services/environment/TempFileManager.ts`
+5. `apps/desktop/src/main/services/environment/EnvironmentService.ts`
+6. `apps/desktop/src/main/services/environment/index.ts`
+7. `apps/desktop/src/main/ipc/agentHandlers.ts`（更新）
+8. `apps/desktop/src/preload/channels.ts`（更新）
+
+#### 完了条件
+
+- [ ] 全クラスが実装されている
+- [ ] コンテンツ抽出が動作する
+- [ ] サニタイズが動作する
+- [ ] 一時ファイル管理が動作する
+- [ ] テストがすべて通過（Green）
+
+---
+
+### Phase 6-13: 標準フロー
+
+標準のPhase 6-13フローに従って実装を完了する。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] HTMLコードブロックを抽出できる
+- [ ] HTMLがサニタイズされる
+- [ ] 一時ファイルとして保存できる
+- [ ] IPC経由でプレビューコンテンツを取得できる
+- [ ] 一時ファイルがクリーンアップされる
+
+### セキュリティ要件
+
+- [ ] XSS対策が実装されている
+- [ ] 危険なタグ・属性が除去される
+- [ ] 一時ファイルの権限が適切
+
+### 品質要件
+
+- [ ] テストカバレッジ: Line 80%以上
+- [ ] TypeScript型エラーなし
+- [ ] ESLint/Prettierエラーなし
+
+### ドキュメント要件
+
+- [ ] セキュリティ仕様が文書化されている
+- [ ] 実装ガイドが作成されている
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+```bash
+# ユニットテスト
+pnpm --filter @repo/desktop test src/main/services/environment/
+```
+
+### 検証手順
+
+1. エージェントでHTMLを生成させる
+2. agent:extract-contentで抽出を確認
+3. サニタイズ結果を確認（script除去等）
+4. 一時ファイル保存を確認
+5. アプリ終了後にファイルがクリーンアップされることを確認
+
+### セキュリティ検証
+
+```html
+<!-- テスト用悪意のあるHTML -->
+<script>
+  alert("XSS");
+</script>
+<div onclick="alert('XSS')">Click</div>
+<iframe src="https://evil.com"></iframe>
+```
+
+上記が除去されることを確認する。
+
+---
+
+## 7. リスクと対策
+
+| リスク               | 影響度 | 発生確率 | 対策                               |
+| -------------------- | ------ | -------- | ---------------------------------- |
+| サニタイズ漏れ       | 高     | 低       | DOMPurify使用、テスト充実          |
+| 一時ファイルの肥大化 | 中     | 中       | 定期クリーンアップ、サイズ制限     |
+| ファイル残存         | 低     | 中       | アプリ終了時の確実なクリーンアップ |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- [DOMPurify](https://github.com/cure53/DOMPurify)
+- `apps/desktop/src/main/services/` - 既存サービス参照
+
+### 参考資料
+
+- [OWASP XSS Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+
+---
+
+## 9. 備考
+
+### DOMPurify設定
+
+```typescript
+const config = {
+  FORBID_TAGS: ["script", "style", "iframe", "object", "embed", "base"],
+  FORBID_ATTR: ["onclick", "onerror", "onload", "onmouseover", "onfocus"],
+  ALLOW_DATA_ATTR: false,
+  SAFE_FOR_TEMPLATES: true,
+};
+```
+
+### 一時ファイル管理
+
+- ディレクトリ: `{app.getPath('temp')}/ai-workflow-orchestrator/`
+- ファイル名: `preview-{uuid}.{ext}`
+- 権限: 600 (owner read/write only)
+- クリーンアップ: アプリ終了時 + 明示的呼び出し
+
+### 将来の拡張
+
+- コード実行サンドボックス（WebWorker + iframe）
+- Mermaid/PlantUML変換
+- PDF生成


### PR DESCRIPTION
## 概要

Claude CodeのClaude Agent SDKを使用したエージェント機能をアプリケーションに統合するための実装計画ドキュメントを追加します。

## 変更内容

### 追加されたドキュメント

- `task-agent-00-index.md`: エージェント機能全体のインデックスと依存関係マップ
- `task-agent-01-dashboard-foundation.md`: AGENT-001 エージェントダッシュボード基盤
- `task-agent-02-skill-management-ui.md`: AGENT-002 スキル管理UI
- `task-agent-03-skill-management-backend.md`: AGENT-003 スキル管理バックエンド
- `task-agent-04-execution-ui.md`: AGENT-004 エージェント実行UI
- `task-agent-05-claude-code-integration.md`: AGENT-005 Claude Agent SDK統合
- `task-agent-06-custom-environment-ui.md`: AGENT-006 カスタム実行環境UI
- `task-agent-07-environment-backend.md`: AGENT-007 実行環境管理バックエンド

### 設定変更

- `.claude/settings.local.json`: Context7 MCPサーバーのツール許可設定を追加

## 変更タイプ

- [x] 📝 ドキュメント (documentation)
- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [ ] 🧪 テスト (test)
- [ ] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト

- [x] 型チェック実行 (`pnpm typecheck`)
- [x] ESLint チェック実行 (`pnpm lint`)
- [x] ユニットテスト実行 (`pnpm test`)
- [x] ビルド確認 (not applicable for docs)

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [x] 新規・変更機能にテストを追加した (not applicable)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)