### PR TITLE
fix(desktop): add isDestroyed mock to streaming tests

### DIFF
--- a/apps/desktop/src/main/handlers/__tests__/llm.test.ts
+++ b/apps/desktop/src/main/handlers/__tests__/llm.test.ts
@@ -348,7 +348,9 @@ describe("LLM IPC Handlers", () => {
       ).mockResolvedValue(mockAdapter);
 
       // When: Stream chat
-      const mockEvent = { sender: { send: vi.fn() } };
+      const mockEvent = {
+        sender: { send: vi.fn(), isDestroyed: vi.fn().mockReturnValue(false) },
+      };
       await handleStreamChat(mockEvent as never, validRequest);
 
       // Then: Chunks emitted
@@ -373,7 +375,9 @@ describe("LLM IPC Handlers", () => {
       ).mockResolvedValue(mockAdapter);
 
       // When: Stream chat
-      const mockEvent = { sender: { send: vi.fn() } };
+      const mockEvent = {
+        sender: { send: vi.fn(), isDestroyed: vi.fn().mockReturnValue(false) },
+      };
       await handleStreamChat(mockEvent as never, validRequest);
 
       // Then: End event emitted
@@ -396,7 +400,9 @@ describe("LLM IPC Handlers", () => {
       ).mockResolvedValue(mockAdapter);
 
       // When: Stream chat
-      const mockEvent = { sender: { send: vi.fn() } };
+      const mockEvent = {
+        sender: { send: vi.fn(), isDestroyed: vi.fn().mockReturnValue(false) },
+      };
       await handleStreamChat(mockEvent as never, validRequest);
 
       // Then: Error event emitted

--- a/apps/desktop/src/main/handlers/llm.ts
+++ b/apps/desktop/src/main/handlers/llm.ts
@@ -268,7 +268,11 @@ export async function handleStreamChat(
   // Helper to safely send events (check isDestroyed)
   const safeSend = (channel: string, data?: unknown) => {
     if (!event.sender.isDestroyed()) {
-      event.sender.send(channel, data);
+      if (data !== undefined) {
+        event.sender.send(channel, data);
+      } else {
+        event.sender.send(channel);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- テストのモックに`isDestroyed`メソッドを追加
- `safeSend`関数でデータがundefinedの場合、引数を1つだけ渡すように修正

## 背景
`handleStreamChat`関数の`safeSend`ヘルパーが`event.sender.isDestroyed()`を呼び出しますが、テストのモックにはこのメソッドが定義されていませんでした。

## 変更内容
1. **llm.test.ts**: 3つのストリーミングテストの`mockEvent`に`isDestroyed: vi.fn().mockReturnValue(false)`を追加
2. **llm.ts**: `safeSend`関数を修正し、`data`が`undefined`の場合は`send(channel)`のみを呼び出すように変更

## Test plan
- [x] IPC-004ストリーミングテスト3件が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)