### PR TITLE
fix(ipc): agent:abort をsafeInvoke/handleに統一 (UT-FIX-5-3)

### DIFF
--- a/apps/desktop/src/main/agent/__tests__/agent-handler.test.ts
+++ b/apps/desktop/src/main/agent/__tests__/agent-handler.test.ts
@@ -125,7 +125,7 @@ describe("AgentHandler", () => {
         "agent:destroySession",
         expect.any(Function),
       );
-      expect(ipcMain.on).toHaveBeenCalledWith(
+      expect(ipcMain.handle).toHaveBeenCalledWith(
         "agent:abort",
         expect.any(Function),
       );
@@ -143,6 +143,7 @@ describe("AgentHandler", () => {
       expect(ipcMain.removeHandler).toHaveBeenCalledWith(
         "agent:destroySession",
       );
+      expect(ipcMain.removeHandler).toHaveBeenCalledWith("agent:abort");
     });
   });
 

--- a/apps/desktop/src/main/agent/agent-handler.ts
+++ b/apps/desktop/src/main/agent/agent-handler.ts
@@ -60,6 +60,7 @@ export class AgentHandler {
     ipcMain.removeHandler("agent:createSession");
     ipcMain.removeHandler("agent:resumeSession");
     ipcMain.removeHandler("agent:destroySession");
+    ipcMain.removeHandler("agent:abort");
   }
 
   /**
@@ -173,7 +174,7 @@ export class AgentHandler {
       return this.handleDestroySession(request);
     });
 
-    ipcMain.on("agent:abort", () => {
+    ipcMain.handle("agent:abort", () => {
       this.handleAbort();
     });
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -420,9 +420,7 @@ const agentSDKAPI: AgentSDKAPI = {
       ...request,
       options: { ...request.options, timeout: agentSDKOptions.timeout },
     }),
-  abort: () => {
-    ipcRenderer.send("agent:abort");
-  },
+  abort: () => safeInvoke(IPC_CHANNELS.AGENT_ABORT),
   onMessage: (callback: (message: AgentSDKMessage) => void) =>
     safeOn<AgentSDKMessage>(IPC_CHANNELS.AGENT_MESSAGE, callback),
   setOption: (options: { timeout?: number }) => {


### PR DESCRIPTION
## Summary
- Preload側の`agent:abort`を`ipcRenderer.send()`から`safeInvoke()`へ変更
- Main側のIPCハンドラーを`ipcMain.on()`から`ipcMain.handle()`へ変更
- `dispose()`メソッドに`removeHandler("agent:abort")`を追加

## Technical Details
### 変更前の問題点
- `ipcRenderer.send()`を直接使用していたため、ホワイトリスト検証をバイパス
- 一方向通信（`ipcMain.on`）のため、エラーハンドリングが不可能
- `dispose()`時のリソースリークリスク

### 変更後の改善
- `safeInvoke()`によるホワイトリスト検証（セキュリティ強化）
- 双方向通信（`ipcMain.handle`）によるエラーハンドリング可能化
- `dispose()`での適切なクリーンアップ

### 影響範囲
- apps/desktop/src/preload/index.ts (1行変更)
- apps/desktop/src/main/agent/agent-handler.ts (2行変更)
- apps/desktop/src/main/agent/__tests__/agent-handler.test.ts (2行変更)

## Test Plan
- [x] typecheck: ✅
- [x] lint: ✅ (4 warnings, 0 errors)
- [x] agent-handler.test.ts: ✅ (18 tests passed)
- [x] pre-push全テスト: ✅

## Related Issues
- Related: #765 (UT-FIX-5-4: AgentSDKAPI型定義不一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)