### PR TITLE
refactor(chat-history): クリーンアーキテクチャへの移行

### DIFF
--- a/packages/shared/src/core/Result.ts
+++ b/packages/shared/src/core/Result.ts
@@ -1,0 +1,319 @@
+/**
+ * Result型 - Railway-Oriented Programming
+ *
+ * 型安全なエラーハンドリングを提供する。
+ * 例外ベースのエラー処理を置き換え、明示的なエラー処理を強制する。
+ *
+ * @module core/Result
+ */
+
+/**
+ * 成功結果
+ */
+export interface Ok<T> {
+  readonly ok: true;
+  readonly value: T;
+}
+
+/**
+ * 失敗結果
+ */
+export interface Err<E> {
+  readonly ok: false;
+  readonly error: E;
+}
+
+/**
+ * Result型（成功または失敗）
+ */
+export type Result<T, E> = Ok<T> | Err<E>;
+
+/**
+ * 非同期Result型
+ */
+export type AsyncResult<T, E> = Promise<Result<T, E>>;
+
+// ========================================
+// Factory Functions
+// ========================================
+
+/**
+ * 成功結果を作成する
+ *
+ * @param value 成功値
+ * @returns Ok<T>
+ */
+export function ok<T>(value: T): Ok<T> {
+  return { ok: true, value };
+}
+
+/**
+ * 失敗結果を作成する
+ *
+ * @param error エラー値
+ * @returns Err<E>
+ */
+export function err<E>(error: E): Err<E> {
+  return { ok: false, error };
+}
+
+// ========================================
+// Type Guards
+// ========================================
+
+/**
+ * 成功かどうかを判定する型ガード
+ *
+ * @param result 判定対象
+ * @returns 成功の場合true
+ */
+export function isOk<T, E>(result: Result<T, E>): result is Ok<T> {
+  return result.ok;
+}
+
+/**
+ * 失敗かどうかを判定する型ガード
+ *
+ * @param result 判定対象
+ * @returns 失敗の場合true
+ */
+export function isErr<T, E>(result: Result<T, E>): result is Err<E> {
+  return !result.ok;
+}
+
+// ========================================
+// Map Functions
+// ========================================
+
+/**
+ * 成功値を変換する
+ *
+ * @param result 元のResult
+ * @param fn 変換関数
+ * @returns 変換後のResult
+ */
+export function map<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => U,
+): Result<U, E> {
+  if (result.ok) {
+    return ok(fn(result.value));
+  }
+  return result;
+}
+
+/**
+ * 失敗値を変換する
+ *
+ * @param result 元のResult
+ * @param fn 変換関数
+ * @returns 変換後のResult
+ */
+export function mapErr<T, E, F>(
+  result: Result<T, E>,
+  fn: (error: E) => F,
+): Result<T, F> {
+  if (!result.ok) {
+    return err(fn(result.error));
+  }
+  return result;
+}
+
+// ========================================
+// FlatMap (Bind/Chain)
+// ========================================
+
+/**
+ * 成功値に対して別のResult返却関数を適用する
+ * Railway-Oriented Programmingの中核
+ *
+ * @param result 元のResult
+ * @param fn Result返却関数
+ * @returns 適用後のResult
+ */
+export function flatMap<T, U, E>(
+  result: Result<T, E>,
+  fn: (value: T) => Result<U, E>,
+): Result<U, E> {
+  if (result.ok) {
+    return fn(result.value);
+  }
+  return result;
+}
+
+/**
+ * flatMapのエイリアス（チェーン用）
+ */
+export const andThen = flatMap;
+
+// ========================================
+// Unwrap Functions
+// ========================================
+
+/**
+ * 成功値を取り出す（失敗時はデフォルト値）
+ *
+ * @param result 元のResult
+ * @param defaultValue デフォルト値
+ * @returns 成功値またはデフォルト値
+ */
+export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
+  if (result.ok) {
+    return result.value;
+  }
+  return defaultValue;
+}
+
+/**
+ * 成功値を取り出す（失敗時は関数実行）
+ *
+ * @param result 元のResult
+ * @param fn エラーから値を生成する関数
+ * @returns 成功値または関数の戻り値
+ */
+export function unwrapOrElse<T, E>(
+  result: Result<T, E>,
+  fn: (error: E) => T,
+): T {
+  if (result.ok) {
+    return result.value;
+  }
+  return fn(result.error);
+}
+
+/**
+ * 成功値を取り出す（失敗時は例外スロー）
+ * 注意: 最終手段としてのみ使用
+ *
+ * @param result 元のResult
+ * @returns 成功値
+ * @throws Errの場合
+ */
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.ok) {
+    return result.value;
+  }
+  throw new Error(`Called unwrap on an Err value: ${String(result.error)}`);
+}
+
+// ========================================
+// Combine Functions
+// ========================================
+
+/**
+ * 複数のResultを合成する（全成功または最初の失敗）
+ *
+ * @param results Result配列
+ * @returns 合成後のResult
+ */
+export function combine<T, E>(results: Result<T, E>[]): Result<T[], E> {
+  const values: T[] = [];
+
+  for (const result of results) {
+    if (!result.ok) {
+      return result;
+    }
+    values.push(result.value);
+  }
+
+  return ok(values);
+}
+
+/**
+ * オブジェクト形式のResult合成
+ *
+ * @param results キーごとのResult
+ * @returns 合成後のResult
+ */
+export function combineObject<T extends Record<string, unknown>, E>(results: {
+  [K in keyof T]: Result<T[K], E>;
+}): Result<T, E> {
+  const obj = {} as T;
+
+  for (const key in results) {
+    const result = results[key];
+    if (!result.ok) {
+      return result;
+    }
+    obj[key] = result.value;
+  }
+
+  return ok(obj);
+}
+
+// ========================================
+// Async Utilities
+// ========================================
+
+/**
+ * 非同期mapユーティリティ
+ *
+ * @param result AsyncResult
+ * @param fn 変換関数
+ * @returns 変換後のAsyncResult
+ */
+export async function mapAsync<T, U, E>(
+  result: AsyncResult<T, E>,
+  fn: (value: T) => U | Promise<U>,
+): AsyncResult<U, E> {
+  const awaited = await result;
+  if (awaited.ok) {
+    return ok(await fn(awaited.value));
+  }
+  return awaited;
+}
+
+/**
+ * 非同期flatMapユーティリティ
+ *
+ * @param result AsyncResult
+ * @param fn Result返却関数
+ * @returns 適用後のAsyncResult
+ */
+export async function flatMapAsync<T, U, E>(
+  result: AsyncResult<T, E>,
+  fn: (value: T) => AsyncResult<U, E>,
+): AsyncResult<U, E> {
+  const awaited = await result;
+  if (awaited.ok) {
+    return fn(awaited.value);
+  }
+  return awaited;
+}
+
+/**
+ * Promiseの例外をResultに変換する
+ *
+ * @param promise 変換対象のPromise
+ * @param errorMapper エラー変換関数
+ * @returns AsyncResult
+ */
+export async function fromPromise<T, E>(
+  promise: Promise<T>,
+  errorMapper: (error: unknown) => E,
+): AsyncResult<T, E> {
+  try {
+    const value = await promise;
+    return ok(value);
+  } catch (error) {
+    return err(errorMapper(error));
+  }
+}
+
+/**
+ * try-catchをResultに変換する（同期版）
+ *
+ * @param fn 実行関数
+ * @param errorMapper エラー変換関数
+ * @returns Result
+ */
+export function fromTry<T, E>(
+  fn: () => T,
+  errorMapper: (error: unknown) => E,
+): Result<T, E> {
+  try {
+    return ok(fn());
+  } catch (error) {
+    return err(errorMapper(error));
+  }
+}

--- a/packages/shared/src/core/__tests__/Result.test.ts
+++ b/packages/shared/src/core/__tests__/Result.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from "vitest";
+import {
+  ok,
+  err,
+  type Result,
+  isOk,
+  isErr,
+  map,
+  flatMap,
+  unwrapOr,
+  unwrapOrElse,
+  combine,
+} from "../Result.js";
+
+describe("Result", () => {
+  describe("ok", () => {
+    it("値を保持できる", () => {
+      // Arrange
+      const value = 42;
+
+      // Act
+      const result = ok(value);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(result.value).toBe(42);
+    });
+
+    it("nullを保持できる", () => {
+      // Act
+      const result = ok(null);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(result.value).toBeNull();
+    });
+  });
+
+  describe("err", () => {
+    it("エラーを保持できる", () => {
+      // Arrange
+      const error = new Error("test error");
+
+      // Act
+      const result = err(error);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe(error);
+    });
+  });
+
+  describe("isOk", () => {
+    it("Ok型の場合はtrueを返す", () => {
+      // Arrange
+      const result = ok(42);
+
+      // Assert
+      expect(isOk(result)).toBe(true);
+    });
+
+    it("Err型の場合はfalseを返す", () => {
+      // Arrange
+      const result = err(new Error("test"));
+
+      // Assert
+      expect(isOk(result)).toBe(false);
+    });
+  });
+
+  describe("isErr", () => {
+    it("Err型の場合はtrueを返す", () => {
+      // Arrange
+      const result = err(new Error("test"));
+
+      // Assert
+      expect(isErr(result)).toBe(true);
+    });
+
+    it("Ok型の場合はfalseを返す", () => {
+      // Arrange
+      const result = ok(42);
+
+      // Assert
+      expect(isErr(result)).toBe(false);
+    });
+  });
+
+  describe("map", () => {
+    it("Okの場合は値を変換できる", () => {
+      // Arrange
+      const result = ok(10);
+      const fn = (x: number) => x * 2;
+
+      // Act
+      const mapped = map(result, fn);
+
+      // Assert
+      expect(mapped.ok).toBe(true);
+      if (mapped.ok) expect(mapped.value).toBe(20);
+    });
+
+    it("Errの場合はエラーをそのまま返す", () => {
+      // Arrange
+      const error = new Error("test");
+      const result: Result<number, Error> = err(error);
+      const fn = (x: number) => x * 2;
+
+      // Act
+      const mapped = map(result, fn);
+
+      // Assert
+      expect(mapped.ok).toBe(false);
+      if (!mapped.ok) expect(mapped.error).toBe(error);
+    });
+  });
+
+  describe("flatMap", () => {
+    it("Okの場合はResult返却関数を適用できる", () => {
+      // Arrange
+      const result = ok(10);
+      const fn = (x: number) => ok(x * 2);
+
+      // Act
+      const flatMapped = flatMap(result, fn);
+
+      // Assert
+      expect(flatMapped.ok).toBe(true);
+      if (flatMapped.ok) expect(flatMapped.value).toBe(20);
+    });
+
+    it("チェーン内でエラーが発生した場合はエラーを返す", () => {
+      // Arrange
+      const result = ok(10);
+      const fn = (_x: number) => err(new Error("chain error"));
+
+      // Act
+      const flatMapped = flatMap(result, fn);
+
+      // Assert
+      expect(flatMapped.ok).toBe(false);
+    });
+
+    it("Errの場合はエラーをそのまま返す", () => {
+      // Arrange
+      const error = new Error("original error");
+      const result: Result<number, Error> = err(error);
+      const fn = (x: number) => ok(x * 2);
+
+      // Act
+      const flatMapped = flatMap(result, fn);
+
+      // Assert
+      expect(flatMapped.ok).toBe(false);
+      if (!flatMapped.ok) expect(flatMapped.error).toBe(error);
+    });
+  });
+
+  describe("unwrapOr", () => {
+    it("Okの場合は値を取得できる", () => {
+      // Arrange
+      const result = ok(42);
+
+      // Act
+      const value = unwrapOr(result, 0);
+
+      // Assert
+      expect(value).toBe(42);
+    });
+
+    it("Errの場合はデフォルト値を返す", () => {
+      // Arrange
+      const result: Result<number, Error> = err(new Error("test"));
+
+      // Act
+      const value = unwrapOr(result, 0);
+
+      // Assert
+      expect(value).toBe(0);
+    });
+  });
+
+  describe("unwrapOrElse", () => {
+    it("Okの場合は値を取得できる", () => {
+      // Arrange
+      const result = ok(42);
+
+      // Act
+      const value = unwrapOrElse(result, () => 0);
+
+      // Assert
+      expect(value).toBe(42);
+    });
+
+    it("Errの場合は関数を実行して値を返す", () => {
+      // Arrange
+      const result: Result<number, Error> = err(new Error("test"));
+
+      // Act
+      const value = unwrapOrElse(result, (e) => e.message.length);
+
+      // Assert
+      expect(value).toBe(4); // "test".length
+    });
+  });
+
+  describe("combine", () => {
+    it("全てOkの場合は値の配列を返す", () => {
+      // Arrange
+      const results = [ok(1), ok(2), ok(3)];
+
+      // Act
+      const combined = combine(results);
+
+      // Assert
+      expect(combined.ok).toBe(true);
+      if (combined.ok) expect(combined.value).toEqual([1, 2, 3]);
+    });
+
+    it("一つでもErrがある場合は最初のエラーを返す", () => {
+      // Arrange
+      const error = new Error("first error");
+      const results = [ok(1), err(error), ok(3)];
+
+      // Act
+      const combined = combine(results);
+
+      // Assert
+      expect(combined.ok).toBe(false);
+      if (!combined.ok) expect(combined.error).toBe(error);
+    });
+
+    it("空配列の場合は空配列を返す", () => {
+      // Arrange
+      const results: Result<number, Error>[] = [];
+
+      // Act
+      const combined = combine(results);
+
+      // Assert
+      expect(combined.ok).toBe(true);
+      if (combined.ok) expect(combined.value).toEqual([]);
+    });
+  });
+});

--- a/packages/shared/src/core/errors/AppError.ts
+++ b/packages/shared/src/core/errors/AppError.ts
@@ -1,0 +1,40 @@
+/**
+ * アプリケーションエラーの基底クラス
+ *
+ * 全てのカスタムエラーはこのクラスを継承する。
+ * エラーコード、ステータスコード、JSON変換機能を提供。
+ *
+ * @module core/errors/AppError
+ */
+export abstract class AppError extends Error {
+  /**
+   * エラーコード（識別用）
+   */
+  abstract readonly code: string;
+
+  /**
+   * HTTPステータスコード相当の数値
+   */
+  abstract readonly statusCode: number;
+
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    // ES6クラスでのError継承の問題を解決
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  /**
+   * JSONシリアライズ用
+   *
+   * @returns エラー情報を含むオブジェクト
+   */
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      statusCode: this.statusCode,
+    };
+  }
+}

--- a/packages/shared/src/core/errors/DomainError.ts
+++ b/packages/shared/src/core/errors/DomainError.ts
@@ -1,0 +1,49 @@
+/**
+ * ドメイン層のエラー
+ *
+ * ビジネスルール違反、バリデーションエラーなど
+ * ドメイン層で発生するエラーを表現する。
+ *
+ * @module core/errors/DomainError
+ */
+
+import { AppError } from "./AppError.js";
+
+/**
+ * ドメインエラーの基底クラス
+ */
+export abstract class DomainError extends AppError {
+  readonly statusCode = 400; // Bad Request
+
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * バリデーションエラー
+ *
+ * 値オブジェクトの不変条件違反など
+ */
+export class ValidationError extends DomainError {
+  constructor(
+    readonly field: string,
+    message: string,
+  ) {
+    super("VALIDATION_ERROR", `${field}: ${message}`);
+  }
+}
+
+/**
+ * ビジネスルール違反エラー
+ *
+ * ドメインのビジネスルールに反する操作が試みられた場合
+ */
+export class BusinessRuleError extends DomainError {
+  constructor(code: string, message: string) {
+    super(code, message);
+  }
+}

--- a/packages/shared/src/core/errors/InfrastructureError.ts
+++ b/packages/shared/src/core/errors/InfrastructureError.ts
@@ -1,0 +1,46 @@
+/**
+ * インフラストラクチャ層のエラー
+ *
+ * データベース、外部サービスなど
+ * インフラ層で発生するエラーを表現する。
+ *
+ * @module core/errors/InfrastructureError
+ */
+
+import { AppError } from "./AppError.js";
+
+/**
+ * インフラエラーの基底クラス
+ */
+export class InfrastructureError extends AppError {
+  readonly statusCode = 500; // Internal Server Error
+
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly cause?: Error,
+  ) {
+    super(message);
+    if (cause) {
+      this.stack = `${this.stack}\nCaused by: ${cause.stack}`;
+    }
+  }
+}
+
+/**
+ * データベースエラー
+ */
+export class DatabaseError extends InfrastructureError {
+  constructor(message: string, cause?: Error) {
+    super("DATABASE_ERROR", message, cause);
+  }
+}
+
+/**
+ * 外部サービスエラー
+ */
+export class ExternalServiceError extends InfrastructureError {
+  constructor(serviceName: string, message: string, cause?: Error) {
+    super("EXTERNAL_SERVICE_ERROR", `${serviceName}: ${message}`, cause);
+  }
+}

--- a/packages/shared/src/core/errors/UseCaseError.ts
+++ b/packages/shared/src/core/errors/UseCaseError.ts
@@ -1,0 +1,56 @@
+/**
+ * Use Case層のエラー
+ *
+ * アプリケーション層で発生するエラーを表現する。
+ * リソース未発見、権限エラー、競合エラーなど。
+ *
+ * @module core/errors/UseCaseError
+ */
+
+import { AppError } from "./AppError.js";
+
+/**
+ * Use Caseエラーの基底クラス
+ */
+export class UseCaseError extends AppError {
+  readonly statusCode: number;
+  readonly data?: Record<string, unknown>;
+
+  constructor(
+    readonly code: string,
+    message: string,
+    statusCode = 400,
+    data?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.statusCode = statusCode;
+    this.data = data;
+  }
+}
+
+/**
+ * リソース未発見エラー
+ */
+export class NotFoundError extends UseCaseError {
+  constructor(resourceType: string, id: string) {
+    super("NOT_FOUND", `${resourceType} not found: ${id}`, 404);
+  }
+}
+
+/**
+ * 権限エラー
+ */
+export class UnauthorizedError extends UseCaseError {
+  constructor(message = "Unauthorized") {
+    super("UNAUTHORIZED", message, 401);
+  }
+}
+
+/**
+ * 競合エラー
+ */
+export class ConflictError extends UseCaseError {
+  constructor(message: string) {
+    super("CONFLICT", message, 409);
+  }
+}

--- a/packages/shared/src/core/errors/index.ts
+++ b/packages/shared/src/core/errors/index.ts
@@ -1,0 +1,23 @@
+/**
+ * エラー型の集約エクスポート
+ *
+ * @module core/errors
+ */
+
+export { AppError } from "./AppError.js";
+export {
+  DomainError,
+  ValidationError,
+  BusinessRuleError,
+} from "./DomainError.js";
+export {
+  UseCaseError,
+  NotFoundError,
+  UnauthorizedError,
+  ConflictError,
+} from "./UseCaseError.js";
+export {
+  InfrastructureError,
+  DatabaseError,
+  ExternalServiceError,
+} from "./InfrastructureError.js";

--- a/packages/shared/src/features/chat-history/__tests__/architecture/dependency-rules.test.ts
+++ b/packages/shared/src/features/chat-history/__tests__/architecture/dependency-rules.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Clean Architecture 依存関係ルール検証テスト
+ *
+ * @description
+ * Domain層、Application層、Infrastructure層の依存関係が
+ * Clean Architectureの原則に従っていることを検証する。
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FEATURE_ROOT = join(__dirname, "../..");
+
+/**
+ * 指定ディレクトリ配下の全TypeScriptファイルを再帰的に取得する
+ */
+function getAllTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir);
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      // __tests__ ディレクトリはスキップ
+      if (entry !== "__tests__") {
+        files.push(...getAllTsFiles(fullPath));
+      }
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * ファイル内のimport文を抽出する
+ */
+function extractImports(filePath: string): string[] {
+  const content = readFileSync(filePath, "utf-8");
+  const importRegex = /import\s+(?:(?:type\s+)?[^;]+from\s+)?["']([^"']+)["']/g;
+  const imports: string[] = [];
+
+  let match;
+  while ((match = importRegex.exec(content)) !== null) {
+    imports.push(match[1]);
+  }
+
+  return imports;
+}
+
+/**
+ * 相対パスから実際の解決パスを取得する
+ */
+function resolveImportPath(importPath: string, fromDir: string): string | null {
+  if (importPath.startsWith(".")) {
+    // 相対パスの場合、実際のパスを解決
+    const resolved = join(fromDir, importPath);
+    // .js を .ts に変換
+    return resolved.replace(/\.js$/, ".ts");
+  }
+  return importPath;
+}
+
+describe("Clean Architecture Dependency Rules", () => {
+  describe("Domain層の依存関係", () => {
+    const domainDir = join(FEATURE_ROOT, "domain");
+    let domainFiles: string[] = [];
+
+    try {
+      domainFiles = getAllTsFiles(domainDir);
+    } catch {
+      // ディレクトリが存在しない場合は空配列
+    }
+
+    it("Domain層がInfrastructure層に依存していない", () => {
+      const violations: string[] = [];
+
+      for (const file of domainFiles) {
+        const imports = extractImports(file);
+        const fileDir = dirname(file);
+
+        for (const imp of imports) {
+          const resolved = resolveImportPath(imp, fileDir);
+
+          if (resolved && resolved.includes("/infrastructure/")) {
+            violations.push(
+              `${file.replace(FEATURE_ROOT, "")} imports from infrastructure: ${imp}`,
+            );
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+
+    it("Domain層がApplication層に依存していない", () => {
+      const violations: string[] = [];
+
+      for (const file of domainFiles) {
+        const imports = extractImports(file);
+        const fileDir = dirname(file);
+
+        for (const imp of imports) {
+          const resolved = resolveImportPath(imp, fileDir);
+
+          if (resolved && resolved.includes("/application/")) {
+            violations.push(
+              `${file.replace(FEATURE_ROOT, "")} imports from application: ${imp}`,
+            );
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+
+    it("Domain層がDrizzle ORMに依存していない", () => {
+      const violations: string[] = [];
+
+      for (const file of domainFiles) {
+        const imports = extractImports(file);
+
+        for (const imp of imports) {
+          if (imp.includes("drizzle-orm") || imp.includes("drizzle/")) {
+            violations.push(
+              `${file.replace(FEATURE_ROOT, "")} imports drizzle: ${imp}`,
+            );
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("Application層の依存関係", () => {
+    const applicationDir = join(FEATURE_ROOT, "application");
+    let applicationFiles: string[] = [];
+
+    try {
+      applicationFiles = getAllTsFiles(applicationDir);
+    } catch {
+      // ディレクトリが存在しない場合は空配列
+    }
+
+    it("Application層がInfrastructure層に依存していない", () => {
+      const violations: string[] = [];
+
+      for (const file of applicationFiles) {
+        const imports = extractImports(file);
+        const fileDir = dirname(file);
+
+        for (const imp of imports) {
+          const resolved = resolveImportPath(imp, fileDir);
+
+          if (resolved && resolved.includes("/infrastructure/")) {
+            violations.push(
+              `${file.replace(FEATURE_ROOT, "")} imports from infrastructure: ${imp}`,
+            );
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+
+    it("Application層がDrizzle ORMに依存していない", () => {
+      const violations: string[] = [];
+
+      for (const file of applicationFiles) {
+        const imports = extractImports(file);
+
+        for (const imp of imports) {
+          if (imp.includes("drizzle-orm") || imp.includes("drizzle/")) {
+            violations.push(
+              `${file.replace(FEATURE_ROOT, "")} imports drizzle: ${imp}`,
+            );
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("Infrastructure層の依存関係", () => {
+    const infrastructureDir = join(FEATURE_ROOT, "infrastructure");
+    let _infrastructureFiles: string[] = [];
+
+    try {
+      _infrastructureFiles = getAllTsFiles(infrastructureDir);
+    } catch {
+      // ディレクトリが存在しない場合は空配列（_prefixは意図的に未使用を示す）
+    }
+
+    it("Infrastructure層はDomain層に依存できる", () => {
+      // Infrastructure層からDomain層への依存は許可される
+      // これは依存性逆転の原則に従っている（具体が抽象に依存）
+      expect(true).toBe(true);
+    });
+
+    it("Infrastructure層はApplication層に依存できる", () => {
+      // Infrastructure層からApplication層への依存は許可される
+      // （DTOの利用など）
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/__tests__/architecture/layer-boundaries.test.ts
+++ b/packages/shared/src/features/chat-history/__tests__/architecture/layer-boundaries.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Clean Architecture レイヤー境界検証テスト
+ *
+ * @description
+ * 各レイヤーのファイルが正しいディレクトリに配置されていることを検証する。
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FEATURE_ROOT = join(__dirname, "../..");
+
+describe("Layer Boundaries", () => {
+  describe("Domain層の配置", () => {
+    it("エンティティがdomain/entities/に配置されている", () => {
+      const entitiesDir = join(FEATURE_ROOT, "domain/entities");
+      expect(existsSync(entitiesDir)).toBe(true);
+
+      // 主要エンティティの存在確認
+      expect(existsSync(join(entitiesDir, "ChatSession.ts"))).toBe(true);
+      expect(existsSync(join(entitiesDir, "ChatMessage.ts"))).toBe(true);
+    });
+
+    it("値オブジェクトがdomain/value-objects/に配置されている", () => {
+      const voDir = join(FEATURE_ROOT, "domain/value-objects");
+      expect(existsSync(voDir)).toBe(true);
+
+      // 主要値オブジェクトの存在確認
+      expect(existsSync(join(voDir, "ChatSessionId.ts"))).toBe(true);
+      expect(existsSync(join(voDir, "ChatSessionTitle.ts"))).toBe(true);
+      expect(existsSync(join(voDir, "MessageContent.ts"))).toBe(true);
+    });
+
+    it("リポジトリインターフェースがdomain/repositories/に配置されている", () => {
+      const repoDir = join(FEATURE_ROOT, "domain/repositories");
+      expect(existsSync(repoDir)).toBe(true);
+
+      // リポジトリインターフェースの存在確認
+      expect(existsSync(join(repoDir, "IChatSessionRepository.ts"))).toBe(true);
+      expect(existsSync(join(repoDir, "IChatMessageRepository.ts"))).toBe(true);
+    });
+
+    it("ドメインエラーがdomain/errors/に配置されている", () => {
+      const errorsDir = join(FEATURE_ROOT, "domain/errors");
+      expect(existsSync(errorsDir)).toBe(true);
+    });
+  });
+
+  describe("Application層の配置", () => {
+    it("Use Caseがapplication/use-cases/に配置されている", () => {
+      const useCasesDir = join(FEATURE_ROOT, "application/use-cases");
+      expect(existsSync(useCasesDir)).toBe(true);
+
+      // 主要Use Caseの存在確認
+      expect(existsSync(join(useCasesDir, "CreateChatSessionUseCase.ts"))).toBe(
+        true,
+      );
+      expect(existsSync(join(useCasesDir, "AddUserMessageUseCase.ts"))).toBe(
+        true,
+      );
+    });
+
+    it("DTOがapplication/dto/に配置されている", () => {
+      const dtoDir = join(FEATURE_ROOT, "application/dto");
+      expect(existsSync(dtoDir)).toBe(true);
+
+      // DTOの存在確認
+      expect(existsSync(join(dtoDir, "ChatSessionDTO.ts"))).toBe(true);
+      expect(existsSync(join(dtoDir, "ChatMessageDTO.ts"))).toBe(true);
+    });
+
+    it("Use Caseエラーがapplication/errors/に配置されている", () => {
+      const errorsDir = join(FEATURE_ROOT, "application/errors");
+      expect(existsSync(errorsDir)).toBe(true);
+
+      expect(existsSync(join(errorsDir, "UseCaseErrors.ts"))).toBe(true);
+    });
+  });
+
+  describe("Infrastructure層の配置", () => {
+    it("マッパーがinfrastructure/persistence/mappers/に配置されている", () => {
+      const mappersDir = join(
+        FEATURE_ROOT,
+        "infrastructure/persistence/mappers",
+      );
+      expect(existsSync(mappersDir)).toBe(true);
+
+      // マッパーの存在確認
+      expect(existsSync(join(mappersDir, "ChatSessionMapper.ts"))).toBe(true);
+      expect(existsSync(join(mappersDir, "ChatMessageMapper.ts"))).toBe(true);
+    });
+  });
+
+  describe("レイヤー分離の原則", () => {
+    it("Domain層はビジネスルールのみを含む", () => {
+      // Domain層に含まれるべきファイル種別
+      const domainDir = join(FEATURE_ROOT, "domain");
+      expect(existsSync(domainDir)).toBe(true);
+
+      // Domain層にUIやDBアクセスのコードがないことを確認
+      // （ディレクトリ構造から判断）
+      expect(existsSync(join(domainDir, "components"))).toBe(false);
+      expect(existsSync(join(domainDir, "drizzle"))).toBe(false);
+    });
+
+    it("Application層はユースケースの調整のみを行う", () => {
+      // Application層に含まれるべきファイル種別
+      const applicationDir = join(FEATURE_ROOT, "application");
+      expect(existsSync(applicationDir)).toBe(true);
+
+      // Application層にUIやDBアクセスのコードがないことを確認
+      expect(existsSync(join(applicationDir, "components"))).toBe(false);
+      expect(existsSync(join(applicationDir, "drizzle"))).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/application/dto/ChatMessageDTO.ts
+++ b/packages/shared/src/features/chat-history/application/dto/ChatMessageDTO.ts
@@ -1,0 +1,112 @@
+/**
+ * LLMメタデータDTO
+ */
+export interface LLMMetadataDTO {
+  /** LLMプロバイダー */
+  provider: string;
+  /** LLMモデル */
+  model: string;
+  /** トークン使用量 */
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+  /** レスポンス時間 (ms) */
+  responseTime?: number;
+  /** Temperature設定 */
+  temperature?: number;
+  /** 最大トークン数 */
+  maxTokens?: number;
+  /** 終了理由 */
+  finishReason?: string;
+}
+
+/**
+ * チャットメッセージDTO
+ * Application層とPresentation層間のデータ転送用
+ */
+export interface ChatMessageDTO {
+  /** メッセージID (UUID) */
+  id: string;
+  /** セッションID */
+  sessionId: string;
+  /** メッセージロール */
+  role: "user" | "assistant";
+  /** メッセージ内容 */
+  content: string;
+  /** メッセージインデックス */
+  messageIndex: number;
+  /** LLMメタデータ (assistantの場合のみ) */
+  llmMetadata: LLMMetadataDTO | null;
+  /** 作成日時 (ISO 8601) */
+  createdAt: string;
+}
+
+/**
+ * ユーザーメッセージ追加入力DTO
+ */
+export interface AddUserMessageInput {
+  sessionId: string;
+  content: string;
+}
+
+/**
+ * ユーザーメッセージ追加出力DTO
+ */
+export interface AddUserMessageOutput {
+  message: ChatMessageDTO;
+  updatedSession: {
+    lastMessagePreview: string;
+    messageCount: number;
+    updatedAt: string;
+  };
+}
+
+/**
+ * アシスタントメッセージ追加入力DTO
+ */
+export interface AddAssistantMessageInput {
+  sessionId: string;
+  content: string;
+  llmModel: string;
+  llmProvider: string;
+  llmMetadata?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    responseTime?: number;
+    temperature?: number;
+    maxTokens?: number;
+    finishReason?: string;
+  };
+}
+
+/**
+ * アシスタントメッセージ追加出力DTO
+ */
+export interface AddAssistantMessageOutput {
+  message: ChatMessageDTO;
+  updatedSession: {
+    lastMessagePreview: string;
+    messageCount: number;
+    updatedAt: string;
+  };
+}
+
+/**
+ * メッセージ取得入力DTO
+ */
+export interface GetMessagesInput {
+  sessionId: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * メッセージ取得出力DTO
+ */
+export interface GetMessagesOutput {
+  messages: ChatMessageDTO[];
+  total: number;
+}

--- a/packages/shared/src/features/chat-history/application/dto/ChatSessionDTO.ts
+++ b/packages/shared/src/features/chat-history/application/dto/ChatSessionDTO.ts
@@ -1,0 +1,111 @@
+/**
+ * チャットセッションDTO
+ * Application層とPresentation層間のデータ転送用
+ */
+export interface ChatSessionDTO {
+  /** セッションID (UUID) */
+  id: string;
+  /** ユーザーID */
+  userId: string;
+  /** セッションタイトル */
+  title: string;
+  /** 最後のメッセージプレビュー */
+  lastMessagePreview: string | null;
+  /** メッセージ数 */
+  messageCount: number;
+  /** お気に入りフラグ */
+  isFavorite: boolean;
+  /** ピン留めフラグ */
+  isPinned: boolean;
+  /** 作成日時 (ISO 8601) */
+  createdAt: string;
+  /** 更新日時 (ISO 8601) */
+  updatedAt: string;
+}
+
+/**
+ * セッション作成入力DTO
+ */
+export interface CreateChatSessionInput {
+  userId: string;
+  title?: string;
+}
+
+/**
+ * セッション作成出力DTO
+ */
+export interface CreateChatSessionOutput {
+  session: ChatSessionDTO;
+}
+
+/**
+ * セッション検索入力DTO
+ */
+export interface SearchSessionsInput {
+  userId: string;
+  keyword?: string;
+  isFavorite?: boolean;
+  isPinned?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * セッション検索出力DTO
+ */
+export interface SearchSessionsOutput {
+  sessions: ChatSessionDTO[];
+  total: number;
+}
+
+/**
+ * セッション更新入力DTO
+ */
+export interface UpdateSessionInput {
+  sessionId: string;
+  title?: string;
+}
+
+/**
+ * セッション更新出力DTO
+ */
+export interface UpdateSessionOutput {
+  session: ChatSessionDTO;
+}
+
+/**
+ * ピン留めトグル入力DTO
+ */
+export interface TogglePinnedInput {
+  sessionId: string;
+}
+
+/**
+ * ピン留めトグル出力DTO
+ */
+export interface TogglePinnedOutput {
+  session: ChatSessionDTO;
+  isPinned: boolean;
+}
+
+/**
+ * お気に入りトグル入力DTO
+ */
+export interface ToggleFavoriteInput {
+  sessionId: string;
+}
+
+/**
+ * お気に入りトグル出力DTO
+ */
+export interface ToggleFavoriteOutput {
+  session: ChatSessionDTO;
+  isFavorite: boolean;
+}
+
+/**
+ * セッション削除入力DTO
+ */
+export interface DeleteSessionInput {
+  sessionId: string;
+}

--- a/packages/shared/src/features/chat-history/application/dto/index.ts
+++ b/packages/shared/src/features/chat-history/application/dto/index.ts
@@ -1,0 +1,28 @@
+export type {
+  ChatSessionDTO,
+  CreateChatSessionInput,
+  CreateChatSessionOutput,
+  SearchSessionsInput,
+  SearchSessionsOutput,
+  UpdateSessionInput,
+  UpdateSessionOutput,
+  TogglePinnedInput,
+  TogglePinnedOutput,
+  ToggleFavoriteInput,
+  ToggleFavoriteOutput,
+  DeleteSessionInput,
+} from "./ChatSessionDTO.js";
+
+export type {
+  ChatMessageDTO,
+  LLMMetadataDTO,
+  AddUserMessageInput,
+  AddUserMessageOutput,
+  AddAssistantMessageInput,
+  AddAssistantMessageOutput,
+  GetMessagesInput,
+  GetMessagesOutput,
+} from "./ChatMessageDTO.js";
+
+// DTO変換ユーティリティ
+export { sessionToDTO, messageToDTO } from "./transformers.js";

--- a/packages/shared/src/features/chat-history/application/dto/transformers.ts
+++ b/packages/shared/src/features/chat-history/application/dto/transformers.ts
@@ -1,0 +1,67 @@
+/**
+ * DTO変換ユーティリティ
+ *
+ * ドメインエンティティからDTOへの変換を一元化する。
+ * Clean Architecture準拠: Application層内で完結。
+ *
+ * @module features/chat-history/application/dto/transformers
+ */
+
+import type { ChatSession } from "../../domain/entities/ChatSession.js";
+import type { ChatMessage } from "../../domain/entities/ChatMessage.js";
+import type { ChatSessionDTO } from "./ChatSessionDTO.js";
+import type { ChatMessageDTO } from "./ChatMessageDTO.js";
+
+/**
+ * ChatSessionエンティティをDTOに変換する
+ *
+ * @param session ドメインエンティティ
+ * @returns ChatSessionDTO
+ *
+ * @example
+ * const dto = sessionToDTO(session);
+ */
+export function sessionToDTO(session: ChatSession): ChatSessionDTO {
+  return {
+    id: session.id.value,
+    userId: session.userId.value,
+    title: session.title.value,
+    lastMessagePreview: session.lastMessagePreview,
+    messageCount: session.messageCount,
+    isFavorite: session.isFavorite,
+    isPinned: session.isPinned,
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * ChatMessageエンティティをDTOに変換する
+ *
+ * @param message ドメインエンティティ
+ * @returns ChatMessageDTO
+ *
+ * @example
+ * const dto = messageToDTO(message);
+ */
+export function messageToDTO(message: ChatMessage): ChatMessageDTO {
+  return {
+    id: message.id.value,
+    sessionId: message.sessionId.value,
+    role: message.role.value,
+    content: message.content.value,
+    messageIndex: message.messageIndex,
+    llmMetadata: message.llmMetadata
+      ? {
+          provider: message.llmMetadata.provider,
+          model: message.llmMetadata.model,
+          // null → undefined変換（DTO型に合わせる）
+          tokenUsage: message.llmMetadata.tokenUsage ?? undefined,
+          responseTime: message.llmMetadata.responseTime ?? undefined,
+          temperature: message.llmMetadata.temperature ?? undefined,
+          maxTokens: message.llmMetadata.maxTokens ?? undefined,
+        }
+      : null,
+    createdAt: message.createdAt.toISOString(),
+  };
+}

--- a/packages/shared/src/features/chat-history/application/errors/UseCaseErrors.ts
+++ b/packages/shared/src/features/chat-history/application/errors/UseCaseErrors.ts
@@ -1,0 +1,103 @@
+import { UseCaseError } from "../../../../core/errors/UseCaseError.js";
+
+/**
+ * セッションが見つからないエラー
+ */
+export class SessionNotFoundError extends UseCaseError {
+  constructor(sessionId: string) {
+    super(
+      "SESSION_NOT_FOUND",
+      `セッションが見つかりません: ${sessionId}`,
+      404,
+      { sessionId },
+    );
+  }
+}
+
+/**
+ * メッセージが見つからないエラー
+ */
+export class MessageNotFoundError extends UseCaseError {
+  constructor(messageId: string) {
+    super(
+      "MESSAGE_NOT_FOUND",
+      `メッセージが見つかりません: ${messageId}`,
+      404,
+      { messageId },
+    );
+  }
+}
+
+/**
+ * ピン留め上限エラー
+ */
+export class MaxPinnedSessionsError extends UseCaseError {
+  constructor(currentCount: number, maxCount: number) {
+    super(
+      "MAX_PINNED_SESSIONS",
+      `ピン留めセッションの上限（${maxCount}件）に達しています`,
+      400,
+      { currentCount, maxCount },
+    );
+  }
+}
+
+/**
+ * リポジトリエラー
+ */
+export class RepositoryError extends UseCaseError {
+  constructor(message: string, cause?: Error) {
+    super("REPOSITORY_ERROR", message, 500, { cause: cause?.message });
+  }
+}
+
+/**
+ * 無効なセッションIDエラー
+ */
+export class InvalidSessionIdError extends UseCaseError {
+  constructor(sessionId: string) {
+    super("INVALID_SESSION_ID", `無効なセッションID: ${sessionId}`, 400, {
+      sessionId,
+    });
+  }
+}
+
+/**
+ * 無効なユーザーIDエラー
+ */
+export class InvalidUserIdError extends UseCaseError {
+  constructor(userId: string) {
+    super("INVALID_USER_ID", `無効なユーザーID: ${userId}`, 400, { userId });
+  }
+}
+
+/**
+ * 無効なタイトルエラー
+ */
+export class InvalidTitleError extends UseCaseError {
+  constructor(message: string) {
+    super("INVALID_TITLE", message, 400);
+  }
+}
+
+/**
+ * 無効なコンテンツエラー
+ */
+export class InvalidContentError extends UseCaseError {
+  constructor(message: string) {
+    super("INVALID_CONTENT", message, 400);
+  }
+}
+
+/**
+ * Use Caseエラー型のユニオン
+ */
+export type ChatHistoryUseCaseError =
+  | SessionNotFoundError
+  | MessageNotFoundError
+  | MaxPinnedSessionsError
+  | RepositoryError
+  | InvalidSessionIdError
+  | InvalidUserIdError
+  | InvalidTitleError
+  | InvalidContentError;

--- a/packages/shared/src/features/chat-history/application/errors/index.ts
+++ b/packages/shared/src/features/chat-history/application/errors/index.ts
@@ -1,0 +1,12 @@
+export {
+  SessionNotFoundError,
+  MessageNotFoundError,
+  MaxPinnedSessionsError,
+  RepositoryError,
+  InvalidSessionIdError,
+  InvalidUserIdError,
+  InvalidTitleError,
+  InvalidContentError,
+} from "./UseCaseErrors.js";
+
+export type { ChatHistoryUseCaseError } from "./UseCaseErrors.js";

--- a/packages/shared/src/features/chat-history/application/use-cases/AddAssistantMessageUseCase.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/AddAssistantMessageUseCase.ts
@@ -1,0 +1,121 @@
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { ChatMessage } from "../../domain/entities/ChatMessage.js";
+import type { IChatSessionRepository } from "../../domain/repositories/IChatSessionRepository.js";
+import type { IChatMessageRepository } from "../../domain/repositories/IChatMessageRepository.js";
+import { ChatSessionId } from "../../domain/value-objects/ChatSessionId.js";
+import type {
+  AddAssistantMessageInput,
+  AddAssistantMessageOutput,
+} from "../dto/ChatMessageDTO.js";
+import { messageToDTO } from "../dto/transformers.js";
+import {
+  SessionNotFoundError,
+  InvalidSessionIdError,
+  InvalidContentError,
+  RepositoryError,
+} from "../errors/UseCaseErrors.js";
+import type { ChatHistoryUseCaseError } from "../errors/UseCaseErrors.js";
+
+/**
+ * アシスタントメッセージ追加Use Case
+ */
+export class AddAssistantMessageUseCase {
+  constructor(
+    private readonly sessionRepository: IChatSessionRepository,
+    private readonly messageRepository: IChatMessageRepository,
+  ) {}
+
+  /**
+   * アシスタントメッセージを追加する
+   */
+  async execute(
+    input: AddAssistantMessageInput,
+  ): Promise<Result<AddAssistantMessageOutput, ChatHistoryUseCaseError>> {
+    // 1. セッションIDのバリデーション
+    const sessionIdResult = ChatSessionId.create(input.sessionId);
+    if (!sessionIdResult.ok) {
+      return err(new InvalidSessionIdError(input.sessionId));
+    }
+    const sessionId = sessionIdResult.value;
+
+    // 2. セッションの存在確認
+    const session = await this.sessionRepository.findById(sessionId);
+    if (!session) {
+      return err(new SessionNotFoundError(input.sessionId));
+    }
+
+    // 3. 次のメッセージインデックスを取得
+    const messageCount =
+      await this.messageRepository.countBySessionId(sessionId);
+
+    // 4. メッセージエンティティを作成
+    const messageResult = ChatMessage.createAssistantMessage({
+      sessionId: input.sessionId,
+      content: input.content,
+      messageIndex: messageCount,
+      llmModel: input.llmModel,
+      llmProvider: input.llmProvider,
+      llmMetadata: input.llmMetadata
+        ? {
+            tokenUsage: input.llmMetadata.inputTokens
+              ? {
+                  inputTokens: input.llmMetadata.inputTokens,
+                  outputTokens: input.llmMetadata.outputTokens ?? 0,
+                  totalTokens: input.llmMetadata.totalTokens ?? 0,
+                }
+              : undefined,
+            responseTime: input.llmMetadata.responseTime,
+            temperature: input.llmMetadata.temperature,
+            maxTokens: input.llmMetadata.maxTokens,
+          }
+        : undefined,
+    });
+
+    if (!messageResult.ok) {
+      const error = messageResult.error;
+      if (error.code === "INVALID_CONTENT") {
+        return err(new InvalidContentError(error.message));
+      }
+      return err(new RepositoryError(error.message));
+    }
+
+    const message = messageResult.value;
+
+    // 5. メッセージを保存
+    try {
+      await this.messageRepository.save(message);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "メッセージの保存に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 6. セッションを更新
+    session.updatePreview(input.content);
+    session.incrementMessageCount();
+
+    try {
+      await this.sessionRepository.save(session);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "セッションの更新に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 7. DTOに変換して返却
+    return ok({
+      message: messageToDTO(message),
+      updatedSession: {
+        lastMessagePreview: session.lastMessagePreview ?? "",
+        messageCount: session.messageCount,
+        updatedAt: session.updatedAt.toISOString(),
+      },
+    });
+  }
+}

--- a/packages/shared/src/features/chat-history/application/use-cases/AddUserMessageUseCase.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/AddUserMessageUseCase.ts
@@ -1,0 +1,105 @@
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { ChatMessage } from "../../domain/entities/ChatMessage.js";
+import type { IChatSessionRepository } from "../../domain/repositories/IChatSessionRepository.js";
+import type { IChatMessageRepository } from "../../domain/repositories/IChatMessageRepository.js";
+import { ChatSessionId } from "../../domain/value-objects/ChatSessionId.js";
+import type {
+  AddUserMessageInput,
+  AddUserMessageOutput,
+} from "../dto/ChatMessageDTO.js";
+import { messageToDTO } from "../dto/transformers.js";
+import {
+  SessionNotFoundError,
+  InvalidSessionIdError,
+  InvalidContentError,
+  RepositoryError,
+} from "../errors/UseCaseErrors.js";
+import type { ChatHistoryUseCaseError } from "../errors/UseCaseErrors.js";
+
+/**
+ * ユーザーメッセージ追加Use Case
+ */
+export class AddUserMessageUseCase {
+  constructor(
+    private readonly sessionRepository: IChatSessionRepository,
+    private readonly messageRepository: IChatMessageRepository,
+  ) {}
+
+  /**
+   * ユーザーメッセージを追加する
+   */
+  async execute(
+    input: AddUserMessageInput,
+  ): Promise<Result<AddUserMessageOutput, ChatHistoryUseCaseError>> {
+    // 1. セッションIDのバリデーション
+    const sessionIdResult = ChatSessionId.create(input.sessionId);
+    if (!sessionIdResult.ok) {
+      return err(new InvalidSessionIdError(input.sessionId));
+    }
+    const sessionId = sessionIdResult.value;
+
+    // 2. セッションの存在確認
+    const session = await this.sessionRepository.findById(sessionId);
+    if (!session) {
+      return err(new SessionNotFoundError(input.sessionId));
+    }
+
+    // 3. 次のメッセージインデックスを取得
+    const messageCount =
+      await this.messageRepository.countBySessionId(sessionId);
+
+    // 4. メッセージエンティティを作成
+    const messageResult = ChatMessage.createUserMessage({
+      sessionId: input.sessionId,
+      content: input.content,
+      messageIndex: messageCount,
+    });
+
+    if (!messageResult.ok) {
+      const error = messageResult.error;
+      if (error.code === "INVALID_CONTENT") {
+        return err(new InvalidContentError(error.message));
+      }
+      return err(new RepositoryError(error.message));
+    }
+
+    const message = messageResult.value;
+
+    // 5. メッセージを保存
+    try {
+      await this.messageRepository.save(message);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "メッセージの保存に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 6. セッションを更新
+    session.updatePreview(input.content);
+    session.incrementMessageCount();
+
+    try {
+      await this.sessionRepository.save(session);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "セッションの更新に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 7. DTOに変換して返却
+    return ok({
+      message: messageToDTO(message),
+      updatedSession: {
+        lastMessagePreview: session.lastMessagePreview ?? "",
+        messageCount: session.messageCount,
+        updatedAt: session.updatedAt.toISOString(),
+      },
+    });
+  }
+}

--- a/packages/shared/src/features/chat-history/application/use-cases/CreateChatSessionUseCase.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/CreateChatSessionUseCase.ts
@@ -1,0 +1,65 @@
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { ChatSession } from "../../domain/entities/ChatSession.js";
+import type { IChatSessionRepository } from "../../domain/repositories/IChatSessionRepository.js";
+import type {
+  CreateChatSessionInput,
+  CreateChatSessionOutput,
+} from "../dto/ChatSessionDTO.js";
+import { sessionToDTO } from "../dto/transformers.js";
+import {
+  InvalidUserIdError,
+  InvalidTitleError,
+  RepositoryError,
+} from "../errors/UseCaseErrors.js";
+import type { ChatHistoryUseCaseError } from "../errors/UseCaseErrors.js";
+
+/**
+ * チャットセッション作成Use Case
+ */
+export class CreateChatSessionUseCase {
+  constructor(private readonly sessionRepository: IChatSessionRepository) {}
+
+  /**
+   * 新しいチャットセッションを作成する
+   */
+  async execute(
+    input: CreateChatSessionInput,
+  ): Promise<Result<CreateChatSessionOutput, ChatHistoryUseCaseError>> {
+    // 1. ドメインエンティティを作成
+    const sessionResult = ChatSession.create({
+      userId: input.userId,
+      title: input.title,
+    });
+
+    // バリデーションエラーをUse Caseエラーに変換
+    if (!sessionResult.ok) {
+      const error = sessionResult.error;
+      if (error.code === "INVALID_USER_ID") {
+        return err(new InvalidUserIdError(input.userId));
+      }
+      if (error.code === "INVALID_TITLE") {
+        return err(new InvalidTitleError(error.message));
+      }
+      return err(new RepositoryError(error.message));
+    }
+
+    const session = sessionResult.value;
+
+    // 2. リポジトリに保存
+    try {
+      await this.sessionRepository.save(session);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "セッションの保存に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 3. DTOに変換して返却
+    return ok({
+      session: sessionToDTO(session),
+    });
+  }
+}

--- a/packages/shared/src/features/chat-history/application/use-cases/SearchSessionsUseCase.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/SearchSessionsUseCase.ts
@@ -1,0 +1,59 @@
+import { type Result, ok, err } from "../../../../core/Result.js";
+import type { IChatSessionRepository } from "../../domain/repositories/IChatSessionRepository.js";
+import { UserId } from "../../domain/value-objects/UserId.js";
+import type {
+  SearchSessionsInput,
+  SearchSessionsOutput,
+} from "../dto/ChatSessionDTO.js";
+import { sessionToDTO } from "../dto/transformers.js";
+import {
+  InvalidUserIdError,
+  RepositoryError,
+} from "../errors/UseCaseErrors.js";
+import type { ChatHistoryUseCaseError } from "../errors/UseCaseErrors.js";
+
+/**
+ * セッション検索Use Case
+ */
+export class SearchSessionsUseCase {
+  constructor(private readonly sessionRepository: IChatSessionRepository) {}
+
+  /**
+   * セッションを検索する
+   */
+  async execute(
+    input: SearchSessionsInput,
+  ): Promise<Result<SearchSessionsOutput, ChatHistoryUseCaseError>> {
+    // 1. ユーザーIDのバリデーション
+    const userIdResult = UserId.create(input.userId);
+    if (!userIdResult.ok) {
+      return err(new InvalidUserIdError(input.userId));
+    }
+    const userId = userIdResult.value;
+
+    // 2. 検索実行
+    try {
+      const sessions = await this.sessionRepository.search({
+        userId,
+        keyword: input.keyword,
+        isFavorite: input.isFavorite,
+        isPinned: input.isPinned,
+        limit: input.limit ?? 50,
+        offset: input.offset ?? 0,
+      });
+
+      // 3. DTOに変換して返却
+      return ok({
+        sessions: sessions.map((session) => sessionToDTO(session)),
+        total: sessions.length, // TODO: 実際の総件数を返す場合はリポジトリを拡張
+      });
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "セッションの検索に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+  }
+}

--- a/packages/shared/src/features/chat-history/application/use-cases/TogglePinnedUseCase.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/TogglePinnedUseCase.ts
@@ -1,0 +1,87 @@
+import { type Result, ok, err } from "../../../../core/Result.js";
+import type { IChatSessionRepository } from "../../domain/repositories/IChatSessionRepository.js";
+import { ChatSessionId } from "../../domain/value-objects/ChatSessionId.js";
+import type {
+  TogglePinnedInput,
+  TogglePinnedOutput,
+} from "../dto/ChatSessionDTO.js";
+import { sessionToDTO } from "../dto/transformers.js";
+import {
+  SessionNotFoundError,
+  InvalidSessionIdError,
+  MaxPinnedSessionsError,
+  RepositoryError,
+} from "../errors/UseCaseErrors.js";
+import type { ChatHistoryUseCaseError } from "../errors/UseCaseErrors.js";
+
+/** ピン留めセッションの上限 (BR-SESSION-002) */
+const MAX_PINNED_SESSIONS = 10;
+
+/**
+ * ピン留めトグルUse Case
+ */
+export class TogglePinnedUseCase {
+  constructor(private readonly sessionRepository: IChatSessionRepository) {}
+
+  /**
+   * セッションのピン留め状態を切り替える
+   */
+  async execute(
+    input: TogglePinnedInput,
+  ): Promise<Result<TogglePinnedOutput, ChatHistoryUseCaseError>> {
+    // 1. セッションIDのバリデーション
+    const sessionIdResult = ChatSessionId.create(input.sessionId);
+    if (!sessionIdResult.ok) {
+      return err(new InvalidSessionIdError(input.sessionId));
+    }
+    const sessionId = sessionIdResult.value;
+
+    // 2. セッションの取得
+    const session = await this.sessionRepository.findById(sessionId);
+    if (!session) {
+      return err(new SessionNotFoundError(input.sessionId));
+    }
+
+    // 3. ピン留めする場合は上限チェック (BR-SESSION-002)
+    if (!session.isPinned) {
+      try {
+        const pinnedCount = await this.sessionRepository.countPinned(
+          session.userId,
+        );
+        if (pinnedCount >= MAX_PINNED_SESSIONS) {
+          return err(
+            new MaxPinnedSessionsError(pinnedCount, MAX_PINNED_SESSIONS),
+          );
+        }
+      } catch (error) {
+        return err(
+          new RepositoryError(
+            "ピン留め数の確認に失敗しました",
+            error instanceof Error ? error : undefined,
+          ),
+        );
+      }
+    }
+
+    // 4. ピン留め状態をトグル
+    const newIsPinned = session.togglePinned();
+
+    // 5. 保存
+    try {
+      await this.sessionRepository.save(session);
+    } catch (error) {
+      return err(
+        new RepositoryError(
+          "セッションの保存に失敗しました",
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    }
+
+    // 6. DTOに変換して返却
+    return ok({
+      session: sessionToDTO(session),
+      isPinned: newIsPinned,
+    });
+  }
+}

--- a/packages/shared/src/features/chat-history/application/use-cases/__tests__/AddAssistantMessageUseCase.test.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/__tests__/AddAssistantMessageUseCase.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AddAssistantMessageUseCase } from "../AddAssistantMessageUseCase.js";
+import type { IChatSessionRepository } from "../../../domain/repositories/IChatSessionRepository.js";
+import type { IChatMessageRepository } from "../../../domain/repositories/IChatMessageRepository.js";
+import { ChatSession } from "../../../domain/entities/ChatSession.js";
+
+describe("AddAssistantMessageUseCase", () => {
+  let useCase: AddAssistantMessageUseCase;
+  let mockSessionRepository: IChatSessionRepository;
+  let mockMessageRepository: IChatMessageRepository;
+
+  function createMockSession(): ChatSession {
+    const result = ChatSession.create({
+      userId: "user-123",
+      title: "テストセッション",
+    });
+    if (!result.ok) throw new Error("Failed to create mock session");
+    return result.value;
+  }
+
+  beforeEach(() => {
+    const mockSession = createMockSession();
+
+    mockSessionRepository = {
+      findById: vi.fn().mockResolvedValue(mockSession),
+      findByUserId: vi.fn(),
+      findPinned: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+      search: vi.fn(),
+      countPinned: vi.fn(),
+      exists: vi.fn(),
+    };
+    mockMessageRepository = {
+      findById: vi.fn(),
+      findBySessionId: vi.fn(),
+      findLatestBySessionId: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      saveMany: vi.fn(),
+      delete: vi.fn(),
+      deleteBySessionId: vi.fn(),
+      countBySessionId: vi.fn().mockResolvedValue(0),
+    };
+    useCase = new AddAssistantMessageUseCase(
+      mockSessionRepository,
+      mockMessageRepository,
+    );
+  });
+
+  it("アシスタントメッセージを追加できる", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは、お手伝いします",
+      llmModel: "gpt-4o",
+      llmProvider: "openai",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.message.content).toBe(input.content);
+      expect(result.value.message.role).toBe("assistant");
+      expect(result.value.message.llmMetadata?.model).toBe("gpt-4o");
+      expect(result.value.message.llmMetadata?.provider).toBe("openai");
+    }
+  });
+
+  it("LLMメタデータを含めてメッセージを追加できる", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは",
+      llmModel: "gpt-4o",
+      llmProvider: "openai",
+      llmMetadata: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        finishReason: "stop",
+        responseTime: 1500,
+      },
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.message.llmMetadata).not.toBeNull();
+      expect(result.value.message.llmMetadata?.tokenUsage?.inputTokens).toBe(
+        100,
+      );
+    }
+  });
+
+  it("セッションのupdatedAtが更新される（BR-MESSAGE-003）", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは",
+      llmModel: "gpt-4o",
+      llmProvider: "openai",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mockSessionRepository.save).toHaveBeenCalled();
+  });
+
+  it("存在しないセッションでエラーを返す", async () => {
+    // Arrange
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(null);
+    const input = {
+      sessionId: "550e8400-e29b-41d4-a716-446655440000",
+      content: "こんにちは",
+      llmModel: "gpt-4o",
+      llmProvider: "openai",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("SESSION_NOT_FOUND");
+    }
+  });
+});

--- a/packages/shared/src/features/chat-history/application/use-cases/__tests__/AddUserMessageUseCase.test.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/__tests__/AddUserMessageUseCase.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AddUserMessageUseCase } from "../AddUserMessageUseCase.js";
+import type { IChatSessionRepository } from "../../../domain/repositories/IChatSessionRepository.js";
+import type { IChatMessageRepository } from "../../../domain/repositories/IChatMessageRepository.js";
+import { ChatSession } from "../../../domain/entities/ChatSession.js";
+
+describe("AddUserMessageUseCase", () => {
+  let useCase: AddUserMessageUseCase;
+  let mockSessionRepository: IChatSessionRepository;
+  let mockMessageRepository: IChatMessageRepository;
+
+  function createMockSession(): ChatSession {
+    const result = ChatSession.create({
+      userId: "user-123",
+      title: "テストセッション",
+    });
+    if (!result.ok) throw new Error("Failed to create mock session");
+    return result.value;
+  }
+
+  beforeEach(() => {
+    const mockSession = createMockSession();
+
+    mockSessionRepository = {
+      findById: vi.fn().mockResolvedValue(mockSession),
+      findByUserId: vi.fn(),
+      findPinned: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+      search: vi.fn(),
+      countPinned: vi.fn(),
+      exists: vi.fn(),
+    };
+    mockMessageRepository = {
+      findById: vi.fn(),
+      findBySessionId: vi.fn(),
+      findLatestBySessionId: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      saveMany: vi.fn(),
+      delete: vi.fn(),
+      deleteBySessionId: vi.fn(),
+      countBySessionId: vi.fn().mockResolvedValue(0),
+    };
+    useCase = new AddUserMessageUseCase(
+      mockSessionRepository,
+      mockMessageRepository,
+    );
+  });
+
+  it("ユーザーメッセージを追加できる", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.message.content).toBe(input.content);
+      expect(result.value.message.role).toBe("user");
+      expect(mockMessageRepository.save).toHaveBeenCalled();
+    }
+  });
+
+  it("セッションのプレビューが更新される", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "これは最初のメッセージです",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.updatedSession.lastMessagePreview).toBe(
+        input.content,
+      );
+      expect(mockSessionRepository.save).toHaveBeenCalled();
+    }
+  });
+
+  it("セッションのupdatedAtが更新される", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    const originalUpdatedAt = mockSession.updatedAt;
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは",
+    };
+
+    // Wait a bit to ensure time difference
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const updatedAtTime = new Date(
+        result.value.updatedSession.updatedAt,
+      ).getTime();
+      expect(updatedAtTime).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
+    }
+  });
+
+  it("存在しないセッションでエラーを返す", async () => {
+    // Arrange
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(null);
+    const input = {
+      sessionId: "550e8400-e29b-41d4-a716-446655440000", // Valid UUID but non-existent
+      content: "こんにちは",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("SESSION_NOT_FOUND");
+    }
+  });
+
+  it("空のコンテンツでエラーを返す", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_CONTENT");
+    }
+  });
+
+  it("メッセージインデックスが正しく設定される", async () => {
+    // Arrange
+    const mockSession = createMockSession();
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(mockSession);
+    mockMessageRepository.countBySessionId = vi.fn().mockResolvedValue(5);
+    const input = {
+      sessionId: mockSession.id.value,
+      content: "こんにちは",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.message.messageIndex).toBe(5);
+    }
+  });
+});

--- a/packages/shared/src/features/chat-history/application/use-cases/__tests__/CreateChatSessionUseCase.test.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/__tests__/CreateChatSessionUseCase.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { CreateChatSessionUseCase } from "../CreateChatSessionUseCase.js";
+import type { IChatSessionRepository } from "../../../domain/repositories/IChatSessionRepository.js";
+
+describe("CreateChatSessionUseCase", () => {
+  let useCase: CreateChatSessionUseCase;
+  let mockSessionRepository: IChatSessionRepository;
+
+  beforeEach(() => {
+    mockSessionRepository = {
+      findById: vi.fn(),
+      findByUserId: vi.fn(),
+      findPinned: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+      search: vi.fn(),
+      countPinned: vi.fn(),
+      exists: vi.fn(),
+    };
+    useCase = new CreateChatSessionUseCase(mockSessionRepository);
+  });
+
+  it("新しいセッションを作成できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.session.userId).toBe(input.userId);
+      expect(result.value.session.title).toMatch(/^新しいチャット/);
+      expect(mockSessionRepository.save).toHaveBeenCalled();
+    }
+  });
+
+  it("タイトル指定でセッションを作成できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      title: "カスタムタイトル",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.session.title).toBe("カスタムタイトル");
+    }
+  });
+
+  it("無効なユーザーIDでエラーを返す", async () => {
+    // Arrange
+    const input = {
+      userId: "",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INVALID_USER_ID");
+    }
+  });
+
+  it("タイトル1文字は有効（境界値テスト）", async () => {
+    // Arrange - ChatSessionTitleはMIN_LENGTH=1
+    const input = {
+      userId: "user-123",
+      title: "a",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.session.title).toBe("a");
+    }
+  });
+
+  it("リポジトリエラー時にエラーを返す", async () => {
+    // Arrange
+    mockSessionRepository.save = vi
+      .fn()
+      .mockRejectedValue(new Error("DB Error"));
+    const input = {
+      userId: "user-123",
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("REPOSITORY_ERROR");
+    }
+  });
+});

--- a/packages/shared/src/features/chat-history/application/use-cases/__tests__/SearchSessionsUseCase.test.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/__tests__/SearchSessionsUseCase.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SearchSessionsUseCase } from "../SearchSessionsUseCase.js";
+import type { IChatSessionRepository } from "../../../domain/repositories/IChatSessionRepository.js";
+import { ChatSession } from "../../../domain/entities/ChatSession.js";
+
+describe("SearchSessionsUseCase", () => {
+  let useCase: SearchSessionsUseCase;
+  let mockSessionRepository: IChatSessionRepository;
+
+  function createMockSession(
+    overrides: {
+      title?: string;
+      isFavorite?: boolean;
+      isPinned?: boolean;
+    } = {},
+  ): ChatSession {
+    const result = ChatSession.create({
+      userId: "user-123",
+      title: overrides.title ?? "テストセッション",
+    });
+    if (!result.ok) throw new Error("Failed to create mock session");
+
+    const session = result.value;
+    if (overrides.isFavorite) session.toggleFavorite();
+    if (overrides.isPinned) session.togglePinned();
+    return session;
+  }
+
+  beforeEach(() => {
+    mockSessionRepository = {
+      findById: vi.fn(),
+      findByUserId: vi.fn(),
+      findPinned: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+      countPinned: vi.fn(),
+      exists: vi.fn(),
+    };
+    useCase = new SearchSessionsUseCase(mockSessionRepository);
+  });
+
+  it("キーワードでセッションを検索できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      keyword: "テスト",
+    };
+    mockSessionRepository.search = vi
+      .fn()
+      .mockResolvedValue([
+        createMockSession({ title: "テストセッション1" }),
+        createMockSession({ title: "テストセッション2" }),
+      ]);
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.sessions.length).toBe(2);
+    }
+  });
+
+  it("お気に入りフィルターで検索できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      isFavorite: true,
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mockSessionRepository.search).toHaveBeenCalledWith(
+      expect.objectContaining({ isFavorite: true }),
+    );
+  });
+
+  it("ピン留めフィルターで検索できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      isPinned: true,
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mockSessionRepository.search).toHaveBeenCalledWith(
+      expect.objectContaining({ isPinned: true }),
+    );
+  });
+
+  it("ページネーションを適用できる", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      limit: 10,
+      offset: 20,
+    };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mockSessionRepository.search).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, offset: 20 }),
+    );
+  });
+
+  it("検索結果がない場合は空配列を返す", async () => {
+    // Arrange
+    const input = {
+      userId: "user-123",
+      keyword: "存在しないキーワード",
+    };
+    mockSessionRepository.search = vi.fn().mockResolvedValue([]);
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.sessions).toEqual([]);
+    }
+  });
+});

--- a/packages/shared/src/features/chat-history/application/use-cases/__tests__/TogglePinnedUseCase.test.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/__tests__/TogglePinnedUseCase.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { TogglePinnedUseCase } from "../TogglePinnedUseCase.js";
+import type { IChatSessionRepository } from "../../../domain/repositories/IChatSessionRepository.js";
+import { ChatSession } from "../../../domain/entities/ChatSession.js";
+
+describe("TogglePinnedUseCase", () => {
+  let useCase: TogglePinnedUseCase;
+  let mockSessionRepository: IChatSessionRepository;
+
+  function createMockSession(isPinned: boolean = false): ChatSession {
+    const result = ChatSession.create({
+      userId: "user-123",
+      title: "テストセッション",
+    });
+    if (!result.ok) throw new Error("Failed to create mock session");
+
+    const session = result.value;
+    if (isPinned) session.togglePinned();
+    return session;
+  }
+
+  beforeEach(() => {
+    mockSessionRepository = {
+      findById: vi.fn().mockResolvedValue(createMockSession(false)),
+      findByUserId: vi.fn(),
+      findPinned: vi.fn(),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+      search: vi.fn(),
+      countPinned: vi.fn().mockResolvedValue(0),
+      exists: vi.fn(),
+    };
+    useCase = new TogglePinnedUseCase(mockSessionRepository);
+  });
+
+  it("ピン留め状態をtrueに切り替えられる", async () => {
+    // Arrange
+    const unpinnedSession = createMockSession(false);
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(unpinnedSession);
+    const input = { sessionId: unpinnedSession.id.value };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.isPinned).toBe(true);
+    }
+  });
+
+  it("ピン留め状態をfalseに切り替えられる", async () => {
+    // Arrange
+    const pinnedSession = createMockSession(true);
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(pinnedSession);
+    const input = { sessionId: pinnedSession.id.value };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.isPinned).toBe(false);
+    }
+  });
+
+  it("ピン留め上限（10件）に達している場合はエラーを返す（BR-SESSION-002）", async () => {
+    // Arrange
+    const unpinnedSession = createMockSession(false);
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(unpinnedSession);
+    mockSessionRepository.countPinned = vi.fn().mockResolvedValue(10);
+    const input = { sessionId: unpinnedSession.id.value };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("MAX_PINNED_SESSIONS");
+    }
+  });
+
+  it("ピン留め解除時は上限チェックをスキップする", async () => {
+    // Arrange
+    const pinnedSession = createMockSession(true);
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(pinnedSession);
+    mockSessionRepository.countPinned = vi.fn().mockResolvedValue(10);
+    const input = { sessionId: pinnedSession.id.value };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(true); // 解除なので成功
+    if (result.ok) {
+      expect(result.value.isPinned).toBe(false);
+    }
+  });
+
+  it("存在しないセッションでエラーを返す", async () => {
+    // Arrange
+    mockSessionRepository.findById = vi.fn().mockResolvedValue(null);
+    const input = { sessionId: "550e8400-e29b-41d4-a716-446655440000" };
+
+    // Act
+    const result = await useCase.execute(input);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("SESSION_NOT_FOUND");
+    }
+  });
+});

--- a/packages/shared/src/features/chat-history/application/use-cases/index.ts
+++ b/packages/shared/src/features/chat-history/application/use-cases/index.ts
@@ -1,0 +1,5 @@
+export { CreateChatSessionUseCase } from "./CreateChatSessionUseCase.js";
+export { AddUserMessageUseCase } from "./AddUserMessageUseCase.js";
+export { AddAssistantMessageUseCase } from "./AddAssistantMessageUseCase.js";
+export { SearchSessionsUseCase } from "./SearchSessionsUseCase.js";
+export { TogglePinnedUseCase } from "./TogglePinnedUseCase.js";

--- a/packages/shared/src/features/chat-history/domain/entities/ChatMessage.ts
+++ b/packages/shared/src/features/chat-history/domain/entities/ChatMessage.ts
@@ -1,0 +1,254 @@
+/**
+ * チャットメッセージ エンティティ
+ *
+ * セッション内の個別メッセージを表すドメインエンティティ。
+ * ユーザーメッセージとアシスタントメッセージを区別する。
+ *
+ * @module features/chat-history/domain/entities/ChatMessage
+ */
+
+import { ChatMessageId } from "../value-objects/ChatMessageId.js";
+import { ChatSessionId } from "../value-objects/ChatSessionId.js";
+import { MessageContent } from "../value-objects/MessageContent.js";
+import { MessageRole } from "../value-objects/MessageRole.js";
+import { LLMMetadata } from "../value-objects/LLMMetadata.js";
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { ChatMessageError } from "../errors/ChatMessageErrors.js";
+
+/**
+ * ユーザーメッセージ作成パラメータ
+ */
+export interface CreateUserMessageParams {
+  sessionId: string;
+  content: string;
+  messageIndex: number;
+}
+
+/**
+ * アシスタントメッセージ作成パラメータ
+ */
+export interface CreateAssistantMessageParams {
+  sessionId: string;
+  content: string;
+  messageIndex: number;
+  llmProvider: string;
+  llmModel: string;
+  llmMetadata?: {
+    tokenUsage?: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens: number;
+    };
+    responseTime?: number;
+    temperature?: number;
+    maxTokens?: number;
+  };
+}
+
+/**
+ * メッセージ再構築パラメータ
+ */
+export interface ReconstituteMessageParams {
+  id: string;
+  sessionId: string;
+  role: "user" | "assistant";
+  content: string;
+  messageIndex: number;
+  timestamp: Date;
+  llmProvider: string | null;
+  llmModel: string | null;
+  llmMetadata: Record<string, unknown> | null;
+}
+
+/**
+ * チャットメッセージ エンティティ
+ */
+export class ChatMessage {
+  private constructor(
+    private readonly _id: ChatMessageId,
+    private readonly _sessionId: ChatSessionId,
+    private readonly _role: MessageRole,
+    private readonly _content: MessageContent,
+    private readonly _messageIndex: number,
+    private readonly _timestamp: Date,
+    private readonly _llmMetadata: LLMMetadata | null,
+  ) {}
+
+  // ========================================
+  // Factory Methods
+  // ========================================
+
+  /**
+   * ユーザーメッセージを作成する
+   *
+   * @param params 作成パラメータ
+   * @returns 成功時: ChatMessage, 失敗時: ChatMessageError
+   */
+  static createUserMessage(
+    params: CreateUserMessageParams,
+  ): Result<ChatMessage, ChatMessageError> {
+    const sessionIdResult = ChatSessionId.create(params.sessionId);
+    if (!sessionIdResult.ok) {
+      return err(
+        new ChatMessageError(
+          "INVALID_SESSION_ID",
+          sessionIdResult.error.message,
+        ),
+      );
+    }
+
+    const contentResult = MessageContent.create(params.content);
+    if (!contentResult.ok) {
+      return err(
+        new ChatMessageError("INVALID_CONTENT", contentResult.error.message),
+      );
+    }
+
+    return ok(
+      new ChatMessage(
+        ChatMessageId.generate(),
+        sessionIdResult.value,
+        MessageRole.User,
+        contentResult.value,
+        params.messageIndex,
+        new Date(),
+        null, // ユーザーメッセージにはLLMメタデータなし
+      ),
+    );
+  }
+
+  /**
+   * アシスタントメッセージを作成する
+   *
+   * @param params 作成パラメータ
+   * @returns 成功時: ChatMessage, 失敗時: ChatMessageError
+   */
+  static createAssistantMessage(
+    params: CreateAssistantMessageParams,
+  ): Result<ChatMessage, ChatMessageError> {
+    const sessionIdResult = ChatSessionId.create(params.sessionId);
+    if (!sessionIdResult.ok) {
+      return err(
+        new ChatMessageError(
+          "INVALID_SESSION_ID",
+          sessionIdResult.error.message,
+        ),
+      );
+    }
+
+    const contentResult = MessageContent.create(params.content);
+    if (!contentResult.ok) {
+      return err(
+        new ChatMessageError("INVALID_CONTENT", contentResult.error.message),
+      );
+    }
+
+    // アシスタントメッセージにはLLMメタデータを含める
+    const llmMetadataResult = LLMMetadata.create({
+      provider: params.llmProvider,
+      model: params.llmModel,
+      tokenUsage: params.llmMetadata?.tokenUsage,
+      responseTime: params.llmMetadata?.responseTime,
+      temperature: params.llmMetadata?.temperature,
+      maxTokens: params.llmMetadata?.maxTokens,
+    });
+
+    if (!llmMetadataResult.ok) {
+      return err(
+        new ChatMessageError(
+          "INVALID_LLM_METADATA",
+          llmMetadataResult.error.message,
+        ),
+      );
+    }
+
+    return ok(
+      new ChatMessage(
+        ChatMessageId.generate(),
+        sessionIdResult.value,
+        MessageRole.Assistant,
+        contentResult.value,
+        params.messageIndex,
+        new Date(),
+        llmMetadataResult.value,
+      ),
+    );
+  }
+
+  /**
+   * 永続化されたデータからメッセージを再構築する
+   *
+   * @param params 再構築パラメータ
+   * @returns ChatMessage
+   */
+  static reconstitute(params: ReconstituteMessageParams): ChatMessage {
+    return new ChatMessage(
+      ChatMessageId.fromString(params.id),
+      ChatSessionId.fromString(params.sessionId),
+      params.role === "user" ? MessageRole.User : MessageRole.Assistant,
+      MessageContent.fromString(params.content),
+      params.messageIndex,
+      params.timestamp,
+      params.llmMetadata && params.llmProvider && params.llmModel
+        ? LLMMetadata.reconstitute(
+            params.llmProvider,
+            params.llmModel,
+            params.llmMetadata,
+          )
+        : null,
+    );
+  }
+
+  // ========================================
+  // Getters
+  // ========================================
+
+  get id(): ChatMessageId {
+    return this._id;
+  }
+
+  get sessionId(): ChatSessionId {
+    return this._sessionId;
+  }
+
+  get role(): MessageRole {
+    return this._role;
+  }
+
+  get content(): MessageContent {
+    return this._content;
+  }
+
+  get messageIndex(): number {
+    return this._messageIndex;
+  }
+
+  get timestamp(): Date {
+    return this._timestamp;
+  }
+
+  /**
+   * 作成日時 (timestampのエイリアス)
+   */
+  get createdAt(): Date {
+    return this._timestamp;
+  }
+
+  get llmMetadata(): LLMMetadata | null {
+    return this._llmMetadata;
+  }
+
+  /**
+   * ユーザーメッセージかどうか
+   */
+  get isUserMessage(): boolean {
+    return this._role.isUser;
+  }
+
+  /**
+   * アシスタントメッセージかどうか
+   */
+  get isAssistantMessage(): boolean {
+    return this._role.isAssistant;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/entities/ChatSession.ts
+++ b/packages/shared/src/features/chat-history/domain/entities/ChatSession.ts
@@ -1,0 +1,268 @@
+/**
+ * チャットセッション エンティティ
+ *
+ * ユーザーとAIアシスタント間の会話セッションを表すドメインエンティティ。
+ * ビジネスルールをカプセル化し、不変条件を保証する。
+ *
+ * @module features/chat-history/domain/entities/ChatSession
+ */
+
+import { ChatSessionId } from "../value-objects/ChatSessionId.js";
+import { ChatSessionTitle } from "../value-objects/ChatSessionTitle.js";
+import { UserId } from "../value-objects/UserId.js";
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { ChatSessionError } from "../errors/ChatSessionErrors.js";
+import { InvalidTitleError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * セッション作成パラメータ
+ */
+export interface CreateChatSessionParams {
+  userId: string;
+  title?: string;
+}
+
+/**
+ * セッション再構築パラメータ（DBからの復元用）
+ */
+export interface ReconstituteChatSessionParams {
+  id: string;
+  userId: string;
+  title: string;
+  messageCount: number;
+  isFavorite: boolean;
+  isPinned: boolean;
+  pinOrder: number | null;
+  lastMessagePreview: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * チャットセッション エンティティ
+ */
+export class ChatSession {
+  private static readonly PREVIEW_MAX_LENGTH = 100;
+  private static readonly PREVIEW_ELLIPSIS = "...";
+
+  private constructor(
+    private readonly _id: ChatSessionId,
+    private readonly _userId: UserId,
+    private _title: ChatSessionTitle,
+    private _messageCount: number,
+    private _isFavorite: boolean,
+    private _isPinned: boolean,
+    private _pinOrder: number | null,
+    private _lastMessagePreview: string | null,
+    private readonly _createdAt: Date,
+    private _updatedAt: Date,
+  ) {}
+
+  // ========================================
+  // Factory Methods
+  // ========================================
+
+  /**
+   * 新しいセッションを作成する
+   *
+   * @param params 作成パラメータ
+   * @returns 成功時: ChatSession, 失敗時: ChatSessionError
+   */
+  static create(
+    params: CreateChatSessionParams,
+  ): Result<ChatSession, ChatSessionError> {
+    // UserIdの検証
+    const userIdResult = UserId.create(params.userId);
+    if (!userIdResult.ok) {
+      return err(
+        new ChatSessionError("INVALID_USER_ID", userIdResult.error.message),
+      );
+    }
+
+    // タイトルの作成（省略時はデフォルト）
+    const titleResult = params.title
+      ? ChatSessionTitle.create(params.title)
+      : ok(ChatSessionTitle.createDefault());
+
+    if (!titleResult.ok) {
+      return err(
+        new ChatSessionError("INVALID_TITLE", titleResult.error.message),
+      );
+    }
+
+    const now = new Date();
+
+    return ok(
+      new ChatSession(
+        ChatSessionId.generate(),
+        userIdResult.value,
+        titleResult.value,
+        0, // messageCount
+        false, // isFavorite
+        false, // isPinned
+        null, // pinOrder
+        null, // lastMessagePreview
+        now, // createdAt
+        now, // updatedAt
+      ),
+    );
+  }
+
+  /**
+   * 永続化されたデータからセッションを再構築する
+   *
+   * @param params 再構築パラメータ
+   * @returns ChatSession
+   */
+  static reconstitute(params: ReconstituteChatSessionParams): ChatSession {
+    return new ChatSession(
+      ChatSessionId.fromString(params.id),
+      UserId.fromString(params.userId),
+      ChatSessionTitle.fromString(params.title),
+      params.messageCount,
+      params.isFavorite,
+      params.isPinned,
+      params.pinOrder,
+      params.lastMessagePreview,
+      params.createdAt,
+      params.updatedAt,
+    );
+  }
+
+  // ========================================
+  // Business Logic
+  // ========================================
+
+  /**
+   * タイトルを更新する
+   *
+   * @param newTitle 新しいタイトル
+   * @returns 成功時: void, 失敗時: InvalidTitleError
+   */
+  updateTitle(newTitle: string): Result<void, InvalidTitleError> {
+    const titleResult = ChatSessionTitle.create(newTitle);
+    if (!titleResult.ok) {
+      return err(titleResult.error);
+    }
+
+    this._title = titleResult.value;
+    this._updatedAt = new Date();
+    return ok(undefined);
+  }
+
+  /**
+   * お気に入り状態を切り替える
+   *
+   * @returns 新しいお気に入り状態
+   */
+  toggleFavorite(): boolean {
+    this._isFavorite = !this._isFavorite;
+    this._updatedAt = new Date();
+    return this._isFavorite;
+  }
+
+  /**
+   * ピン留め状態を切り替える
+   *
+   * @returns 新しいピン留め状態
+   */
+  togglePinned(): boolean {
+    this._isPinned = !this._isPinned;
+    if (!this._isPinned) {
+      this._pinOrder = null;
+    }
+    this._updatedAt = new Date();
+    return this._isPinned;
+  }
+
+  /**
+   * ピン留め状態を設定する
+   *
+   * @param isPinned ピン留め状態
+   * @param pinOrder ピン留め順序（isPinned=trueの場合に使用）
+   */
+  setPinned(isPinned: boolean, pinOrder: number | null = null): void {
+    this._isPinned = isPinned;
+    this._pinOrder = isPinned ? pinOrder : null;
+    this._updatedAt = new Date();
+  }
+
+  /**
+   * ピン留めを解除する
+   */
+  unpin(): void {
+    this._isPinned = false;
+    this._pinOrder = null;
+    this._updatedAt = new Date();
+  }
+
+  /**
+   * メッセージプレビューを更新する
+   *
+   * @param content メッセージ内容
+   */
+  updatePreview(content: string): void {
+    if (content.length <= ChatSession.PREVIEW_MAX_LENGTH) {
+      this._lastMessagePreview = content;
+    } else {
+      this._lastMessagePreview =
+        content.slice(
+          0,
+          ChatSession.PREVIEW_MAX_LENGTH - ChatSession.PREVIEW_ELLIPSIS.length,
+        ) + ChatSession.PREVIEW_ELLIPSIS;
+    }
+    this._updatedAt = new Date();
+  }
+
+  /**
+   * メッセージカウントをインクリメントする
+   */
+  incrementMessageCount(): void {
+    this._messageCount++;
+    this._updatedAt = new Date();
+  }
+
+  // ========================================
+  // Getters
+  // ========================================
+
+  get id(): ChatSessionId {
+    return this._id;
+  }
+
+  get userId(): UserId {
+    return this._userId;
+  }
+
+  get title(): ChatSessionTitle {
+    return this._title;
+  }
+
+  get messageCount(): number {
+    return this._messageCount;
+  }
+
+  get isFavorite(): boolean {
+    return this._isFavorite;
+  }
+
+  get isPinned(): boolean {
+    return this._isPinned;
+  }
+
+  get pinOrder(): number | null {
+    return this._pinOrder;
+  }
+
+  get lastMessagePreview(): string | null {
+    return this._lastMessagePreview;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/entities/__tests__/ChatMessage.test.ts
+++ b/packages/shared/src/features/chat-history/domain/entities/__tests__/ChatMessage.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { ChatMessage } from "../ChatMessage.js";
+
+describe("ChatMessage", () => {
+  const validSessionId = "550e8400-e29b-41d4-a716-446655440000";
+
+  describe("createUserMessage", () => {
+    it("ユーザーメッセージを作成できる", () => {
+      // Arrange
+      const content = "こんにちは、これはテストメッセージです。";
+      const messageIndex = 0;
+
+      // Act
+      const result = ChatMessage.createUserMessage({
+        sessionId: validSessionId,
+        content,
+        messageIndex,
+      });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.sessionId.value).toBe(validSessionId);
+        expect(result.value.content.value).toBe(content);
+        expect(result.value.role.value).toBe("user");
+        expect(result.value.messageIndex).toBe(messageIndex);
+        expect(result.value.llmMetadata).toBeNull();
+      }
+    });
+
+    it("空のコンテンツでエラーを返す", () => {
+      // Arrange
+      const content = "";
+      const messageIndex = 0;
+
+      // Act
+      const result = ChatMessage.createUserMessage({
+        sessionId: validSessionId,
+        content,
+        messageIndex,
+      });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_CONTENT");
+      }
+    });
+
+    it("無効なセッションIDでエラーを返す", () => {
+      // Arrange
+      const content = "テストメッセージ";
+      const messageIndex = 0;
+
+      // Act
+      const result = ChatMessage.createUserMessage({
+        sessionId: "invalid-id",
+        content,
+        messageIndex,
+      });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_SESSION_ID");
+      }
+    });
+  });
+
+  describe("createAssistantMessage", () => {
+    it("アシスタントメッセージを作成できる", () => {
+      // Arrange
+      const content = "こんにちは、お手伝いできることはありますか？";
+      const messageIndex = 1;
+      const llmModel = "gpt-4o";
+      const llmProvider = "openai";
+
+      // Act
+      const result = ChatMessage.createAssistantMessage({
+        sessionId: validSessionId,
+        content,
+        messageIndex,
+        llmModel,
+        llmProvider,
+      });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.sessionId.value).toBe(validSessionId);
+        expect(result.value.content.value).toBe(content);
+        expect(result.value.role.value).toBe("assistant");
+        expect(result.value.messageIndex).toBe(messageIndex);
+        expect(result.value.llmMetadata).not.toBeNull();
+        expect(result.value.llmMetadata?.model).toBe(llmModel);
+        expect(result.value.llmMetadata?.provider).toBe(llmProvider);
+      }
+    });
+
+    it("LLMメタデータを含めて作成できる", () => {
+      // Arrange
+      const content = "これはテスト応答です。";
+      const messageIndex = 1;
+      const llmModel = "gpt-4o";
+      const llmProvider = "openai";
+      const llmMetadata = {
+        tokenUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+        },
+        responseTime: 1500,
+      };
+
+      // Act
+      const result = ChatMessage.createAssistantMessage({
+        sessionId: validSessionId,
+        content,
+        messageIndex,
+        llmModel,
+        llmProvider,
+        llmMetadata,
+      });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.llmMetadata).not.toBeNull();
+        expect(result.value.llmMetadata?.tokenUsage?.inputTokens).toBe(100);
+        expect(result.value.llmMetadata?.tokenUsage?.outputTokens).toBe(50);
+        expect(result.value.llmMetadata?.tokenUsage?.totalTokens).toBe(150);
+        expect(result.value.llmMetadata?.responseTime).toBe(1500);
+      }
+    });
+
+    it("空のコンテンツでエラーを返す", () => {
+      // Arrange
+      const content = "";
+      const messageIndex = 1;
+
+      // Act
+      const result = ChatMessage.createAssistantMessage({
+        sessionId: validSessionId,
+        content,
+        messageIndex,
+        llmModel: "gpt-4o",
+        llmProvider: "openai",
+      });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_CONTENT");
+      }
+    });
+  });
+
+  describe("properties", () => {
+    it("isUserMessageがユーザーメッセージで正しく動作する", () => {
+      // Arrange
+      const result = ChatMessage.createUserMessage({
+        sessionId: validSessionId,
+        content: "テスト",
+        messageIndex: 0,
+      });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.isUserMessage).toBe(true);
+        expect(result.value.isAssistantMessage).toBe(false);
+      }
+    });
+
+    it("isAssistantMessageがアシスタントメッセージで正しく動作する", () => {
+      // Arrange
+      const result = ChatMessage.createAssistantMessage({
+        sessionId: validSessionId,
+        content: "テスト",
+        messageIndex: 1,
+        llmModel: "gpt-4o",
+        llmProvider: "openai",
+      });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.isUserMessage).toBe(false);
+        expect(result.value.isAssistantMessage).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/domain/entities/__tests__/ChatSession.test.ts
+++ b/packages/shared/src/features/chat-history/domain/entities/__tests__/ChatSession.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { ChatSession } from "../ChatSession.js";
+
+describe("ChatSession", () => {
+  describe("create", () => {
+    it("有効なパラメータでセッションを作成できる", () => {
+      // Arrange
+      const userId = "user-123";
+      const title = "テストセッション";
+
+      // Act
+      const result = ChatSession.create({ userId, title });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.userId.value).toBe(userId);
+        expect(result.value.title.value).toBe(title);
+        expect(result.value.isFavorite).toBe(false);
+        expect(result.value.isPinned).toBe(false);
+      }
+    });
+
+    it("タイトル未指定時はデフォルトタイトルが設定される", () => {
+      // Arrange
+      const userId = "user-123";
+
+      // Act
+      const result = ChatSession.create({ userId });
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.title.value).toMatch(/^新しいチャット/);
+      }
+    });
+
+    it("無効なユーザーIDでエラーを返す", () => {
+      // Arrange
+      const userId = "";
+      const title = "テストセッション";
+
+      // Act
+      const result = ChatSession.create({ userId, title });
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_USER_ID");
+      }
+    });
+  });
+
+  describe("updateTitle", () => {
+    it("有効なタイトルで更新できる", () => {
+      // Arrange
+      const session = createTestSession();
+      const newTitle = "更新後のタイトル";
+
+      // Act
+      const result = session.updateTitle(newTitle);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      expect(session.title.value).toBe(newTitle);
+    });
+
+    it("無効なタイトルでエラーを返す", () => {
+      // Arrange
+      const session = createTestSession();
+      const invalidTitle = ""; // 空文字
+
+      // Act
+      const result = session.updateTitle(invalidTitle);
+
+      // Assert
+      expect(result.ok).toBe(false);
+    });
+
+    it("更新後にupdatedAtが更新される", async () => {
+      // Arrange
+      const session = createTestSession();
+      const originalUpdatedAt = session.updatedAt;
+
+      // Act
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      session.updateTitle("新しいタイトル");
+
+      // Assert
+      expect(session.updatedAt.getTime()).toBeGreaterThan(
+        originalUpdatedAt.getTime(),
+      );
+    });
+  });
+
+  describe("toggleFavorite", () => {
+    it("お気に入り状態を切り替えられる", () => {
+      // Arrange
+      const session = createTestSession(); // isFavorite = false
+
+      // Act
+      const newState = session.toggleFavorite();
+
+      // Assert
+      expect(newState).toBe(true);
+      expect(session.isFavorite).toBe(true);
+
+      // 再度トグル
+      const newState2 = session.toggleFavorite();
+      expect(newState2).toBe(false);
+      expect(session.isFavorite).toBe(false);
+    });
+  });
+
+  describe("togglePinned", () => {
+    it("ピン留め状態を切り替えられる", () => {
+      // Arrange
+      const session = createTestSession(); // isPinned = false
+
+      // Act
+      const newState = session.togglePinned();
+
+      // Assert
+      expect(newState).toBe(true);
+      expect(session.isPinned).toBe(true);
+
+      // 再度トグル
+      const newState2 = session.togglePinned();
+      expect(newState2).toBe(false);
+      expect(session.isPinned).toBe(false);
+    });
+
+    // Note: ピン留め数上限（BR-SESSION-002）はUse Case層で検証
+  });
+
+  describe("updatePreview", () => {
+    it("プレビューを更新できる", () => {
+      // Arrange
+      const session = createTestSession();
+      const newPreview = "これはプレビューです";
+
+      // Act
+      session.updatePreview(newPreview);
+
+      // Assert
+      expect(session.lastMessagePreview).toBe(newPreview);
+    });
+
+    it("100文字を超える場合は切り詰められる", () => {
+      // Arrange
+      const session = createTestSession();
+      const longContent = "あ".repeat(150);
+
+      // Act
+      session.updatePreview(longContent);
+
+      // Assert
+      expect(session.lastMessagePreview!.length).toBeLessThanOrEqual(100);
+      expect(session.lastMessagePreview).toContain("...");
+    });
+  });
+
+  describe("incrementMessageCount", () => {
+    it("メッセージカウントをインクリメントできる", () => {
+      // Arrange
+      const session = createTestSession();
+      expect(session.messageCount).toBe(0);
+
+      // Act
+      session.incrementMessageCount();
+
+      // Assert
+      expect(session.messageCount).toBe(1);
+    });
+  });
+});
+
+function createTestSession(): ChatSession {
+  const result = ChatSession.create({
+    userId: "user-123",
+    title: "テストセッション",
+  });
+  if (!result.ok) throw new Error("Failed to create test session");
+  return result.value;
+}

--- a/packages/shared/src/features/chat-history/domain/entities/index.ts
+++ b/packages/shared/src/features/chat-history/domain/entities/index.ts
@@ -1,0 +1,18 @@
+/**
+ * エンティティの集約エクスポート
+ *
+ * @module features/chat-history/domain/entities
+ */
+
+export {
+  ChatSession,
+  type CreateChatSessionParams,
+  type ReconstituteChatSessionParams,
+} from "./ChatSession.js";
+
+export {
+  ChatMessage,
+  type CreateUserMessageParams,
+  type CreateAssistantMessageParams,
+  type ReconstituteMessageParams,
+} from "./ChatMessage.js";

--- a/packages/shared/src/features/chat-history/domain/errors/ChatMessageErrors.ts
+++ b/packages/shared/src/features/chat-history/domain/errors/ChatMessageErrors.ts
@@ -1,0 +1,34 @@
+/**
+ * チャットメッセージのエラー型
+ *
+ * @module features/chat-history/domain/errors/ChatMessageErrors
+ */
+
+import { DomainError } from "../../../../core/errors/DomainError.js";
+
+/**
+ * チャットメッセージ エラー
+ */
+export class ChatMessageError extends DomainError {
+  constructor(code: string, message: string) {
+    super(code, message);
+  }
+}
+
+/**
+ * 無効なメッセージコンテンツ エラー
+ */
+export class InvalidMessageContentError extends DomainError {
+  constructor(reason: string) {
+    super("INVALID_MESSAGE_CONTENT", `Invalid message content: ${reason}`);
+  }
+}
+
+/**
+ * LLMメタデータ欠落エラー
+ */
+export class MissingLLMMetadataError extends DomainError {
+  constructor() {
+    super("MISSING_LLM_METADATA", "Assistant messages require LLM metadata");
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/errors/ChatSessionErrors.ts
+++ b/packages/shared/src/features/chat-history/domain/errors/ChatSessionErrors.ts
@@ -1,0 +1,55 @@
+/**
+ * チャットセッションのエラー型
+ *
+ * @module features/chat-history/domain/errors/ChatSessionErrors
+ */
+
+import {
+  DomainError,
+  BusinessRuleError,
+} from "../../../../core/errors/DomainError.js";
+
+/**
+ * チャットセッション エラー
+ */
+export class ChatSessionError extends DomainError {
+  constructor(code: string, message: string) {
+    super(code, message);
+  }
+}
+
+/**
+ * 無効なセッションタイトル エラー
+ */
+export class InvalidSessionTitleError extends DomainError {
+  constructor(title: string, reason: string) {
+    super(
+      "INVALID_SESSION_TITLE",
+      `Invalid session title "${title}": ${reason}`,
+    );
+  }
+}
+
+/**
+ * ピン留め上限エラー (BR-SESSION-002)
+ */
+export class MaxPinnedSessionsError extends BusinessRuleError {
+  constructor(maxCount: number) {
+    super(
+      "MAX_PINNED_SESSIONS",
+      `Maximum pinned sessions (${maxCount}) reached`,
+    );
+  }
+}
+
+/**
+ * セッションアーカイブ済みエラー
+ */
+export class SessionArchivedError extends BusinessRuleError {
+  constructor(sessionId: string) {
+    super(
+      "SESSION_ARCHIVED",
+      `Session ${sessionId} is archived and cannot be modified`,
+    );
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/errors/ValueObjectErrors.ts
+++ b/packages/shared/src/features/chat-history/domain/errors/ValueObjectErrors.ts
@@ -1,0 +1,43 @@
+/**
+ * 値オブジェクトのエラー型
+ *
+ * @module features/chat-history/domain/errors/ValueObjectErrors
+ */
+
+import { DomainError } from "../../../../core/errors/DomainError.js";
+
+/**
+ * 無効なID エラー
+ */
+export class InvalidIdError extends DomainError {
+  constructor(type: string, value: string) {
+    super("INVALID_ID", `Invalid ${type}: ${value}`);
+  }
+}
+
+/**
+ * 無効なタイトル エラー
+ */
+export class InvalidTitleError extends DomainError {
+  constructor(message: string) {
+    super("INVALID_TITLE", message);
+  }
+}
+
+/**
+ * 無効なコンテンツ エラー
+ */
+export class InvalidContentError extends DomainError {
+  constructor(message: string) {
+    super("INVALID_CONTENT", message);
+  }
+}
+
+/**
+ * 無効なLLMメタデータ エラー
+ */
+export class InvalidLLMMetadataError extends DomainError {
+  constructor(message: string) {
+    super("INVALID_LLM_METADATA", message);
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/errors/index.ts
+++ b/packages/shared/src/features/chat-history/domain/errors/index.ts
@@ -1,0 +1,25 @@
+/**
+ * チャット履歴機能のエラー型集約
+ *
+ * @module features/chat-history/domain/errors
+ */
+
+export {
+  InvalidIdError,
+  InvalidTitleError,
+  InvalidContentError,
+  InvalidLLMMetadataError,
+} from "./ValueObjectErrors.js";
+
+export {
+  ChatSessionError,
+  InvalidSessionTitleError,
+  MaxPinnedSessionsError,
+  SessionArchivedError,
+} from "./ChatSessionErrors.js";
+
+export {
+  ChatMessageError,
+  InvalidMessageContentError,
+  MissingLLMMetadataError,
+} from "./ChatMessageErrors.js";

--- a/packages/shared/src/features/chat-history/domain/repositories/IChatMessageRepository.ts
+++ b/packages/shared/src/features/chat-history/domain/repositories/IChatMessageRepository.ts
@@ -1,0 +1,83 @@
+/**
+ * チャットメッセージ リポジトリインターフェース
+ *
+ * Domain層に配置し、依存性逆転の原則に従う。
+ * 実装はInfrastructure層で提供される。
+ *
+ * @module features/chat-history/domain/repositories/IChatMessageRepository
+ */
+
+import type { ChatMessage } from "../entities/ChatMessage.js";
+import type { ChatMessageId } from "../value-objects/ChatMessageId.js";
+import type { ChatSessionId } from "../value-objects/ChatSessionId.js";
+
+/**
+ * チャットメッセージ リポジトリインターフェース
+ */
+export interface IChatMessageRepository {
+  /**
+   * IDでメッセージを取得する
+   *
+   * @param id メッセージID
+   * @returns メッセージ（存在しない場合はnull）
+   */
+  findById(id: ChatMessageId): Promise<ChatMessage | null>;
+
+  /**
+   * セッションIDでメッセージ一覧を取得する
+   *
+   * @param sessionId セッションID
+   * @param limit 取得件数
+   * @param offset オフセット
+   * @returns メッセージ一覧（messageIndex順）
+   */
+  findBySessionId(
+    sessionId: ChatSessionId,
+    limit?: number,
+    offset?: number,
+  ): Promise<ChatMessage[]>;
+
+  /**
+   * セッション内の最新メッセージを取得する
+   *
+   * @param sessionId セッションID
+   * @returns 最新メッセージ（存在しない場合はnull）
+   */
+  findLatestBySessionId(sessionId: ChatSessionId): Promise<ChatMessage | null>;
+
+  /**
+   * セッション内のメッセージ数を取得する
+   *
+   * @param sessionId セッションID
+   * @returns メッセージ数
+   */
+  countBySessionId(sessionId: ChatSessionId): Promise<number>;
+
+  /**
+   * メッセージを保存する（作成または更新）
+   *
+   * @param message メッセージ
+   */
+  save(message: ChatMessage): Promise<void>;
+
+  /**
+   * 複数のメッセージを一括保存する
+   *
+   * @param messages メッセージ配列
+   */
+  saveMany(messages: ChatMessage[]): Promise<void>;
+
+  /**
+   * メッセージを削除する
+   *
+   * @param id メッセージID
+   */
+  delete(id: ChatMessageId): Promise<void>;
+
+  /**
+   * セッションの全メッセージを削除する
+   *
+   * @param sessionId セッションID
+   */
+  deleteBySessionId(sessionId: ChatSessionId): Promise<void>;
+}

--- a/packages/shared/src/features/chat-history/domain/repositories/IChatSessionRepository.ts
+++ b/packages/shared/src/features/chat-history/domain/repositories/IChatSessionRepository.ts
@@ -1,0 +1,97 @@
+/**
+ * チャットセッション リポジトリインターフェース
+ *
+ * Domain層に配置し、依存性逆転の原則に従う。
+ * 実装はInfrastructure層で提供される。
+ *
+ * @module features/chat-history/domain/repositories/IChatSessionRepository
+ */
+
+import type { ChatSession } from "../entities/ChatSession.js";
+import type { ChatSessionId } from "../value-objects/ChatSessionId.js";
+import type { UserId } from "../value-objects/UserId.js";
+
+/**
+ * セッション検索条件
+ */
+export interface ChatSessionSearchCriteria {
+  userId: UserId;
+  keyword?: string;
+  isFavorite?: boolean;
+  isPinned?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * チャットセッション リポジトリインターフェース
+ */
+export interface IChatSessionRepository {
+  /**
+   * IDでセッションを取得する
+   *
+   * @param id セッションID
+   * @returns セッション（存在しない場合はnull）
+   */
+  findById(id: ChatSessionId): Promise<ChatSession | null>;
+
+  /**
+   * ユーザーIDでセッション一覧を取得する
+   *
+   * @param userId ユーザーID
+   * @param limit 取得件数
+   * @param offset オフセット
+   * @returns セッション一覧
+   */
+  findByUserId(
+    userId: UserId,
+    limit?: number,
+    offset?: number,
+  ): Promise<ChatSession[]>;
+
+  /**
+   * ピン留めセッション一覧を取得する
+   *
+   * @param userId ユーザーID
+   * @returns ピン留めセッション一覧（pinOrder順）
+   */
+  findPinned(userId: UserId): Promise<ChatSession[]>;
+
+  /**
+   * 検索条件でセッションを検索する
+   *
+   * @param criteria 検索条件
+   * @returns マッチしたセッション一覧
+   */
+  search(criteria: ChatSessionSearchCriteria): Promise<ChatSession[]>;
+
+  /**
+   * セッションを保存する（作成または更新）
+   *
+   * @param session セッション
+   */
+  save(session: ChatSession): Promise<void>;
+
+  /**
+   * セッションを削除する
+   *
+   * @param id セッションID
+   */
+  delete(id: ChatSessionId): Promise<void>;
+
+  /**
+   * セッションが存在するか確認する
+   *
+   * @param id セッションID
+   * @returns 存在する場合true
+   */
+  exists(id: ChatSessionId): Promise<boolean>;
+
+  /**
+   * ピン留めセッション数をカウントする
+   *
+   * @param userId ユーザーID
+   * @returns ピン留めセッション数
+   */
+  countPinned(userId: UserId): Promise<number>;
+}

--- a/packages/shared/src/features/chat-history/domain/repositories/index.ts
+++ b/packages/shared/src/features/chat-history/domain/repositories/index.ts
@@ -1,0 +1,12 @@
+/**
+ * リポジトリインターフェースの集約エクスポート
+ *
+ * @module features/chat-history/domain/repositories
+ */
+
+export type {
+  IChatSessionRepository,
+  ChatSessionSearchCriteria,
+} from "./IChatSessionRepository.js";
+
+export type { IChatMessageRepository } from "./IChatMessageRepository.js";

--- a/packages/shared/src/features/chat-history/domain/value-objects/ChatMessageId.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/ChatMessageId.ts
@@ -1,0 +1,77 @@
+/**
+ * チャットメッセージID 値オブジェクト
+ *
+ * UUID v4形式のメッセージ一意識別子を表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/ChatMessageId
+ */
+
+import { randomUUID } from "crypto";
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidIdError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * チャットメッセージID 値オブジェクト
+ */
+export class ChatMessageId {
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  private constructor(private readonly _value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * 文字列からChatMessageIdを作成する
+   *
+   * @param value UUID文字列
+   * @returns 成功時: ChatMessageId, 失敗時: InvalidIdError
+   */
+  static create(value: string): Result<ChatMessageId, InvalidIdError> {
+    if (!value || !this.UUID_REGEX.test(value)) {
+      return err(new InvalidIdError("ChatMessageId", value ?? ""));
+    }
+    return ok(new ChatMessageId(value));
+  }
+
+  /**
+   * 新しいChatMessageIdを生成する
+   *
+   * @returns ChatMessageId
+   */
+  static generate(): ChatMessageId {
+    return new ChatMessageId(randomUUID());
+  }
+
+  /**
+   * 文字列から直接作成する（DBからの復元用）
+   *
+   * @param value UUID文字列
+   * @returns ChatMessageId
+   */
+  static fromString(value: string): ChatMessageId {
+    return new ChatMessageId(value);
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: ChatMessageId): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/ChatSessionId.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/ChatSessionId.ts
@@ -1,0 +1,81 @@
+/**
+ * チャットセッションID 値オブジェクト
+ *
+ * UUID v4形式のセッション一意識別子を表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/ChatSessionId
+ */
+
+import { randomUUID } from "crypto";
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidIdError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * チャットセッションID 値オブジェクト
+ */
+export class ChatSessionId {
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  private constructor(private readonly _value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * 文字列からChatSessionIdを作成する
+   *
+   * @param value UUID文字列
+   * @returns 成功時: ChatSessionId, 失敗時: InvalidIdError
+   */
+  static create(value: string): Result<ChatSessionId, InvalidIdError> {
+    if (!value || !this.UUID_REGEX.test(value)) {
+      return err(new InvalidIdError("ChatSessionId", value ?? ""));
+    }
+    return ok(new ChatSessionId(value));
+  }
+
+  /**
+   * 新しいChatSessionIdを生成する
+   *
+   * @returns ChatSessionId
+   */
+  static generate(): ChatSessionId {
+    return new ChatSessionId(randomUUID());
+  }
+
+  /**
+   * 文字列から直接作成する（DBからの復元用）
+   * 検証なしで作成するため、内部使用のみ
+   *
+   * @param value UUID文字列
+   * @returns ChatSessionId
+   */
+  static fromString(value: string): ChatSessionId {
+    return new ChatSessionId(value);
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * 等価性を判定する
+   *
+   * @param other 比較対象
+   * @returns 等価な場合true
+   */
+  equals(other: ChatSessionId): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/ChatSessionTitle.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/ChatSessionTitle.ts
@@ -1,0 +1,106 @@
+/**
+ * チャットセッションタイトル 値オブジェクト
+ *
+ * 1〜100文字のセッションタイトルを表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/ChatSessionTitle
+ */
+
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidTitleError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * チャットセッションタイトル 値オブジェクト
+ */
+export class ChatSessionTitle {
+  private static readonly MIN_LENGTH = 1;
+  private static readonly MAX_LENGTH = 100;
+  private static readonly DEFAULT_PREFIX = "新しいチャット";
+
+  private constructor(private readonly _value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * タイトルを作成する
+   *
+   * @param value タイトル文字列
+   * @returns 成功時: ChatSessionTitle, 失敗時: InvalidTitleError
+   */
+  static create(value: string): Result<ChatSessionTitle, InvalidTitleError> {
+    const trimmed = value.trim();
+
+    if (trimmed.length < this.MIN_LENGTH) {
+      return err(
+        new InvalidTitleError(
+          `タイトルは${this.MIN_LENGTH}文字以上必要です（現在: ${trimmed.length}文字）`,
+        ),
+      );
+    }
+
+    if (trimmed.length > this.MAX_LENGTH) {
+      return err(
+        new InvalidTitleError(
+          `タイトルは${this.MAX_LENGTH}文字以内にしてください（現在: ${trimmed.length}文字）`,
+        ),
+      );
+    }
+
+    return ok(new ChatSessionTitle(trimmed));
+  }
+
+  /**
+   * デフォルトタイトルを作成する
+   *
+   * @returns ChatSessionTitle（"新しいチャット YYYY-MM-DD HH:mm"形式）
+   */
+  static createDefault(): ChatSessionTitle {
+    const now = new Date();
+    const formatted = this.formatDateTime(now);
+    return new ChatSessionTitle(`${this.DEFAULT_PREFIX} ${formatted}`);
+  }
+
+  /**
+   * 文字列から直接作成する（DBからの復元用）
+   *
+   * @param value タイトル文字列
+   * @returns ChatSessionTitle
+   */
+  static fromString(value: string): ChatSessionTitle {
+    return new ChatSessionTitle(value);
+  }
+
+  /**
+   * 日時をフォーマットする
+   */
+  private static formatDateTime(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: ChatSessionTitle): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/LLMMetadata.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/LLMMetadata.ts
@@ -1,0 +1,162 @@
+/**
+ * LLMメタデータ 値オブジェクト
+ *
+ * アシスタントメッセージのLLM応答に関するメタデータを表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/LLMMetadata
+ */
+
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidLLMMetadataError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * トークン使用量
+ */
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * LLMメタデータ作成パラメータ
+ */
+export interface CreateLLMMetadataParams {
+  provider: string;
+  model: string;
+  tokenUsage?: TokenUsage;
+  responseTime?: number;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+/**
+ * LLMメタデータ 値オブジェクト
+ */
+export class LLMMetadata {
+  private constructor(
+    private readonly _provider: string,
+    private readonly _model: string,
+    private readonly _tokenUsage: TokenUsage | null,
+    private readonly _responseTime: number | null,
+    private readonly _temperature: number | null,
+    private readonly _maxTokens: number | null,
+  ) {
+    Object.freeze(this);
+  }
+
+  /**
+   * LLMメタデータを作成する
+   *
+   * @param params 作成パラメータ
+   * @returns 成功時: LLMMetadata, 失敗時: InvalidLLMMetadataError
+   */
+  static create(
+    params: CreateLLMMetadataParams,
+  ): Result<LLMMetadata, InvalidLLMMetadataError> {
+    if (!params.provider || params.provider.trim() === "") {
+      return err(new InvalidLLMMetadataError("LLMプロバイダーは必須です"));
+    }
+
+    if (!params.model || params.model.trim() === "") {
+      return err(new InvalidLLMMetadataError("LLMモデルは必須です"));
+    }
+
+    return ok(
+      new LLMMetadata(
+        params.provider.trim(),
+        params.model.trim(),
+        params.tokenUsage ?? null,
+        params.responseTime ?? null,
+        params.temperature ?? null,
+        params.maxTokens ?? null,
+      ),
+    );
+  }
+
+  /**
+   * DBからの復元用
+   */
+  static reconstitute(
+    provider: string,
+    model: string,
+    metadata: Record<string, unknown> | null,
+  ): LLMMetadata {
+    return new LLMMetadata(
+      provider,
+      model,
+      (metadata?.tokenUsage as TokenUsage) ?? null,
+      (metadata?.responseTime as number) ?? null,
+      (metadata?.temperature as number) ?? null,
+      (metadata?.maxTokens as number) ?? null,
+    );
+  }
+
+  /**
+   * プロバイダーを取得する
+   */
+  get provider(): string {
+    return this._provider;
+  }
+
+  /**
+   * モデルを取得する
+   */
+  get model(): string {
+    return this._model;
+  }
+
+  /**
+   * トークン使用量を取得する
+   */
+  get tokenUsage(): TokenUsage | null {
+    return this._tokenUsage;
+  }
+
+  /**
+   * レスポンス時間を取得する
+   */
+  get responseTime(): number | null {
+    return this._responseTime;
+  }
+
+  /**
+   * temperature設定を取得する
+   */
+  get temperature(): number | null {
+    return this._temperature;
+  }
+
+  /**
+   * 最大トークン数を取得する
+   */
+  get maxTokens(): number | null {
+    return this._maxTokens;
+  }
+
+  /**
+   * JSON形式に変換する（永続化用）
+   */
+  toJSON(): Record<string, unknown> {
+    return {
+      provider: this._provider,
+      model: this._model,
+      tokenUsage: this._tokenUsage,
+      responseTime: this._responseTime,
+      temperature: this._temperature,
+      maxTokens: this._maxTokens,
+    };
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: LLMMetadata): boolean {
+    return (
+      this._provider === other._provider &&
+      this._model === other._model &&
+      JSON.stringify(this._tokenUsage) === JSON.stringify(other._tokenUsage)
+    );
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/MessageContent.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/MessageContent.ts
@@ -1,0 +1,97 @@
+/**
+ * メッセージ内容 値オブジェクト
+ *
+ * 1〜50,000文字のメッセージ本文を表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/MessageContent
+ */
+
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidContentError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * メッセージ内容 値オブジェクト
+ */
+export class MessageContent {
+  private static readonly MIN_LENGTH = 1;
+  private static readonly MAX_LENGTH = 50000;
+  private static readonly PREVIEW_LENGTH = 100;
+  private static readonly PREVIEW_ELLIPSIS = "...";
+
+  private constructor(private readonly _value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * メッセージ内容を作成する
+   *
+   * @param value 内容文字列
+   * @returns 成功時: MessageContent, 失敗時: InvalidContentError
+   */
+  static create(value: string): Result<MessageContent, InvalidContentError> {
+    if (!value || value.length < this.MIN_LENGTH) {
+      return err(new InvalidContentError("メッセージ内容は必須です"));
+    }
+
+    if (value.length > this.MAX_LENGTH) {
+      return err(
+        new InvalidContentError(
+          `メッセージは${this.MAX_LENGTH.toLocaleString()}文字以内にしてください`,
+        ),
+      );
+    }
+
+    return ok(new MessageContent(value));
+  }
+
+  /**
+   * 文字列から直接作成する（DBからの復元用）
+   *
+   * @param value 内容文字列
+   * @returns MessageContent
+   */
+  static fromString(value: string): MessageContent {
+    return new MessageContent(value);
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * プレビュー文字列を取得する（先頭100文字）
+   */
+  get preview(): string {
+    if (this._value.length <= MessageContent.PREVIEW_LENGTH) {
+      return this._value;
+    }
+    const cutLength =
+      MessageContent.PREVIEW_LENGTH - MessageContent.PREVIEW_ELLIPSIS.length;
+    return this._value.slice(0, cutLength) + MessageContent.PREVIEW_ELLIPSIS;
+  }
+
+  /**
+   * 文字数を取得する
+   */
+  get length(): number {
+    return this._value.length;
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: MessageContent): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/MessageRole.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/MessageRole.ts
@@ -1,0 +1,82 @@
+/**
+ * メッセージロール 値オブジェクト
+ *
+ * メッセージの発信者種別を表す列挙的な値オブジェクト。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/MessageRole
+ */
+
+/**
+ * メッセージロール 値オブジェクト
+ */
+export class MessageRole {
+  private static readonly _User = new MessageRole("user");
+  private static readonly _Assistant = new MessageRole("assistant");
+
+  private constructor(private readonly _value: "user" | "assistant") {
+    Object.freeze(this);
+  }
+
+  /**
+   * ユーザーロールを取得する
+   */
+  static get User(): MessageRole {
+    return this._User;
+  }
+
+  /**
+   * アシスタントロールを取得する
+   */
+  static get Assistant(): MessageRole {
+    return this._Assistant;
+  }
+
+  /**
+   * 文字列からMessageRoleを作成する
+   *
+   * @param value ロール文字列
+   * @returns MessageRole
+   * @throws 不正な値の場合
+   */
+  static fromString(value: string): MessageRole {
+    if (value === "user") return this._User;
+    if (value === "assistant") return this._Assistant;
+    throw new Error(`Invalid message role: ${value}`);
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): "user" | "assistant" {
+    return this._value;
+  }
+
+  /**
+   * ユーザーメッセージかどうか
+   */
+  get isUser(): boolean {
+    return this._value === "user";
+  }
+
+  /**
+   * アシスタントメッセージかどうか
+   */
+  get isAssistant(): boolean {
+    return this._value === "assistant";
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: MessageRole): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/UserId.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/UserId.ts
@@ -1,0 +1,64 @@
+/**
+ * ユーザーID 値オブジェクト
+ *
+ * ユーザーの一意識別子を表す。
+ * 不変かつ値による等価性を持つ。
+ *
+ * @module features/chat-history/domain/value-objects/UserId
+ */
+
+import { type Result, ok, err } from "../../../../core/Result.js";
+import { InvalidIdError } from "../errors/ValueObjectErrors.js";
+
+/**
+ * ユーザーID 値オブジェクト
+ */
+export class UserId {
+  private constructor(private readonly _value: string) {
+    Object.freeze(this);
+  }
+
+  /**
+   * 文字列からUserIdを作成する
+   *
+   * @param value ユーザーID文字列
+   * @returns 成功時: UserId, 失敗時: InvalidIdError
+   */
+  static create(value: string): Result<UserId, InvalidIdError> {
+    if (!value || value.trim() === "") {
+      return err(new InvalidIdError("UserId", value ?? ""));
+    }
+    return ok(new UserId(value.trim()));
+  }
+
+  /**
+   * 文字列から直接作成する（DBからの復元用）
+   *
+   * @param value ユーザーID文字列
+   * @returns UserId
+   */
+  static fromString(value: string): UserId {
+    return new UserId(value);
+  }
+
+  /**
+   * 値を取得する
+   */
+  get value(): string {
+    return this._value;
+  }
+
+  /**
+   * 等価性を判定する
+   */
+  equals(other: UserId): boolean {
+    return this._value === other._value;
+  }
+
+  /**
+   * 文字列表現を返す
+   */
+  toString(): string {
+    return this._value;
+  }
+}

--- a/packages/shared/src/features/chat-history/domain/value-objects/__tests__/ChatSessionId.test.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/__tests__/ChatSessionId.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { ChatSessionId } from "../ChatSessionId.js";
+
+describe("ChatSessionId", () => {
+  describe("create", () => {
+    it("有効なUUIDで作成できる", () => {
+      // Arrange
+      const validUuid = "550e8400-e29b-41d4-a716-446655440000";
+
+      // Act
+      const result = ChatSessionId.create(validUuid);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe(validUuid);
+      }
+    });
+
+    it("無効な形式でエラーを返す", () => {
+      // Arrange
+      const invalidUuid = "not-a-valid-uuid";
+
+      // Act
+      const result = ChatSessionId.create(invalidUuid);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_ID");
+      }
+    });
+
+    it("空文字でエラーを返す", () => {
+      // Arrange
+      const emptyId = "";
+
+      // Act
+      const result = ChatSessionId.create(emptyId);
+
+      // Assert
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("generate", () => {
+    it("新しいUUIDを生成できる", () => {
+      // Act
+      const id = ChatSessionId.generate();
+
+      // Assert
+      expect(id.value).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("生成されたIDはユニークである", () => {
+      // Act
+      const id1 = ChatSessionId.generate();
+      const id2 = ChatSessionId.generate();
+
+      // Assert
+      expect(id1.value).not.toBe(id2.value);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値のIDは等価である", () => {
+      // Arrange
+      const uuid = "550e8400-e29b-41d4-a716-446655440000";
+      const id1 = ChatSessionId.create(uuid);
+      const id2 = ChatSessionId.create(uuid);
+
+      // Assert
+      expect(id1.ok && id2.ok && id1.value.equals(id2.value)).toBe(true);
+    });
+
+    it("異なる値のIDは等価ではない", () => {
+      // Arrange
+      const uuid1 = "550e8400-e29b-41d4-a716-446655440000";
+      const uuid2 = "550e8400-e29b-41d4-a716-446655440001";
+      const id1 = ChatSessionId.create(uuid1);
+      const id2 = ChatSessionId.create(uuid2);
+
+      // Assert
+      expect(id1.ok && id2.ok && id1.value.equals(id2.value)).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/domain/value-objects/__tests__/ChatSessionTitle.test.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/__tests__/ChatSessionTitle.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { ChatSessionTitle } from "../ChatSessionTitle.js";
+
+describe("ChatSessionTitle", () => {
+  describe("create", () => {
+    it("有効なタイトルで作成できる", () => {
+      // Arrange
+      const validTitle = "テストセッション";
+
+      // Act
+      const result = ChatSessionTitle.create(validTitle);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe(validTitle);
+      }
+    });
+
+    it("空文字でエラーを返す", () => {
+      // Arrange
+      const emptyTitle = "";
+
+      // Act
+      const result = ChatSessionTitle.create(emptyTitle);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_TITLE");
+      }
+    });
+
+    it("100文字超でエラーを返す", () => {
+      // Arrange
+      const longTitle = "あ".repeat(101);
+
+      // Act
+      const result = ChatSessionTitle.create(longTitle);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_TITLE");
+      }
+    });
+
+    it("1文字で作成できる（境界値）", () => {
+      // Arrange
+      const minTitle = "a";
+
+      // Act
+      const result = ChatSessionTitle.create(minTitle);
+
+      // Assert
+      expect(result.ok).toBe(true);
+    });
+
+    it("100文字でちょうど作成できる（境界値）", () => {
+      // Arrange
+      const maxTitle = "あ".repeat(100);
+
+      // Act
+      const result = ChatSessionTitle.create(maxTitle);
+
+      // Assert
+      expect(result.ok).toBe(true);
+    });
+
+    it("前後の空白がトリミングされる", () => {
+      // Arrange
+      const titleWithSpaces = "  テストセッション  ";
+
+      // Act
+      const result = ChatSessionTitle.create(titleWithSpaces);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe("テストセッション");
+      }
+    });
+  });
+
+  describe("createDefault", () => {
+    it("デフォルトタイトルを作成する", () => {
+      // Act
+      const title = ChatSessionTitle.createDefault();
+
+      // Assert
+      expect(title.value).toMatch(
+        /^新しいチャット \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/,
+      );
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値のタイトルは等価である", () => {
+      // Arrange
+      const titleStr = "テストタイトル";
+      const title1 = ChatSessionTitle.create(titleStr);
+      const title2 = ChatSessionTitle.create(titleStr);
+
+      // Assert
+      expect(title1.ok && title2.ok && title1.value.equals(title2.value)).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/domain/value-objects/__tests__/MessageContent.test.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/__tests__/MessageContent.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { MessageContent } from "../MessageContent.js";
+
+describe("MessageContent", () => {
+  describe("create", () => {
+    it("有効なコンテンツで作成できる", () => {
+      // Arrange
+      const validContent = "これは有効なメッセージコンテンツです。";
+
+      // Act
+      const result = MessageContent.create(validContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe(validContent);
+      }
+    });
+
+    it("空文字でエラーを返す", () => {
+      // Arrange
+      const emptyContent = "";
+
+      // Act
+      const result = MessageContent.create(emptyContent);
+
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("INVALID_CONTENT");
+      }
+    });
+
+    it("50000文字超でエラーを返す", () => {
+      // Arrange
+      const longContent = "あ".repeat(50001);
+
+      // Act
+      const result = MessageContent.create(longContent);
+
+      // Assert
+      expect(result.ok).toBe(false);
+    });
+
+    it("50000文字でちょうど作成できる（境界値）", () => {
+      // Arrange
+      const maxContent = "あ".repeat(50000);
+
+      // Act
+      const result = MessageContent.create(maxContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+    });
+
+    it("空白のみのコンテンツは許可される（値はそのまま保持）", () => {
+      // Arrange
+      const whitespaceOnly = "   \n\t  ";
+
+      // Act
+      const result = MessageContent.create(whitespaceOnly);
+
+      // Assert
+      // MessageContentはトリミングしないので空白のみでも作成可能
+      expect(result.ok).toBe(true);
+    });
+
+    it("1文字で作成できる（境界値：最小値）", () => {
+      // Arrange
+      const minContent = "a";
+
+      // Act
+      const result = MessageContent.create(minContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe(minContent);
+        expect(result.value.length).toBe(1);
+      }
+    });
+  });
+
+  describe("preview", () => {
+    it("100文字以下はそのまま返す", () => {
+      // Arrange
+      const shortContent = "これは短いメッセージ";
+      const result = MessageContent.create(shortContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.preview).toBe(shortContent);
+      }
+    });
+
+    it("100文字超は省略される", () => {
+      // Arrange
+      const longContent = "あ".repeat(150);
+      const result = MessageContent.create(longContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.preview.length).toBeLessThanOrEqual(100);
+        expect(result.value.preview).toContain("...");
+      }
+    });
+
+    it("ちょうど100文字はそのまま返す（境界値）", () => {
+      // Arrange
+      const exactContent = "あ".repeat(100);
+      const result = MessageContent.create(exactContent);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.preview).toBe(exactContent);
+        expect(result.value.preview.length).toBe(100);
+      }
+    });
+
+    it("101文字でプレビューが切り詰められる（境界値超過）", () => {
+      // Arrange
+      const content101 = "あ".repeat(101);
+      const result = MessageContent.create(content101);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.preview.length).toBeLessThanOrEqual(100);
+        expect(result.value.preview).toContain("...");
+      }
+    });
+  });
+
+  describe("length", () => {
+    it("文字数を取得できる", () => {
+      // Arrange
+      const content = "12345";
+      const result = MessageContent.create(content);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(5);
+      }
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値のコンテンツは等価である", () => {
+      // Arrange
+      const contentStr = "テストコンテンツ";
+      const content1 = MessageContent.create(contentStr);
+      const content2 = MessageContent.create(contentStr);
+
+      // Assert
+      expect(
+        content1.ok && content2.ok && content1.value.equals(content2.value),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/features/chat-history/domain/value-objects/index.ts
+++ b/packages/shared/src/features/chat-history/domain/value-objects/index.ts
@@ -1,0 +1,17 @@
+/**
+ * 値オブジェクトの集約エクスポート
+ *
+ * @module features/chat-history/domain/value-objects
+ */
+
+export { ChatSessionId } from "./ChatSessionId.js";
+export { ChatMessageId } from "./ChatMessageId.js";
+export { UserId } from "./UserId.js";
+export { ChatSessionTitle } from "./ChatSessionTitle.js";
+export { MessageContent } from "./MessageContent.js";
+export { MessageRole } from "./MessageRole.js";
+export {
+  LLMMetadata,
+  type TokenUsage,
+  type CreateLLMMetadataParams,
+} from "./LLMMetadata.js";

--- a/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/ChatMessageMapper.ts
+++ b/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/ChatMessageMapper.ts
@@ -1,0 +1,147 @@
+/**
+ * チャットメッセージマッパー
+ *
+ * DBレコード ⇔ ドメインエンティティ ⇔ DTO の変換を行う。
+ *
+ * @module features/chat-history/infrastructure/persistence/mappers/ChatMessageMapper
+ */
+
+import { type Result, ok, err } from "../../../../../core/Result.js";
+import { ChatMessage } from "../../../domain/entities/ChatMessage.js";
+import type { ChatMessageDTO } from "../../../application/dto/ChatMessageDTO.js";
+import { messageToDTO } from "../../../application/dto/transformers.js";
+import {
+  DomainError,
+  BusinessRuleError,
+} from "../../../../../core/errors/DomainError.js";
+
+/**
+ * DBレコード型（Drizzle推論型相当）
+ * NOTE: 日付はISO 8601文字列形式（DB schemaに合わせる）
+ */
+export interface ChatMessageRecord {
+  id: string;
+  sessionId: string;
+  role: string;
+  content: string;
+  messageIndex: number;
+  llmModel: string | null;
+  llmProvider: string | null;
+  llmMetadata: string | null; // JSON文字列
+  timestamp: string; // ISO 8601 string
+}
+
+/**
+ * チャットメッセージマッパー
+ */
+export class ChatMessageMapper {
+  /**
+   * DBレコードからドメインエンティティに変換
+   *
+   * @param record DBレコード
+   * @returns 成功時: ChatMessage, 失敗時: DomainError
+   */
+  static toDomain(record: ChatMessageRecord): Result<ChatMessage, DomainError> {
+    try {
+      // LLMメタデータのJSONパース
+      let llmMetadata: Record<string, unknown> | null = null;
+      if (record.llmMetadata) {
+        try {
+          const parsed = JSON.parse(record.llmMetadata);
+          // フラット構造から正規化された構造に変換
+          llmMetadata = {
+            // tokenUsageをネスト構造に変換（reconstitute用）
+            tokenUsage:
+              parsed.inputTokens !== undefined ||
+              parsed.outputTokens !== undefined ||
+              parsed.totalTokens !== undefined
+                ? {
+                    inputTokens: parsed.inputTokens,
+                    outputTokens: parsed.outputTokens,
+                    totalTokens: parsed.totalTokens,
+                  }
+                : null,
+            responseTime: parsed.responseTime ?? null,
+            temperature: parsed.temperature ?? null,
+            maxTokens: parsed.maxTokens ?? null,
+          };
+        } catch {
+          // パース失敗時はnullとして処理
+          llmMetadata = null;
+        }
+      }
+
+      const message = ChatMessage.reconstitute({
+        id: record.id,
+        sessionId: record.sessionId,
+        role: record.role as "user" | "assistant",
+        content: record.content,
+        messageIndex: record.messageIndex,
+        timestamp: new Date(record.timestamp), // ISO 8601 string → Date
+        llmProvider: record.llmProvider,
+        llmModel: record.llmModel,
+        llmMetadata,
+      });
+
+      return ok(message);
+    } catch (error) {
+      return err(
+        new BusinessRuleError(
+          "MAPPING_ERROR",
+          `メッセージのマッピングに失敗しました: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+  }
+
+  /**
+   * ドメインエンティティからDBレコードに変換
+   *
+   * @param message ドメインエンティティ
+   * @returns DBレコード
+   */
+  static toPersistence(message: ChatMessage): ChatMessageRecord {
+    // LLMメタデータをJSON文字列化
+    let llmMetadataJson: string | null = null;
+    if (message.llmMetadata) {
+      const metadataObj: Record<string, unknown> = {};
+      if (message.llmMetadata.tokenUsage) {
+        metadataObj.inputTokens = message.llmMetadata.tokenUsage.inputTokens;
+        metadataObj.outputTokens = message.llmMetadata.tokenUsage.outputTokens;
+        metadataObj.totalTokens = message.llmMetadata.tokenUsage.totalTokens;
+      }
+      if (message.llmMetadata.responseTime !== undefined) {
+        metadataObj.responseTime = message.llmMetadata.responseTime;
+      }
+      if (message.llmMetadata.temperature !== undefined) {
+        metadataObj.temperature = message.llmMetadata.temperature;
+      }
+      if (message.llmMetadata.maxTokens !== undefined) {
+        metadataObj.maxTokens = message.llmMetadata.maxTokens;
+      }
+      llmMetadataJson = JSON.stringify(metadataObj);
+    }
+
+    return {
+      id: message.id.value,
+      sessionId: message.sessionId.value,
+      role: message.role.value,
+      content: message.content.value,
+      messageIndex: message.messageIndex,
+      llmModel: message.llmMetadata?.model ?? null,
+      llmProvider: message.llmMetadata?.provider ?? null,
+      llmMetadata: llmMetadataJson,
+      timestamp: message.createdAt.toISOString(), // Date → ISO 8601 string
+    };
+  }
+
+  /**
+   * ドメインエンティティからDTOに変換
+   *
+   * @param message ドメインエンティティ
+   * @returns ChatMessageDTO
+   */
+  static toDTO(message: ChatMessage): ChatMessageDTO {
+    return messageToDTO(message);
+  }
+}

--- a/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/ChatSessionMapper.ts
+++ b/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/ChatSessionMapper.ts
@@ -1,0 +1,101 @@
+/**
+ * チャットセッションマッパー
+ *
+ * DBレコード ⇔ ドメインエンティティ ⇔ DTO の変換を行う。
+ *
+ * @module features/chat-history/infrastructure/persistence/mappers/ChatSessionMapper
+ */
+
+import { type Result, ok, err } from "../../../../../core/Result.js";
+import { ChatSession } from "../../../domain/entities/ChatSession.js";
+import type { ChatSessionDTO } from "../../../application/dto/ChatSessionDTO.js";
+import { sessionToDTO } from "../../../application/dto/transformers.js";
+import {
+  DomainError,
+  BusinessRuleError,
+} from "../../../../../core/errors/DomainError.js";
+
+/**
+ * DBレコード型（Drizzle推論型相当）
+ * NOTE: 日付はISO 8601文字列形式（DB schemaに合わせる）
+ */
+export interface ChatSessionRecord {
+  id: string;
+  userId: string;
+  title: string;
+  lastMessagePreview: string | null;
+  messageCount: number;
+  isFavorite: number; // SQLiteではboolean→integer
+  isPinned: number;
+  pinOrder: number | null;
+  createdAt: string; // ISO 8601 string
+  updatedAt: string;
+}
+
+/**
+ * チャットセッションマッパー
+ */
+export class ChatSessionMapper {
+  /**
+   * DBレコードからドメインエンティティに変換
+   *
+   * @param record DBレコード
+   * @returns 成功時: ChatSession, 失敗時: DomainError
+   */
+  static toDomain(record: ChatSessionRecord): Result<ChatSession, DomainError> {
+    try {
+      const session = ChatSession.reconstitute({
+        id: record.id,
+        userId: record.userId,
+        title: record.title,
+        lastMessagePreview: record.lastMessagePreview,
+        messageCount: record.messageCount,
+        isFavorite: record.isFavorite === 1,
+        isPinned: record.isPinned === 1,
+        pinOrder: record.pinOrder,
+        createdAt: new Date(record.createdAt), // ISO 8601 string → Date
+        updatedAt: new Date(record.updatedAt),
+      });
+
+      return ok(session);
+    } catch (error) {
+      return err(
+        new BusinessRuleError(
+          "MAPPING_ERROR",
+          `セッションのマッピングに失敗しました: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+      );
+    }
+  }
+
+  /**
+   * ドメインエンティティからDBレコードに変換
+   *
+   * @param session ドメインエンティティ
+   * @returns DBレコード
+   */
+  static toPersistence(session: ChatSession): ChatSessionRecord {
+    return {
+      id: session.id.value,
+      userId: session.userId.value,
+      title: session.title.value,
+      lastMessagePreview: session.lastMessagePreview,
+      messageCount: session.messageCount,
+      isFavorite: session.isFavorite ? 1 : 0,
+      isPinned: session.isPinned ? 1 : 0,
+      pinOrder: session.pinOrder,
+      createdAt: session.createdAt.toISOString(), // Date → ISO 8601 string
+      updatedAt: session.updatedAt.toISOString(),
+    };
+  }
+
+  /**
+   * ドメインエンティティからDTOに変換
+   *
+   * @param session ドメインエンティティ
+   * @returns ChatSessionDTO
+   */
+  static toDTO(session: ChatSession): ChatSessionDTO {
+    return sessionToDTO(session);
+  }
+}

--- a/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/__tests__/ChatMessageMapper.test.ts
+++ b/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/__tests__/ChatMessageMapper.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import {
+  ChatMessageMapper,
+  type ChatMessageRecord,
+} from "../ChatMessageMapper.js";
+import { ChatMessage } from "../../../../domain/entities/ChatMessage.js";
+
+describe("ChatMessageMapper", () => {
+  describe("toDomain", () => {
+    it("DBレコードからドメインエンティティに変換できる（ユーザーメッセージ）", () => {
+      // Arrange
+      const dbRecord: ChatMessageRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        role: "user",
+        content: "こんにちは",
+        messageIndex: 0,
+        llmModel: null,
+        llmProvider: null,
+        llmMetadata: null,
+        timestamp: "2024-01-18T00:00:00.000Z",
+      };
+
+      // Act
+      const result = ChatMessageMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.id.value).toBe(dbRecord.id);
+        expect(result.value.sessionId.value).toBe(dbRecord.sessionId);
+        expect(result.value.role.value).toBe("user");
+        expect(result.value.content.value).toBe(dbRecord.content);
+        expect(result.value.messageIndex).toBe(0);
+        expect(result.value.llmMetadata).toBeNull();
+      }
+    });
+
+    it("LLMメタデータがJSONパースされる", () => {
+      // Arrange
+      const dbRecord: ChatMessageRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        role: "assistant",
+        content: "お手伝いします",
+        messageIndex: 1,
+        llmModel: "gpt-4o",
+        llmProvider: "openai",
+        llmMetadata: JSON.stringify({
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+          responseTime: 500,
+        }),
+        timestamp: "2024-01-18T00:00:00.000Z",
+      };
+
+      // Act
+      const result = ChatMessageMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.llmMetadata).not.toBeNull();
+        expect(result.value.llmMetadata?.provider).toBe("openai");
+        expect(result.value.llmMetadata?.model).toBe("gpt-4o");
+        expect(result.value.llmMetadata?.tokenUsage?.inputTokens).toBe(100);
+        expect(result.value.llmMetadata?.tokenUsage?.outputTokens).toBe(50);
+        expect(result.value.llmMetadata?.tokenUsage?.totalTokens).toBe(150);
+        expect(result.value.llmMetadata?.responseTime).toBe(500);
+      }
+    });
+
+    it("nullのLLMメタデータはnullのまま保持される", () => {
+      // Arrange
+      const dbRecord: ChatMessageRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        role: "user",
+        content: "こんにちは",
+        messageIndex: 0,
+        llmModel: null,
+        llmProvider: null,
+        llmMetadata: null,
+        timestamp: "2024-01-18T00:00:00.000Z",
+      };
+
+      // Act
+      const result = ChatMessageMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.llmMetadata).toBeNull();
+      }
+    });
+
+    it("日付が正しく変換される", () => {
+      // Arrange
+      const isoString = "2024-01-18T00:00:00.000Z";
+      const dbRecord: ChatMessageRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        role: "user",
+        content: "こんにちは",
+        messageIndex: 0,
+        llmModel: null,
+        llmProvider: null,
+        llmMetadata: null,
+        timestamp: isoString,
+      };
+
+      // Act
+      const result = ChatMessageMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.createdAt.toISOString()).toBe(isoString);
+      }
+    });
+
+    it("不正なJSONのLLMメタデータはnullとして処理される", () => {
+      // Arrange
+      const dbRecord: ChatMessageRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440001",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
+        role: "assistant",
+        content: "お手伝いします",
+        messageIndex: 1,
+        llmModel: "gpt-4o",
+        llmProvider: "openai",
+        llmMetadata: "invalid json", // 不正なJSON
+        timestamp: "2024-01-18T00:00:00.000Z",
+      };
+
+      // Act
+      const result = ChatMessageMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // 不正なJSONの場合、パースに失敗してllmMetadataがnullになる
+        // ChatMessage.reconstituteはllmMetadataがnullだとLLMMetadataを作成しないため
+        // 結果的にllmMetadataはnullになる
+        expect(result.value.llmMetadata).toBeNull();
+      }
+    });
+  });
+
+  describe("toPersistence", () => {
+    it("ドメインエンティティからDBレコードに変換できる（ユーザーメッセージ）", () => {
+      // Arrange
+      const message = createTestUserMessage();
+
+      // Act
+      const record = ChatMessageMapper.toPersistence(message);
+
+      // Assert
+      expect(record.id).toBe(message.id.value);
+      expect(record.sessionId).toBe(message.sessionId.value);
+      expect(record.role).toBe(message.role.value);
+      expect(record.content).toBe(message.content.value);
+      expect(record.messageIndex).toBe(message.messageIndex);
+      expect(record.llmMetadata).toBeNull();
+      expect(record.llmModel).toBeNull();
+      expect(record.llmProvider).toBeNull();
+    });
+
+    it("LLMメタデータがJSON文字列化される", () => {
+      // Arrange
+      const message = createTestAssistantMessage();
+
+      // Act
+      const record = ChatMessageMapper.toPersistence(message);
+
+      // Assert
+      expect(record.llmProvider).toBe("openai");
+      expect(record.llmModel).toBe("gpt-4o");
+      expect(typeof record.llmMetadata).toBe("string");
+
+      const parsed = JSON.parse(record.llmMetadata!);
+      expect(parsed.inputTokens).toBe(100);
+      expect(parsed.outputTokens).toBe(50);
+      expect(parsed.totalTokens).toBe(150);
+      expect(parsed.responseTime).toBe(500);
+    });
+
+    it("nullのLLMメタデータはnullのまま保持される", () => {
+      // Arrange
+      const message = createTestUserMessage();
+
+      // Act
+      const record = ChatMessageMapper.toPersistence(message);
+
+      // Assert
+      expect(record.llmMetadata).toBeNull();
+    });
+
+    it("日付がISO文字列に変換される", () => {
+      // Arrange
+      const message = createTestUserMessage();
+
+      // Act
+      const record = ChatMessageMapper.toPersistence(message);
+
+      // Assert
+      expect(record.timestamp).toBe(message.createdAt.toISOString());
+    });
+  });
+
+  describe("toDTO", () => {
+    it("ドメインエンティティからDTOに変換できる（ユーザーメッセージ）", () => {
+      // Arrange
+      const message = createTestUserMessage();
+
+      // Act
+      const dto = ChatMessageMapper.toDTO(message);
+
+      // Assert
+      expect(dto.id).toBe(message.id.value);
+      expect(dto.sessionId).toBe(message.sessionId.value);
+      expect(dto.role).toBe(message.role.value);
+      expect(dto.content).toBe(message.content.value);
+      expect(dto.messageIndex).toBe(message.messageIndex);
+      expect(dto.llmMetadata).toBeNull();
+      expect(typeof dto.createdAt).toBe("string"); // ISO文字列
+    });
+
+    it("アシスタントメッセージのDTOにLLM情報が含まれる", () => {
+      // Arrange
+      const message = createTestAssistantMessage();
+
+      // Act
+      const dto = ChatMessageMapper.toDTO(message);
+
+      // Assert
+      expect(dto.llmMetadata).not.toBeNull();
+      expect(dto.llmMetadata?.provider).toBe("openai");
+      expect(dto.llmMetadata?.model).toBe("gpt-4o");
+      expect(dto.llmMetadata?.tokenUsage?.inputTokens).toBe(100);
+      expect(dto.llmMetadata?.tokenUsage?.outputTokens).toBe(50);
+      expect(dto.llmMetadata?.tokenUsage?.totalTokens).toBe(150);
+      expect(dto.llmMetadata?.responseTime).toBe(500);
+    });
+
+    it("日付がISO文字列に変換される", () => {
+      // Arrange
+      const message = createTestUserMessage();
+
+      // Act
+      const dto = ChatMessageMapper.toDTO(message);
+
+      // Assert
+      expect(dto.createdAt).toBe(message.createdAt.toISOString());
+    });
+  });
+});
+
+function createTestUserMessage(): ChatMessage {
+  const result = ChatMessage.createUserMessage({
+    sessionId: "550e8400-e29b-41d4-a716-446655440000",
+    content: "こんにちは",
+    messageIndex: 0,
+  });
+  if (!result.ok) throw new Error("Failed to create test message");
+  return result.value;
+}
+
+function createTestAssistantMessage(): ChatMessage {
+  const result = ChatMessage.createAssistantMessage({
+    sessionId: "550e8400-e29b-41d4-a716-446655440000",
+    content: "お手伝いします",
+    messageIndex: 1,
+    llmProvider: "openai",
+    llmModel: "gpt-4o",
+    llmMetadata: {
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      },
+      responseTime: 500,
+    },
+  });
+  if (!result.ok) throw new Error("Failed to create test message");
+  return result.value;
+}

--- a/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/__tests__/ChatSessionMapper.test.ts
+++ b/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/__tests__/ChatSessionMapper.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  ChatSessionMapper,
+  type ChatSessionRecord,
+} from "../ChatSessionMapper.js";
+import { ChatSession } from "../../../../domain/entities/ChatSession.js";
+
+describe("ChatSessionMapper", () => {
+  describe("toDomain", () => {
+    it("DBレコードからドメインエンティティに変換できる", () => {
+      // Arrange
+      const dbRecord: ChatSessionRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        userId: "user-123",
+        title: "テストセッション",
+        lastMessagePreview: "これはプレビュー",
+        messageCount: 5,
+        isFavorite: 0,
+        isPinned: 1,
+        createdAt: "2024-01-18T00:00:00.000Z", // ISO 8601 string
+        updatedAt: "2024-01-18T00:00:00.000Z",
+      };
+
+      // Act
+      const result = ChatSessionMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.id.value).toBe(dbRecord.id);
+        expect(result.value.userId.value).toBe(dbRecord.userId);
+        expect(result.value.title.value).toBe(dbRecord.title);
+        expect(result.value.lastMessagePreview).toBe(
+          dbRecord.lastMessagePreview,
+        );
+        expect(result.value.messageCount).toBe(dbRecord.messageCount);
+        expect(result.value.isFavorite).toBe(false);
+        expect(result.value.isPinned).toBe(true);
+      }
+    });
+
+    it("日付が正しく変換される", () => {
+      // Arrange
+      const isoString = "2024-01-18T00:00:00.000Z";
+      const dbRecord: ChatSessionRecord = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        userId: "user-123",
+        title: "テストセッション",
+        lastMessagePreview: null,
+        messageCount: 0,
+        isFavorite: 0,
+        isPinned: 0,
+        createdAt: isoString,
+        updatedAt: isoString,
+      };
+
+      // Act
+      const result = ChatSessionMapper.toDomain(dbRecord);
+
+      // Assert
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.createdAt.toISOString()).toBe(isoString);
+        expect(result.value.updatedAt.toISOString()).toBe(isoString);
+      }
+    });
+  });
+
+  describe("toPersistence", () => {
+    it("ドメインエンティティからDBレコードに変換できる", () => {
+      // Arrange
+      const session = createTestSession();
+
+      // Act
+      const record = ChatSessionMapper.toPersistence(session);
+
+      // Assert
+      expect(record.id).toBe(session.id.value);
+      expect(record.userId).toBe(session.userId.value);
+      expect(record.title).toBe(session.title.value);
+      expect(record.messageCount).toBe(session.messageCount);
+      expect(typeof record.createdAt).toBe("string");
+      expect(typeof record.updatedAt).toBe("string");
+    });
+
+    it("boolean値がintegerに変換される", () => {
+      // Arrange
+      const session = createTestSession();
+      session.toggleFavorite(); // isFavorite = true
+      session.togglePinned(); // isPinned = true
+
+      // Act
+      const record = ChatSessionMapper.toPersistence(session);
+
+      // Assert
+      expect(record.isFavorite).toBe(1);
+      expect(record.isPinned).toBe(1);
+    });
+
+    it("boolean false が 0 に変換される", () => {
+      // Arrange
+      const session = createTestSession();
+
+      // Act
+      const record = ChatSessionMapper.toPersistence(session);
+
+      // Assert
+      expect(record.isFavorite).toBe(0);
+      expect(record.isPinned).toBe(0);
+    });
+
+    it("日付がISO文字列に変換される", () => {
+      // Arrange
+      const session = createTestSession();
+
+      // Act
+      const record = ChatSessionMapper.toPersistence(session);
+
+      // Assert
+      expect(record.createdAt).toBe(session.createdAt.toISOString());
+      expect(record.updatedAt).toBe(session.updatedAt.toISOString());
+    });
+  });
+
+  describe("toDTO", () => {
+    it("ドメインエンティティからDTOに変換できる", () => {
+      // Arrange
+      const session = createTestSession();
+
+      // Act
+      const dto = ChatSessionMapper.toDTO(session);
+
+      // Assert
+      expect(dto.id).toBe(session.id.value);
+      expect(dto.userId).toBe(session.userId.value);
+      expect(dto.title).toBe(session.title.value);
+      expect(dto.messageCount).toBe(session.messageCount);
+      expect(dto.isFavorite).toBe(session.isFavorite);
+      expect(dto.isPinned).toBe(session.isPinned);
+      expect(typeof dto.createdAt).toBe("string"); // ISO文字列
+      expect(typeof dto.updatedAt).toBe("string");
+    });
+
+    it("日付がISO文字列に変換される", () => {
+      // Arrange
+      const session = createTestSession();
+
+      // Act
+      const dto = ChatSessionMapper.toDTO(session);
+
+      // Assert
+      expect(dto.createdAt).toBe(session.createdAt.toISOString());
+      expect(dto.updatedAt).toBe(session.updatedAt.toISOString());
+    });
+  });
+});
+
+function createTestSession(): ChatSession {
+  const result = ChatSession.create({
+    userId: "user-123",
+    title: "テストセッション",
+  });
+  if (!result.ok) throw new Error("Failed to create test session");
+  return result.value;
+}

--- a/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/index.ts
+++ b/packages/shared/src/features/chat-history/infrastructure/persistence/mappers/index.ts
@@ -1,0 +1,11 @@
+/**
+ * マッパーのエクスポート
+ *
+ * @module features/chat-history/infrastructure/persistence/mappers
+ */
+
+export { ChatSessionMapper } from "./ChatSessionMapper.js";
+export type { ChatSessionRecord } from "./ChatSessionMapper.js";
+
+export { ChatMessageMapper } from "./ChatMessageMapper.js";
+export type { ChatMessageRecord } from "./ChatMessageMapper.js";


### PR DESCRIPTION
## 概要

チャット履歴機能をクリーンアーキテクチャパターンに基づいて再設計しました。

## 変更内容

### ドメイン層
- エンティティの実装（`ChatSession`, `ChatMessage`）
- 値オブジェクトの実装（`ChatSessionId`, `MessageContent`, `ChatSessionTitle`等）
- リポジトリインターフェースの定義（`IChatSessionRepository`, `IChatMessageRepository`）
- ドメイン固有エラーの実装

### アプリケーション層
- ユースケースの実装（`CreateChatSessionUseCase`, `AddUserMessageUseCase`等）
- DTOとマッパーの実装
- アプリケーション層エラーの実装

### インフラストラクチャ層
- Drizzle ORMを使用した永続化実装
- エンティティ↔DBモデルのマッパー実装

### アーキテクチャテスト
- 依存関係ルールのテスト
- レイヤー境界のテスト

### コア機能
- `Result`型の実装（Railway Oriented Programming）
- 共通エラー基底クラスの実装

## 変更タイプ

- [x] 🔨 リファクタリング (refactoring)
- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 📝 ドキュメント (documentation)
- [ ] 🧪 テスト (test)
- [ ] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test`)
- [x] 型チェック実行 (`pnpm typecheck`)
- [x] ESLint チェック実行 (`pnpm eslint`)
- [x] ビルド確認 (`pnpm build`)

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [x] 新規・変更機能にテストを追加した

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)