### PR TITLE
feat(github-issue-manager): 未同期タスク仕様書のIssue一括作成機能を追加

### DIFF
--- a/.claude/skills/github-issue-manager/SKILL.md
+++ b/.claude/skills/github-issue-manager/SKILL.md
@@ -35,16 +35,17 @@ GitHub Issueを`gh` CLIで操作し、タスク仕様書との双方向連携を
 
 ## モード一覧
 
-| モード     | 用途                       | スクリプト             |
-| ---------- | -------------------------- | ---------------------- |
-| **sync**   | GitHub↔ローカル同期        | `sync_issues.js`       |
-| **create** | 仕様書→Issue作成           | `create_issue.js`      |
-| **select** | 最適Issue選択              | `select_issue.js`      |
-| **list**   | Issue一覧（フィルタ対応）  | `list_issues.js`       |
-| **update** | Issue更新                  | `update_issue.js`      |
-| **close**  | Issueクローズ              | `close_issue.js`       |
-| **relink** | Issue↔仕様書再リンク       | `relink_issues.js`     |
-| **label**  | 全Issueにラベル一括付与    | `label_all_issues.js`  |
+| モード       | 用途                       | スクリプト            |
+| ------------ | -------------------------- | --------------------- |
+| **sync**     | GitHub↔ローカル同期        | `sync_issues.js`      |
+| **sync-new** | 未同期仕様書→Issue一括作成 | `sync_new_issues.js`  |
+| **create**   | 仕様書→Issue作成           | `create_issue.js`     |
+| **select**   | 最適Issue選択              | `select_issue.js`     |
+| **list**     | Issue一覧（フィルタ対応）  | `list_issues.js`      |
+| **update**   | Issue更新                  | `update_issue.js`     |
+| **close**    | Issueクローズ              | `close_issue.js`      |
+| **relink**   | Issue↔仕様書再リンク       | `relink_issues.js`    |
+| **label**    | 全Issueにラベル一括付与    | `label_all_issues.js` |
 
 ---
 
@@ -131,6 +132,23 @@ node .claude/skills/github-issue-manager/scripts/sync_issues.js           # GitH
 node .claude/skills/github-issue-manager/scripts/sync_issues.js --all     # 閉じたIssue含む
 node .claude/skills/github-issue-manager/scripts/sync_issues.js --push    # ローカル→GitHub
 ```
+
+## sync-new: 未同期仕様書→Issue一括作成
+
+`issue_number`を持たないタスク仕様書を検出し、GitHub Issueを一括作成。
+**PR作成前**や**git merge/stash後**に実行推奨（Claude Code Hookが発火しないケース対応）。
+
+```bash
+node .claude/skills/github-issue-manager/scripts/sync_new_issues.js           # 新規Issue作成
+node .claude/skills/github-issue-manager/scripts/sync_new_issues.js --dry-run # 変更内容を確認のみ
+node .claude/skills/github-issue-manager/scripts/sync_new_issues.js --check   # CI用：未同期があれば終了コード1
+```
+
+**ユースケース**:
+
+- `git merge main` 後に新規仕様書が含まれていた場合
+- `git stash pop` で仕様書ファイルが復元された場合
+- PR作成前のIssue同期確認
 
 ## create: Issue作成
 
@@ -232,20 +250,21 @@ node .claude/skills/github-issue-manager/scripts/label_all_issues.js --force   #
 
 ## scripts/
 
-| Script                 | 用途                         |
-| ---------------------- | ---------------------------- |
-| `sync_issues.js`       | GitHub↔ローカル同期          |
-| `create_issue.js`      | 仕様書→Issue作成             |
-| `select_issue.js`      | 最適Issue選択+スコアリング   |
-| `list_issues.js`       | Issue一覧（ローカル優先）    |
-| `update_issue.js`      | Issue更新（ローカル+GitHub） |
-| `close_issue.js`       | Issueクローズ                |
-| `relink_issues.js`     | Issue↔仕様書再リンク         |
-| `cleanup_orphaned.js`  | 孤立Issue検出・クローズ      |
-| `label_all_issues.js`  | 全Issueラベル一括付与        |
-| `init_labels.js`       | ラベル初期化                 |
-| `utils.js`             | 共通ユーティリティ           |
-| `log_usage.js`         | 使用ログ記録                 |
+| Script                | 用途                         |
+| --------------------- | ---------------------------- |
+| `sync_issues.js`      | GitHub↔ローカル同期          |
+| `sync_new_issues.js`  | 未同期仕様書→Issue一括作成   |
+| `create_issue.js`     | 仕様書→Issue作成             |
+| `select_issue.js`     | 最適Issue選択+スコアリング   |
+| `list_issues.js`      | Issue一覧（ローカル優先）    |
+| `update_issue.js`     | Issue更新（ローカル+GitHub） |
+| `close_issue.js`      | Issueクローズ                |
+| `relink_issues.js`    | Issue↔仕様書再リンク         |
+| `cleanup_orphaned.js` | 孤立Issue検出・クローズ      |
+| `label_all_issues.js` | 全Issueラベル一括付与        |
+| `init_labels.js`      | ラベル初期化                 |
+| `utils.js`            | 共通ユーティリティ           |
+| `log_usage.js`        | 使用ログ記録                 |
 
 ## agents/
 
@@ -288,12 +307,13 @@ dependencies: []
 
 ## 変更履歴
 
-| Version   | Date           | Changes                                                   |
-| --------- | -------------- | --------------------------------------------------------- |
-| **1.6.0** | **2026-01-21** | **全Issueラベル一括付与機能追加（label_all_issues.js）**  |
-| 1.5.0     | 2026-01-21     | 削除時自動クローズ、孤立Issue検出、再リンク機能追加       |
-| 1.4.0     | 2026-01-21     | 双方向同期（仕様書↔Issue）、issue_number書戻              |
-| 1.3.0     | 2026-01-21     | YAML形式メタ情報、自動Issue作成Hook追加                   |
-| 1.2.0     | 2026-01-21     | SKILL.md最適化（394→200行、49%削減）                      |
-| 1.1.0     | 2026-01-21     | ローカル同期機能追加                                      |
-| 1.0.0     | 2026-01-21     | 初版作成                                                  |
+| Version   | Date           | Changes                                                     |
+| --------- | -------------- | ----------------------------------------------------------- |
+| **1.7.0** | **2026-01-21** | **未同期仕様書一括Issue作成機能追加（sync_new_issues.js）** |
+| 1.6.0     | 2026-01-21     | 全Issueラベル一括付与機能追加（label_all_issues.js）        |
+| 1.5.0     | 2026-01-21     | 削除時自動クローズ、孤立Issue検出、再リンク機能追加         |
+| 1.4.0     | 2026-01-21     | 双方向同期（仕様書↔Issue）、issue_number書戻                |
+| 1.3.0     | 2026-01-21     | YAML形式メタ情報、自動Issue作成Hook追加                     |
+| 1.2.0     | 2026-01-21     | SKILL.md最適化（394→200行、49%削減）                        |
+| 1.1.0     | 2026-01-21     | ローカル同期機能追加                                        |
+| 1.0.0     | 2026-01-21     | 初版作成                                                    |

--- a/.claude/skills/github-issue-manager/scripts/sync_new_issues.js
+++ b/.claude/skills/github-issue-manager/scripts/sync_new_issues.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * GitHub Issue Manager - 新規Issue同期スクリプト
+ *
+ * issue_numberを持たないタスク仕様書を検出し、GitHub Issueを作成する。
+ * diff-to-prワークフローやPR作成前に実行することを想定。
+ *
+ * Usage:
+ *   node sync_new_issues.js           # issue_numberなしの仕様書にIssue作成
+ *   node sync_new_issues.js --dry-run # 変更内容を確認のみ
+ *   node sync_new_issues.js --check   # 未同期ファイルがあれば終了コード1を返す
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const SPEC_DIR = "docs/30-workflows/unassigned-task";
+const CREATE_SCRIPT = path.join(__dirname, "create_issue.js");
+
+// 色付きログ出力
+const colors = {
+  reset: "\x1b[0m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+};
+
+const log = {
+  success: (msg) => console.log(`${colors.green}✓${colors.reset} ${msg}`),
+  warn: (msg) => console.log(`${colors.yellow}⚠${colors.reset} ${msg}`),
+  error: (msg) => console.error(`${colors.red}✗${colors.reset} ${msg}`),
+  info: (msg) => console.log(`${colors.cyan}ℹ${colors.reset} ${msg}`),
+};
+
+/**
+ * コマンドライン引数をパース
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    dryRun: args.includes("--dry-run"),
+    check: args.includes("--check"),
+    help: args.includes("--help") || args.includes("-h"),
+  };
+}
+
+/**
+ * ヘルプメッセージを表示
+ */
+function showHelp() {
+  console.log(`
+GitHub Issue Manager - 新規Issue同期スクリプト
+
+Usage:
+  node sync_new_issues.js [options]
+
+Options:
+  --dry-run   変更内容を確認のみ（実際にIssueは作成しない）
+  --check     未同期ファイルがあれば終了コード1を返す
+  --help, -h  このヘルプを表示
+
+Examples:
+  node sync_new_issues.js           # 新規Issue作成
+  node sync_new_issues.js --dry-run # 確認のみ
+  node sync_new_issues.js --check   # CI/CD用チェック
+`);
+}
+
+/**
+ * タスク仕様書からissue_numberを抽出
+ * @param {string} content - ファイル内容
+ * @returns {number|null} Issue番号またはnull
+ */
+function extractIssueNumber(content) {
+  // YAML形式でのissue_number
+  const yamlMatch = content.match(/^issue_number:\s*(\d+)/m);
+  if (yamlMatch) {
+    return parseInt(yamlMatch[1], 10);
+  }
+
+  // Markdownテーブル形式でのIssue番号
+  const tableMatch = content.match(/\|\s*Issue\s*\|\s*#?(\d+)\s*\|/i);
+  if (tableMatch) {
+    return parseInt(tableMatch[1], 10);
+  }
+
+  return null;
+}
+
+/**
+ * issue_numberを持たない仕様書を検出
+ * @returns {string[]} ファイルパスの配列
+ */
+function findSpecsWithoutIssue() {
+  const specDir = path.resolve(SPEC_DIR);
+
+  if (!fs.existsSync(specDir)) {
+    log.warn(`ディレクトリが見つかりません: ${SPEC_DIR}`);
+    return [];
+  }
+
+  const files = fs
+    .readdirSync(specDir)
+    .filter((f) => f.endsWith(".md") && f.startsWith("task-"))
+    .map((f) => path.join(specDir, f));
+
+  const specsWithoutIssue = [];
+
+  for (const filePath of files) {
+    try {
+      const content = fs.readFileSync(filePath, "utf-8");
+      const issueNumber = extractIssueNumber(content);
+
+      if (!issueNumber) {
+        specsWithoutIssue.push(filePath);
+      }
+    } catch (err) {
+      log.warn(`ファイル読み込みエラー: ${filePath}`);
+    }
+  }
+
+  return specsWithoutIssue;
+}
+
+/**
+ * 仕様書に対してIssueを作成
+ * @param {string} specPath - 仕様書パス
+ * @param {boolean} dryRun - ドライラン
+ * @returns {boolean} 成功時true
+ */
+function createIssueForSpec(specPath, dryRun) {
+  const relativePath = path.relative(process.cwd(), specPath);
+
+  if (dryRun) {
+    log.info(`[DRY-RUN] Issue作成予定: ${relativePath}`);
+    return true;
+  }
+
+  try {
+    const result = execSync(
+      `node "${CREATE_SCRIPT}" --spec "${relativePath}"`,
+      {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    console.log(result);
+    return true;
+  } catch (err) {
+    log.error(`Issue作成失敗: ${relativePath}`);
+    if (err.stderr) {
+      console.error(err.stderr);
+    }
+    return false;
+  }
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  const options = parseArgs();
+
+  if (options.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  log.info("未同期のタスク仕様書を検出中...");
+
+  const specsWithoutIssue = findSpecsWithoutIssue();
+
+  if (specsWithoutIssue.length === 0) {
+    log.success("全てのタスク仕様書がIssueに同期されています");
+    process.exit(0);
+  }
+
+  log.info(`${specsWithoutIssue.length}件の未同期仕様書を検出`);
+
+  // チェックモードの場合は未同期ファイルがあれば終了コード1
+  if (options.check) {
+    console.log("\n未同期の仕様書:");
+    for (const spec of specsWithoutIssue) {
+      console.log(`  - ${path.relative(process.cwd(), spec)}`);
+    }
+    log.warn(
+      "未同期の仕様書があります。'node sync_new_issues.js' を実行してください。",
+    );
+    process.exit(1);
+  }
+
+  // Issue作成処理
+  let created = 0;
+  let failed = 0;
+
+  for (const specPath of specsWithoutIssue) {
+    if (createIssueForSpec(specPath, options.dryRun)) {
+      created++;
+    } else {
+      failed++;
+    }
+  }
+
+  // 結果サマリー
+  console.log("");
+  if (options.dryRun) {
+    log.info(`[DRY-RUN] 結果: 作成予定=${created}, 失敗=${failed}`);
+  } else {
+    log.success(`結果: 新規作成=${created}, 失敗=${failed}`);
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  log.error(`エラー: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

`issue_number`を持たないタスク仕様書を検出し、GitHub Issueを一括作成する`sync-new`モードを追加。
PR作成前や`git merge`/`git stash pop`後にClaude Code Hookが発火しないケースに対応。

## 変更内容

- `sync_new_issues.js`: 未同期仕様書検出・Issue一括作成スクリプト
- `SKILL.md`: sync-newモードのドキュメント追加

## 変更タイプ

- [ ] バグ修正 (bug fix)
- [x] 新機能 (new feature)
- [ ] リファクタリング (refactoring)
- [ ] ドキュメント (documentation)
- [ ] テスト (test)
- [ ] 設定変更 (configuration)
- [ ] CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test`)
- [x] 型チェック実行 (`pnpm typecheck`)
- [x] ESLintチェック実行 (`pnpm lint`)

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [ ] 新規・変更機能にテストを追加した

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)