### PR TITLE
ci: Railway未使用のためデプロイジョブを停止

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,6 +101,8 @@ flowchart TB
 | `RAILWAY_WEB_DOMAIN`  | ❌   | Webヘルスチェック URL（web未デプロイ時） |
 | `DISCORD_WEBHOOK_URL` | ❌   | デプロイ成功/失敗の通知                  |
 
+現在、Railway は未使用のため GitHub Actions の Railway deploy ジョブは `if: false` で停止しています。
+
 #### デスクトップリリース用
 
 | Secret名                      | 必須          | 取得方法                 |
@@ -200,6 +202,19 @@ cat .github/workflows/deploy-backend.yml | yq .
 1. Secret名が正確か確認（大文字小文字を区別）
 2. Secretsセクションで設定されているか確認
 3. リポジトリレベルのSecretか確認（Organizationレベルではない）
+
+### 「Usage limit exceeded」エラー（Railway）
+
+`railway up` 実行時に以下が出る場合:
+
+```text
+Usage limit exceeded. Please increase or remove the hard limit to resume resource provisioning
+```
+
+1. Railway Dashboard → **Usage** を開く
+2. 現在設定されている **Hard limit** を引き上げるか、必要に応じて解除する
+3. 必要なら未使用サービスを停止してコストを削減する
+4. 設定反映後に GitHub Actions の失敗ジョブを **Re-run** する
 
 ### デプロイが失敗する
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: ci
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: false # Railway 運用停止中のため deploy を無効化
     environment:
       name: production
     steps:
@@ -102,7 +102,20 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           echo "🚀 Deploying to Railway..."
-          railway up --service backend --detach
+          set +e
+          DEPLOY_OUTPUT="$(railway up --service backend --detach 2>&1)"
+          DEPLOY_EXIT_CODE=$?
+          set -e
+
+          echo "$DEPLOY_OUTPUT"
+
+          if [ $DEPLOY_EXIT_CODE -ne 0 ]; then
+            if echo "$DEPLOY_OUTPUT" | grep -qi "Usage limit exceeded"; then
+              echo "::error title=Railway usage limit exceeded::Railway の Hard limit を超過しています。Railway Dashboard > Usage で Hard limit を引き上げるか解除してください。"
+            fi
+            exit $DEPLOY_EXIT_CODE
+          fi
+
           echo "✅ Deployment triggered successfully"
 
       - name: Wait for deployment

--- a/.github/workflows/web-cd.yml
+++ b/.github/workflows/web-cd.yml
@@ -79,10 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [check, ci]
-    if: |
-      needs.check.outputs.web_exists == 'true' &&
-      github.ref == 'refs/heads/main' &&
-      github.event_name == 'push'
+    if: false # Railway 運用停止中のため deploy を無効化
     environment:
       name: production
     steps:
@@ -97,7 +94,20 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           echo "🚀 Deploying web app to Railway..."
-          railway up --service web --detach
+          set +e
+          DEPLOY_OUTPUT="$(railway up --service web --detach 2>&1)"
+          DEPLOY_EXIT_CODE=$?
+          set -e
+
+          echo "$DEPLOY_OUTPUT"
+
+          if [ $DEPLOY_EXIT_CODE -ne 0 ]; then
+            if echo "$DEPLOY_OUTPUT" | grep -qi "Usage limit exceeded"; then
+              echo "::error title=Railway usage limit exceeded::Railway の Hard limit を超過しています。Railway Dashboard > Usage で Hard limit を引き上げるか解除してください。"
+            fi
+            exit $DEPLOY_EXIT_CODE
+          fi
+
           echo "✅ Deployment triggered successfully"
 
       - name: Wait for deployment


### PR DESCRIPTION
## 概要

Railway を現状利用していないため、GitHub Actions の Railway deploy ジョブを停止しました。
あわせて、将来再有効化した際に `Usage limit exceeded` の原因が即時判別できるよう、デプロイステップのエラーメッセージを改善しています。

## 変更内容

- `backend-ci.yml` の deploy ジョブを `if: false` で停止
- `web-cd.yml` の deploy ジョブを `if: false` で停止
- Railway CLI 実行時に `Usage limit exceeded` を検知した場合、`::error` で復旧手順を明示
- workflows README に Railway deploy 停止中であることと `Usage limit exceeded` 対処を追記

## 変更タイプ

- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [x] 📝 ドキュメント (documentation)
- [ ] 🧪 テスト (test)
- [x] 🔧 設定変更 (configuration)
- [x] 🚀 CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test --testTimeout=900000`) ※ユーザー実行
- [x] 型チェック実行 (`pnpm typecheck`) ※ユーザー実行
- [x] ESLint チェック実行 (`pnpm lint`) ※ユーザー実行
- [x] ビルド確認 (`pnpm --filter @repo/shared build`, `pnpm --filter @repo/desktop build`) ※ユーザー実行

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [ ] 新規・変更機能にテストを追加した

---

🤖 Generated with Codex