### PR TITLE
docs: ランタイムバグタスク仕様書作成（IPC 関連2件）

### DIFF
--- a/.claude/skills/aiworkflow-requirements/references/task-workflow.md
+++ b/.claude/skills/aiworkflow-requirements/references/task-workflow.md
@@ -619,6 +619,8 @@
 | task-ref-vitest-module-mock-audit-001        | Vitest モジュールレベルモック監査・使い分けガイドライン策定         | 低 | TASK-FIX-11-1-SDK-TEST-ENABLEMENT Phase 5（実装苦戦箇所）     | `docs/30-workflows/unassigned-task/task-ref-vitest-module-mock-audit-001.md`                 |
 | UT-PERF-001                                   | グラフユーティリティ性能ベンチマーク基準再設計                     | 中 | TODO検出: `packages/shared/src/types/rag/graph/__tests__/utils.test.ts:791` | `docs/30-workflows/unassigned-task/task-ut-perf-001-graph-utils-performance-benchmark.md` |
 | UT-TYPE-DATETIME-DOC-001                       | 型日時表現のガイドライン策定とドキュメント化                       | 低 | TASK-FIX-13-1-DEPRECATED-PROPERTY-MIGRATION Phase 12                       | `docs/30-workflows/unassigned-task/task-ut-type-datetime-doc-001-datetime-representation-guide.md` |
+| UT-FIX-IPC-RESPONSE-UNWRAP-001                 | IPC レスポンスラッパー未展開修正（importedSkills.forEach クラッシュ）| 高 | ランタイムエラー調査（2026-02-13）                                         | `docs/30-workflows/unassigned-task/task-ut-fix-ipc-response-unwrap-001.md`                   |
+| UT-FIX-IPC-HANDLER-DOUBLE-REG-001              | IPC ハンドラ二重登録防止修正（activate イベント）                   | 高 | ランタイムエラー調査（2026-02-13）                                         | `docs/30-workflows/unassigned-task/task-ut-fix-ipc-handler-double-reg-001.md`                |
 
 ### 未タスク管理ルール
 

--- a/docs/30-workflows/unassigned-task/task-ut-fix-ipc-handler-double-reg-001.md
+++ b/docs/30-workflows/unassigned-task/task-ut-fix-ipc-handler-double-reg-001.md
@@ -1,0 +1,206 @@
+# UT-FIX-IPC-HANDLER-DOUBLE-REG-001: IPC ハンドラ二重登録防止修正
+
+## メタ情報
+
+| 項目         | 値                                 |
+| ------------ | ---------------------------------- |
+| タスクID     | UT-FIX-IPC-HANDLER-DOUBLE-REG-001  |
+| GitHub Issue | #814                               |
+| 種別         | バグ修正 (fix)                     |
+| 優先度       | 高                                 |
+| 見積もり     | Phase 1-13 完全実行                |
+| 前提タスク   | なし                               |
+| 検出元       | ランタイムエラー調査（2026-02-13） |
+| 関連Pitfall  | P5（リスナー二重登録）             |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+`app.on("activate")` イベント（macOS でドックアイコンクリック時）で `registerAllIpcHandlers()` が再実行され、`ipcMain.handle()` が同一チャンネルに2回目のハンドラ登録を試みて例外が発生する。
+
+**エラーメッセージ**:
+
+```
+Uncaught Exception: Error: Attempted to register a second handler for 'file:get-tree'
+  at IpcMainImpl.handle
+  at registerFileHandlers
+  at registerAllIpcHandlers
+```
+
+**根本原因**: `apps/desktop/src/main/index.ts` の `app.on("activate")` コールバックが `registerAllIpcHandlers(mainWindowRef)` を呼び出すが、`ipcMain.handle()` は同一チャンネルへの重複登録を許可しない。既存ハンドラの `removeHandler()` が呼ばれないまま再登録が試行される。
+
+**影響範囲**:
+
+- macOS でのアプリ再アクティブ化時にクラッシュ
+- 全 IPC チャンネル（file, store, dashboard, graph, ai, theme, skill）が影響対象
+
+---
+
+## 2. 何を達成するか（What）
+
+### 受入基準
+
+1. `app.on("activate")` でウィンドウ再作成時に IPC ハンドラが正常に登録される
+2. 既存ハンドラが登録済みの場合、二重登録例外が発生しない
+3. macOS ドックアイコンクリックでアプリが正常に復帰する
+4. ウィンドウが存在する場合は不要な再登録が発生しない
+
+### スコープ外
+
+- IPC ハンドラのロジック変更
+- 新規 IPC チャンネルの追加
+
+---
+
+## 3. どう実現するか（How）
+
+### 修正対象ファイル
+
+| ファイル                             | 修正内容                                                      |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `apps/desktop/src/main/index.ts`     | `activate` イベントでの IPC ハンドラ再登録ロジック修正        |
+| `apps/desktop/src/main/ipc/index.ts` | `unregisterAllIpcHandlers()` 関数の追加（または再登録ガード） |
+
+### 実装アプローチ
+
+#### A案: 既存ハンドラを削除してから再登録（推奨）
+
+```typescript
+// ipc/index.ts
+export function unregisterAllIpcHandlers(): void {
+  // 全チャンネルの既存ハンドラを削除
+  Object.values(IPC_CHANNELS).forEach((channel) => {
+    try {
+      ipcMain.removeHandler(channel);
+    } catch {
+      // ハンドラが未登録の場合は無視
+    }
+  });
+}
+
+// main/index.ts
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    mainWindowRef = createWindow();
+    unregisterAllIpcHandlers();
+    registerAllIpcHandlers(mainWindowRef);
+  }
+});
+```
+
+#### B案: 登録済みフラグでガード
+
+```typescript
+// main/index.ts
+let ipcHandlersRegistered = false;
+
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    mainWindowRef = createWindow();
+    if (!ipcHandlersRegistered) {
+      registerAllIpcHandlers(mainWindowRef);
+      ipcHandlersRegistered = true;
+    }
+  }
+});
+```
+
+#### C案: activate では IPC 再登録しない
+
+```typescript
+// main/index.ts
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    mainWindowRef = createWindow();
+    // IPC ハンドラは app.whenReady() で一度だけ登録済み
+    // ipcMain.handle() はグローバルなので再登録不要
+  }
+});
+```
+
+### 設計判断のポイント
+
+- `ipcMain.handle()` はウィンドウではなくプロセスレベルで登録される
+- ウィンドウを閉じてもハンドラは残る → C案が最もシンプル
+- ただしハンドラ内で `mainWindow` 参照を更新する必要がある場合はA案
+- `mainWindowRef` をクロージャで参照している場合、新ウィンドウへの参照更新が必要
+
+---
+
+## 4. 実行手順
+
+### Phase 4: テスト作成
+
+- `registerAllIpcHandlers` の二重呼び出しテスト
+- `app.on("activate")` シミュレーションテスト
+- ハンドラ登録状態の検証テスト
+
+### Phase 5: 実装
+
+1. `mainWindowRef` の参照方式を確認（クロージャ vs グローバル変数）
+2. 選択したアプローチに基づいて修正
+3. activate イベントでのウィンドウ参照更新ロジックを確認
+
+### Phase 6-9: テスト拡充・品質検証
+
+- 既存 IPC テストの動作確認
+- `pnpm typecheck && pnpm lint && pnpm test` 全パス
+
+---
+
+## 5. 完了条件
+
+- [ ] `app.on("activate")` で IPC ハンドラ二重登録例外が発生しない
+- [ ] macOS ドックアイコンクリックでアプリが正常に復帰する
+- [ ] 全 IPC チャンネルが正常に応答する
+- [ ] `pnpm typecheck` PASS
+- [ ] `pnpm lint` PASS
+- [ ] `pnpm test` PASS（関連テスト全パス）
+
+---
+
+## 6. 検証方法
+
+### 自動テスト
+
+```bash
+cd apps/desktop && pnpm vitest run src/main/__tests__/
+cd apps/desktop && pnpm vitest run src/main/ipc/__tests__/
+```
+
+### 手動テスト（macOS）
+
+1. アプリを起動する
+2. ⌘+Q でアプリを終了しない状態でウィンドウを閉じる（⌘+W）
+3. ドックアイコンをクリックしてアプリを再アクティブ化する
+4. エラーなくウィンドウが復帰する
+5. Agent ビューでスキル一覧が正常に表示される
+6. DevTools コンソールに `Attempted to register a second handler` エラーが出ない
+
+---
+
+## 7. リスク・注意事項
+
+- **P5パターン**: リスナー二重登録の既知パターンと同種の問題
+- **mainWindow 参照**: ハンドラ内で `mainWindow` を参照している場合、新ウィンドウ作成後に参照を更新する必要がある
+- **テスト環境**: Electron の `app` イベントはユニットテストで再現が難しいため、手動テストの重要性が高い
+
+---
+
+## 8. 参照情報
+
+| 種別             | パス                                                        |
+| ---------------- | ----------------------------------------------------------- |
+| エラー発生箇所   | `apps/desktop/src/main/index.ts:277`                        |
+| IPC 登録関数     | `apps/desktop/src/main/ipc/index.ts:63-70`                  |
+| ファイルハンドラ | `apps/desktop/src/main/ipc/fileHandlers.ts`                 |
+| 関連Pitfall      | `.claude/rules/06-known-pitfalls.md` P5（リスナー二重登録） |
+
+---
+
+## 9. 備考
+
+- Electron の `ipcMain.handle()` はプロセスレベルでハンドラを登録するため、ウィンドウのライフサイクルとは独立
+- `ipcMain.on()` は重複登録可能だが、`ipcMain.handle()` は不可。この非対称性がバグの原因
+- C案（再登録しない）が最もシンプルだが、ハンドラ内で `mainWindow` 参照を使用している場合は参照更新メカニズムが別途必要

--- a/docs/30-workflows/unassigned-task/task-ut-fix-ipc-response-unwrap-001.md
+++ b/docs/30-workflows/unassigned-task/task-ut-fix-ipc-response-unwrap-001.md
@@ -1,0 +1,185 @@
+# UT-FIX-IPC-RESPONSE-UNWRAP-001: IPC レスポンスラッパー未展開修正
+
+## メタ情報
+
+| 項目         | 値                                                                      |
+| ------------ | ----------------------------------------------------------------------- |
+| タスクID     | UT-FIX-IPC-RESPONSE-UNWRAP-001                                          |
+| GitHub Issue | #813                                                                    |
+| 種別         | バグ修正 (fix)                                                          |
+| 優先度       | 高                                                                      |
+| 見積もり     | Phase 1-13 完全実行                                                     |
+| 前提タスク   | なし                                                                    |
+| 検出元       | ランタイムエラー調査（2026-02-13）                                      |
+| 関連Pitfall  | P19（型キャスト）, P23（API二重定義の型管理）, P24（Store型定義不統一） |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+AgentView コンポーネントで `importedSkills.forEach is not a function` ランタイムエラーが発生している。
+
+**根本原因**: Main Process の IPC ハンドラ（`skillHandlers.ts`）が `{ success: true, data: skills }` 形式でレスポンスを返すが、Preload 層の `safeInvoke<T>()` がこのラッパーオブジェクトをそのまま通過させる。型注釈は `Promise<ImportedSkill[]>` と宣言しているが、実行時の値は `{ success: boolean, data: ImportedSkill[] }` である。結果、`agentSlice.ts` の `fetchSkills()` が非配列オブジェクトを `importedSkills` に格納し、`.forEach()` 呼び出しが失敗する。
+
+**影響範囲**:
+
+- `skill.getImported()` → `importedSkills` が配列でない → AgentView クラッシュ
+- `skill.list()` → `availableSkillsMetadata` も同様の問題の可能性
+- `skill.import()`, `skill.rescan()` も同じパターン
+
+---
+
+## 2. 何を達成するか（What）
+
+### 受入基準
+
+1. `window.electronAPI.skill.getImported()` が `ImportedSkill[]` を直接返す（ラッパーなし）
+2. `window.electronAPI.skill.list()` が `SkillMetadata[]` を直接返す
+3. `window.electronAPI.skill.import()` が `ImportedSkill` を直接返す
+4. `window.electronAPI.skill.rescan()` が `SkillMetadata[]` を直接返す
+5. AgentView で `importedSkills.forEach` が正常動作する
+6. 型注釈と実行時の値が一致する
+7. 既存テストが全て PASS する
+
+### スコープ外
+
+- `skill.execute()` や Permission API のレスポンス形式変更
+- `agentSlice.ts` の `as unknown as Skill[]` 型キャスト除去（別タスク UT-FIX-5-1-001 スコープ）
+
+---
+
+## 3. どう実現するか（How）
+
+### 方針: Preload 層でレスポンスを展開する
+
+IPC ハンドラの `{ success, data }` ラッパーは他のハンドラとの一貫性のため維持し、Preload 層の `skill-api.ts` でラッパーを展開して `data` フィールドを返す。
+
+### 修正対象ファイル
+
+| ファイル                                | 修正内容                                                               |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| `apps/desktop/src/preload/skill-api.ts` | `safeInvoke` の戻り値からラッパーを展開する                            |
+| `apps/desktop/src/preload/skill-api.ts` | `list`, `getImported`, `import`, `rescan` の各メソッドでレスポンス展開 |
+
+### 実装アプローチ
+
+#### A案: 個別メソッドで展開（推奨）
+
+```typescript
+// skill-api.ts
+getImported: async (): Promise<ImportedSkill[]> => {
+  const result = await safeInvoke<{ success: boolean; data: ImportedSkill[] }>(
+    IPC_CHANNELS.SKILL_GET_IMPORTED
+  );
+  if (!result.success) {
+    throw new Error(result.error ?? "Failed to get imported skills");
+  }
+  return result.data;
+},
+```
+
+#### B案: 汎用ラッパー展開関数
+
+```typescript
+async function safeInvokeUnwrap<T>(
+  channel: string,
+  ...args: unknown[]
+): Promise<T> {
+  const result = await safeInvoke<{
+    success: boolean;
+    data: T;
+    error?: string;
+  }>(channel, ...args);
+  if (!result.success) {
+    throw new Error(result.error ?? `IPC call failed: ${channel}`);
+  }
+  return result.data;
+}
+```
+
+### 設計判断のポイント
+
+- A案は各メソッドの型が明示的で可読性が高い
+- B案はDRYだが、全てのハンドラが同じレスポンス形式であることを前提とする
+- エラーレスポンス（`{ success: false, error: "..." }`）のハンドリングも必要
+
+---
+
+## 4. 実行手順
+
+### Phase 4: テスト作成
+
+- `skill-api.ts` のレスポンス展開ロジックのユニットテスト
+- `agentSlice.ts` の `fetchSkills()` が配列を受け取ることを検証するテスト
+- エラーレスポンス時の例外スローテスト
+
+### Phase 5: 実装
+
+1. `skill-api.ts` の `list`, `getImported`, `import`, `rescan` メソッドを修正
+2. レスポンスラッパー展開ロジックを追加
+3. エラーレスポンス時に例外をスローする
+
+### Phase 6-9: テスト拡充・品質検証
+
+- 既存 AgentView テストの動作確認
+- `pnpm typecheck && pnpm lint && pnpm test` 全パス
+
+---
+
+## 5. 完了条件
+
+- [ ] `skill-api.ts` の4メソッドがレスポンスラッパーを展開する
+- [ ] 型注釈と実行時の値が一致する
+- [ ] エラーレスポンス時に適切な例外がスローされる
+- [ ] AgentView で `importedSkills.forEach` が正常動作する
+- [ ] `pnpm typecheck` PASS
+- [ ] `pnpm lint` PASS
+- [ ] `pnpm test` PASS（関連テスト全パス）
+
+---
+
+## 6. 検証方法
+
+### 自動テスト
+
+```bash
+cd apps/desktop && pnpm vitest run src/preload/__tests__/skill-api.test.ts
+cd apps/desktop && pnpm vitest run src/renderer/store/slices/__tests__/agentSlice.test.ts
+cd apps/desktop && pnpm vitest run src/renderer/views/AgentView/__tests__/
+```
+
+### 手動テスト
+
+1. アプリ起動後、Agent ビューを開く
+2. スキル一覧が正常に表示される
+3. DevTools コンソールに `forEach is not a function` エラーが出ない
+4. スキルのインポート・削除が正常動作する
+
+---
+
+## 7. リスク・注意事項
+
+- **P19パターン**: 型アサーションで隠れていた型不一致が顕在化する可能性
+- **P23パターン**: `skill-api.ts` と `SkillAPI` インターフェースの型整合性を維持する必要がある
+- **他ハンドラへの影響**: `skill.execute()` 等の他メソッドも同じ問題を持つ可能性がある（スコープ外だが調査推奨）
+
+---
+
+## 8. 参照情報
+
+| 種別           | パス                                                           |
+| -------------- | -------------------------------------------------------------- |
+| クラッシュ箇所 | `apps/desktop/src/renderer/views/AgentView/index.tsx:151`      |
+| Preload API    | `apps/desktop/src/preload/skill-api.ts:192-200`                |
+| IPC ハンドラ   | `apps/desktop/src/main/ipc/skillHandlers.ts:94-115`            |
+| Store Slice    | `apps/desktop/src/renderer/store/slices/agentSlice.ts:556-577` |
+| 関連Pitfall    | `.claude/rules/06-known-pitfalls.md` P19, P23, P24             |
+| 関連タスク     | TASK-FIX-5-1-SKILL-API-UNIFICATION, UT-FIX-5-1-001             |
+
+---
+
+## 9. 備考
+
+- このバグは P19（型キャストによる実行時検証バイパス）の典型例
+- `safeInvoke<T>()` のジェネリック型パラメータ `T` が IPC ハンドラの実際のレスポンス形式と一致しないことが根本原因
+- 修正後は `as unknown as Skill[]` の型キャストも不要になる可能性がある（別タスクで対応）


### PR DESCRIPTION
## 概要

2つのランタイムバグ（IPC レスポンス未展開と IPC ハンドラ二重登録）のタスク仕様書を作成し、GitHub Issue (#813, #814) に登録しました。

## 変更内容

### 新規タスク仕様書
- **UT-FIX-IPC-RESPONSE-UNWRAP-001** (#813): IPC レスポンスラッパー未展開修正
  - `importedSkills.forEach is not a function` ランタイムクラッシュの修正
  - Preload 層で `{ success, data }` ラッパーを展開する設計
  - 関連 Pitfall: P19, P23, P24

- **UT-FIX-IPC-HANDLER-DOUBLE-REG-001** (#814): IPC ハンドラ二重登録防止修正
  - macOS `app.on("activate")` イベントでの二重登録防止
  - 3つのアプローチ候補を提示（削除/フラグ/再登録しない）
  - 関連 Pitfall: P5

### task-workflow.md 更新
- 残課題テーブルに2タスクを追加（優先度：高）

## 変更タイプ

- [x] 📝 ドキュメント (documentation)
- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [ ] 🧪 テスト (test)
- [ ] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test`) - ドキュメント変更のみのため pre-push でスキップ
- [x] 型チェック実行 (`pnpm typecheck`) - PASS
- [x] ESLint チェック実行 (`pnpm lint`) - PASS (既存警告4件のみ)
- [ ] ビルド確認 (`pnpm build`) - ドキュメント変更のみのため省略

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [x] 新規・変更機能にテストを追加した（該当なし - ドキュメント追加のみ）

## 関連 Issue

- Closes #813
- Closes #814

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)