### PR TITLE
fix(auth): Worker exited unexpectedly エラーを解消

### DIFF
--- a/apps/desktop/src/main/auth/__tests__/authCallbackServer.test.ts
+++ b/apps/desktop/src/main/auth/__tests__/authCallbackServer.test.ts
@@ -86,6 +86,9 @@ describe("ローカルHTTPサーバー", () => {
 
     // 100msのタイムアウトでコールバック待機
     await expect(server.waitForCallback()).rejects.toThrow(/timeout/i);
+
+    // タイムアウト後にサーバーを確実に停止し、ワーカー終了前にクリーンアップを完了させる
+    await server.stop();
   });
 
   it("SRV-07: codeパラメータ欠如時にエラーレスポンスを返す", async () => {

--- a/apps/desktop/src/main/auth/authCallbackServer.ts
+++ b/apps/desktop/src/main/auth/authCallbackServer.ts
@@ -153,9 +153,6 @@ export function createAuthCallbackServer(
           callbackResolve = null;
           timeoutHandle = null;
           reject(new Error("Callback timeout: no response received"));
-
-          // タイムアウト時にサーバーも停止
-          instance.stop().catch(() => {});
         }, timeoutMs);
       });
     },
@@ -172,12 +169,14 @@ export function createAuthCallbackServer(
         callbackReject = null;
       }
 
-      return new Promise((resolve) => {
-        if (!server) {
+      return new Promise<void>((resolve) => {
+        if (!server || !server.listening) {
+          server = null;
           resolve();
           return;
         }
-        server.close(() => {
+        server.close((_err) => {
+          // close エラーは握りつぶす（既に停止済みの場合等）
           server = null;
           resolve();
         });


### PR DESCRIPTION
## Summary
- authCallbackServer のタイムアウト時に fire-and-forget で呼ばれていた `instance.stop()` がワーカープロセスの終了と競合し、Vitest が `Worker exited unexpectedly` を報告していた問題を修正
- `stop()` メソッドに `server.listening` チェックを追加し、二重close を防止
- SRV-06 テストでタイムアウト後に明示的な `await server.stop()` を追加してクリーンアップを保証

## 変更ファイル
- `apps/desktop/src/main/auth/authCallbackServer.ts` — タイムアウト時の fire-and-forget stop() 削除、stop() の堅牢化
- `apps/desktop/src/main/auth/__tests__/authCallbackServer.test.ts` — SRV-06 テストに明示的 stop() 追加

## Test plan
- [x] authCallbackServer テスト 13件 全PASS
- [x] auth 関連テスト 46件 全PASS
- [x] TypeScript 型チェック エラーなし
- [x] ESLint エラーなし
- [x] pre-push フック全チェック通過（Lint + Shared Build + TypeCheck + Tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)