### PR TITLE
docs(workflow): persist hardening の教訓と未タスクを同期

### DIFF
--- a/.claude/skills/aiworkflow-requirements/references/lessons-learned.md
+++ b/.claude/skills/aiworkflow-requirements/references/lessons-learned.md
@@ -20,6 +20,9 @@
 
 | 日付 | バージョン | 変更内容 |
 |------|-----------|----------|
+| 2026-03-08 | 1.29.48 | TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001 の教訓を追加。既実装防御の発見による Phase 転換（P50）、サブエージェントの documentation-changelog 早期完了記載（P51/P4/P43 複合再発）、non-null assertion 残存（P52/P48 派生）、CLI 環境でのスクリーンショット取得制約（P53）の4課題と再発防止手順を追記 |
+| 2026-03-08 | 1.29.48 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 の苦戦箇所3件（canGoBackセレクタ防御漏れ・getItem/setItem対称性・多層防御設計判断）と実装サマリー・5ステップ解決カードを追補。関連未タスク UT-PERSIST-MIGRATION-001, UT-PERSIST-VALIDATION-002 を明記 |
+| 2026-03-08 | 1.29.47 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 のコード例と関連Pitfall参照を追加。customStorage 3段ガードパターンを標準手順として明文化 |
 | 2026-03-08 | 1.29.46 | TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001 の再監査教訓を追補。Phase 11証跡表ヘッダ不一致による validator 失敗と、screenshot 再取得時の Rollup optional dependency 欠落を苦戦箇所として追加し、preflight + 機械検証の標準手順を固定 |
 | 2026-03-07 | 1.29.45 | TASK-10A-F 再確認の教訓を追加。Phase 11 文書名ドリフト（`manual-testing` vs `manual-test`）、TC証跡の未参照化、Phase 12 changelog の「対象/予定」残置を苦戦箇所として整理し、4ステップの再発防止手順を追記 |
 | 2026-03-07 | 1.29.45 | TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001 の教訓を追加。`apiKey:list` 契約型の文書ドリフト（`ProviderStatus[]` vs `ProviderListResult`）と、画面検証を自動テスト代替で済ませてしまう運用リスクを同時に是正し、スクリーンショット検証を標準化 |
@@ -352,6 +355,117 @@ vi.mock("../../../store", () => ({
 2. **状態分類**: 各useStateをStore移行/ローカル維持に分類し、設計書に記録
 3. **テストmock統一**: State用（値返却）/ Action用（関数返却）の標準パターンで `vi.mock` を作成
 4. **防御コード**: 全Store action呼び出しに try/catch を追加（Store側error処理済みでも必須）
+## TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001: persist iterable hardening（2026-03-07）
+
+### 苦戦箇所: 永続化データを信頼しすぎると hydrate でクラッシュする
+
+| 項目       | 内容                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 課題       | `expandedFolders` が配列でない値（`null` / `number` / `object`）を持つと `new Set(...)` で `object is not iterable` が発生した |
+| 再発条件   | localStorageに壊れた値が残った状態で hydrate する場合                                                                          |
+| 対処       | `Array.isArray` + `typeof === "string"` で入力検証し、非配列は空 `Set` にフォールバック                                        |
+| 標準ルール | persist復元時は「型検証→フィルタ→安全既定値」の3段を必須化する                                                                 |
+
+### 苦戦箇所: UI差分が小さいタスクで screenshot 証跡が抜けやすい
+
+| 項目       | 内容                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------ |
+| 課題       | 初期計画を「非視覚のみ」にすると、再監査で証跡不足と判定されやすい                         |
+| 再発条件   | ユーザーが後から screenshot 検証を要求した場合                                             |
+| 対処       | Phase 11 で light/dark 2ケースを撮影し、`manual-test-result.md` に TC-ID と png を紐付けた |
+| 標準ルール | UI差分が小さくても、ユーザー要求があれば screenshot を優先して残す                         |
+
+### コード例: customStorage の3段ガードパターン
+
+```typescript
+// getItem での iterable guard (DD-01)
+const raw = parsed.state.expandedFolders;
+if (Array.isArray(raw)) {
+  // 型検証: 配列の各要素が string であることを確認
+  parsed.state.expandedFolders = new Set(
+    raw.filter((v: unknown) => typeof v === "string"),
+  );
+} else {
+  // 安全既定値: 非配列は空 Set にフォールバック
+  if (raw !== undefined && raw !== null) {
+    console.warn(
+      "[customStorage] expandedFolders is not an array:",
+      typeof raw,
+    );
+  }
+  parsed.state.expandedFolders = new Set<string>();
+}
+```
+
+**3段ガードの構造:**
+
+1. **型検証** — `Array.isArray(raw)` で配列であることを確認（`as Set<string>` のような型キャストを排除）
+2. **要素フィルタ** — `.filter((v: unknown) => typeof v === "string")` で各要素の型を検証
+3. **安全既定値** — 非配列・`null`・`undefined` はすべて空 `Set<string>()` にフォールバック
+
+### 関連Pitfall
+
+- **[P19](../../rules/06-known-pitfalls.md#P19)**: 型キャスト（`as`）による実行時検証バイパス — 本タスクでは `as Set<string>` を `Array.isArray` + `instanceof Set` による実行時型検証に置換した。永続化データは JSON.parse 後の shape が保証されないため、型キャストではなく実行時検証が必須
+- **[P48 (non-null assertion)](../../rules/06-known-pitfalls.md#P48)**: `result.data!.providers` と同様に、永続化データも実行時型検証が必須。localStorage から復元した値に対して `!` や `as` で型安全を偽装すると、破損データでランタイムクラッシュする
+
+### 同種課題の簡潔解決手順（4ステップ）
+
+1. persist復元対象に `Array.isArray` / `instanceof Set` ガードを入れる。
+2. 非正常値は warning を出して安全既定値にフォールバックする。
+3. テストで破損値5パターン以上を固定し、回帰を先に防ぐ。
+4. Phase 11 で最低2枚（light/dark）の画面証跡を残し、TC-IDで紐付ける。
+
+### 実装内容サマリー（2026-03-08 追補）
+
+- `navigationSlice` の `setCurrentView`, `goBack`, `canGoBack` に `Array.isArray` ガードを追加
+- `customStorage.getItem` に `expandedFolders` の Set/Array 検証ガードを追加
+- `customStorage.setItem` に Set→Array 変換ガードを追加
+- `useCanGoBack` セレクタに `Array.isArray` ガードを追加
+- テスト12件追加（破損状態テスト10件 + setCurrentSkillName 2件）
+
+### 苦戦箇所: canGoBack セレクタの防御漏れ
+
+| 項目     | 内容                                                                                                                                                                                                                    |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題     | SubAgent が `navigationSlice` 内の `setCurrentView`, `goBack`, `canGoBack` のガードを実装したが、`store/index.ts` の `useCanGoBack` セレクタ（`state.viewHistory.length > 1`）に `Array.isArray` ガードを追加しなかった |
+| 発見経緯 | メインエージェントが SubAgent 完了後に `store/index.ts` を読み、セレクタ経由のアクセスパスを発見                                                                                                                        |
+| 解決策   | `useCanGoBack` を `Array.isArray(state.viewHistory) && state.viewHistory.length > 1` に修正                                                                                                                             |
+| 再発条件 | Zustand state フィールドに slice 外からアクセスするセレクタ Hook が存在する場合                                                                                                                                         |
+| 再発防止 | `grep -rn "フィールド名" apps/desktop/src/renderer/` で全アクセスパスを検出し、ガード漏れを確認                                                                                                                         |
+
+### 苦戦箇所: customStorage の getItem/setItem 対称性
+
+| 項目     | 内容                                                                                                                                                    |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題     | `expandedFolders` の getItem（JSON Array→Set 変換）と setItem（Set→JSON Array 変換）が対称に実装されていないと、保存→復元サイクルでデータ損失が発生する |
+| 発見経緯 | Phase 5 実装時に getItem だけガードして setItem 側の Set→Array 変換を忘れかけた                                                                         |
+| 解決策   | getItem では `Array.isArray` + `instanceof Set` で入力を判別して Set 化、setItem では `instanceof Set` で `Array.from` に変換                           |
+| 再発条件 | JSON シリアライズ非対応の型（Set, Map, Date 等）を persist 対象にする場合                                                                               |
+| 再発防止 | customStorage の変換ロジックは getItem/setItem をペアで実装・テストする                                                                                 |
+
+### 苦戦箇所: 多層防御の設計判断
+
+| 項目     | 内容                                                                                                                                                                              |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題     | ガードを「Store Hydrate 層（customStorage.getItem）」「Store Serialize 層（customStorage.setItem）」「Navigation Action 層（navigationSlice）」のどの層に配置すべきか判断に迷った |
+| 発見経緯 | Phase 2 設計時に、単一層のみのガードでは不十分と判断                                                                                                                              |
+| 解決策   | 3層全てにガードを配置（Defense in Depth）。各層が独立して安全性を保証                                                                                                             |
+| 再発条件 | persist state 破損の入口が複数ある場合（ストレージ破損、アプリ更新、手動編集等）                                                                                                  |
+| 再発防止 | persist 対象フィールドには必ず「復元時ガード」「保存時ガード」「使用時ガード」の3層を設計する                                                                                     |
+
+### 同種課題の5ステップ解決カード（2026-03-08 追補）
+
+| ステップ                        | 作業内容                                                                    | 検証ゲート                                                       |
+| ------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1. 影響フィールド特定           | `grep -rn "フィールド名" apps/desktop/src/renderer/` で全アクセスパスを列挙 | アクセスパスが0件でないこと                                      |
+| 2. customStorage.getItem ガード | `Array.isArray` / `instanceof Set` で型検証、フォールバック値設定           | 破損入力テスト（null/undefined/数値/文字列/オブジェクト）が PASS |
+| 3. customStorage.setItem ガード | Set→Array 変換等のシリアライズ対応                                          | `JSON.stringify` が正常に完了すること                            |
+| 4. セレクタ Hook ガード         | `store/index.ts` の該当セレクタに型検証を追加                               | セレクタテストが PASS                                            |
+| 5. 仕様同期                     | `arch-state-management.md`, `lessons-learned.md`, `task-workflow.md` を更新 | `verify-unassigned-links` が PASS                                |
+
+**関連 Pitfall**: P19（型キャストバイパス）、P48（non-null assertion）
+**関連未タスク**: UT-PERSIST-MIGRATION-001, UT-PERSIST-VALIDATION-002
+
 ## TASK-UI-03-AGENT-VIEW-ENHANCEMENT: AgentView Enhancement（2026-03-07）
 
 ### 苦戦箇所: z-index 事前設計の必要性
@@ -5724,94 +5838,51 @@ async function safeInvokeUnwrap<T>(
 
 ---
 
-## 06-TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001
+## TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001: ApiKeysSection 契約ガード（2026-03-08）
 
-### コンテキスト
-- 対象: ApiKeysSection `apiKey.list()` 戻り値の契約防御
-- 期間: 2026-03-07
-- カテゴリ: Renderer 境界防御 / Main バリデーション / パターン統一
+### 苦戦箇所: 既実装防御の発見による Phase 転換（P50）
 
-### 実装内容
-1. **Renderer 層（ApiKeysSection/index.tsx）**: `normalizeProviders` type predicate フィルタ追加。`result.data?.providers` の nullish チェック + 要素 shape 検証（`provider`/`status` フィールド必須）
-2. **Main 層（apiKeyHandlers.ts）**: `apiKey:list` ハンドラのレスポンス生成前に `Array.isArray(result?.providers)` バリデーション追加
-3. **パターン統一（profileHandlers.ts）**: 3箇所の `identities ?? []` → `Array.isArray(user.identities) ? user.identities : []` に統一
-4. **テスト**: 20件追加（Renderer 7件 + apiKeyHandlers 7件 + profileHandlers 6件）、全122件 PASS
-5. **カバレッジ**: Statements 93.17% / Branches 86.23% / Functions 91.66%
+| 項目       | 内容                                                                                                                                                        |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題       | GAP-01〜06 の全防御が既に実装済みだった。Phase 4-5（テスト作成→実装）のワークフローが「新規実装」前提で進み、対応する実装が既に存在しテストも全 PASS だった |
+| 再発条件   | Phase 1 で「現在の実装状態の調査」を行わず、新規実装を前提に Phase 4 を開始する場合                                                                         |
+| 対処       | Phase 4 開始前に対象ファイルの `git log` と現在のコードを確認し、既に実装済みかどうかを判定。既実装の場合は Phase 4-5 を「検証・補完」モードに切り替えた    |
+| 標準ルール | Phase 1（要件定義）で「現在の実装状態の調査」を必須ステップとして含める。差分がゼロの場合は Phase 4-5 を検証・文書化モードに転換する                        |
 
-### 苦戦箇所
+### 苦戦箇所: サブエージェントの documentation-changelog 早期完了記載（P51/P4/P43 複合再発）
 
-#### S1: type predicate 内での型キャスト vs in 演算子
-- **症状**: `normalizeProviders` 内で `(item as Record<string, unknown>).provider` を使用したが、Phase 8 で P19（型キャストバイパス）違反と判定
-- **根本原因**: `as Record<string, unknown>` は実行時検証をバイパスする型アサーション。`in` 演算子は実行時チェックを伴う型ナロイング
-- **解決策**: `"provider" in item && typeof item.provider === "string"` に変更。`in` 演算子で TypeScript の型ナロイングと実行時検証を同時に実現
-- **再発条件**: type predicate でオブジェクトプロパティの存在を検証する場合
-- **再利用手順**:
-  1. `as` キャストの代わりに `in` 演算子を使用
-  2. `in` 演算子の後に `typeof` で型検証
-  3. P19 準拠を ESLint rule で強制（将来）
+| 項目       | 内容                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題       | Phase 12 サブエージェントが documentation-changelog.md に「Step 1-A 〜 Step 2 完了」と記載したが、実際には topic-map.md 再生成が未実行だった        |
+| 再発条件   | サブエージェントが Step 実行前に完了記録を書き、途中で中断（rate limit 等）した場合                                                                 |
+| 対処       | `git diff --stat -- .claude/skills/` で実際の変更ファイル数を検証し、topic-map.md 再生成の未実行を発見。手動で再実行した                            |
+| 標準ルール | documentation-changelog には各 Step の実行結果を「事後記録」する。サブエージェント完了後にメインエージェントが `git diff --stat` で実変更を検証する |
 
-#### S2: Main ハンドラの直接テスト困難性
-- **症状**: `apiKeyHandlers.ts` の list ハンドラは `ipcMain.handle` + `withValidation` でラップされており、ハンドラ関数を直接テストできない
-- **根本原因**: ハンドラ登録が `registerApiKeyHandlers()` 関数内にカプセル化されており、個別のハンドラ関数をエクスポートしていない
-- **解決策**: `ipcMain.handle` をモックし、登録時のコールバック関数を取得してテストする間接テストパターンを採用
-- **再発条件**: `withValidation` ラッパーを使う IPC ハンドラの新規テスト作成時
-- **再利用手順**:
-  1. `vi.mock("electron")` で ipcMain をモック
-  2. `registerXxxHandlers()` を呼び出し
-  3. `ipcMain.handle.mock.calls` から対象チャネルのコールバックを取得
-  4. コールバックを直接呼び出してバリデーションロジックをテスト
+**関連パターン**: [06-known-pitfalls.md#P4](../../rules/06-known-pitfalls.md)（早期完了記載）、[06-known-pitfalls.md#P43](../../rules/06-known-pitfalls.md)（サブエージェント中断）、[06-known-pitfalls.md#P2](../../rules/06-known-pitfalls.md)（topic-map 再生成忘れ）
 
-#### S3: `?? []` vs `Array.isArray` の防御力の差
-- **症状**: `profileHandlers.ts` で `identities ?? []` が使われていたが、`identities` が文字列やオブジェクト等の非配列値の場合に防御できない
-- **根本原因**: Nullish coalescing (`??`) は `null`/`undefined` のみ防御。P48 では全型に対する実行時検証が求められる
-- **解決策**: `Array.isArray(user.identities) ? user.identities : []` に統一
-- **再発条件**: 外部データ（IPC レスポンス、DB クエリ結果）から配列を取得する場合
-- **再利用手順**:
-  1. `grep -rn "?? \[\]" apps/desktop/src/` で全箇所を検出
-  2. 外部データ由来の箇所を `Array.isArray` に置換
-  3. 内部コード由来（確実に null/undefined のみ）は `?? []` を維持
+### 苦戦箇所: Phase 10 MINOR 指摘の non-null assertion 残存（P52）
 
-#### S4: IPC契約ドリフト（仕様表の旧値残存）
-- **症状**: API仕様書は更新済みだが、実装変更後に戻り値型テーブルだけ旧値が残るドリフトが発生
-- **根本原因**: 「実装コード」と「仕様表」の両方を同時に検証する手順を固定していなかった
-- **解決策**: `api-ipc-system.md` の `apiKey:list` を `IPCResponse<ProviderListResult>` へ更新し、フィールド表 (`providers/registeredCount/totalCount`) を追加
-- **標準ルール**: IPC契約変更時は「型名 + フィールド表 + 完了タスク台帳」を同一コミット単位で更新する
+| 項目       | 内容                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題       | 防御ガードを追加した同ファイル内の別箇所（L305-306）に `result.data!` という non-null assertion が残存していた。タスクスコープ内は P48 準拠で修正済みだったが、スコープ外コードに同パターンが残っていた |
+| 再発条件   | 防御ガード実装時に対象ファイル全体をスキャンせず、スコープ内のみ修正する場合                                                                                                                            |
+| 対処       | 対象ファイル全体を `!` でスキャンし、non-null assertion の残存箇所をリストアップ。スコープ内は修正、スコープ外は未タスク化した                                                                          |
+| 標準ルール | 防御ガード実装時は対象ファイル全体を `grep -n '!' ファイル名` でスキャンし、同パターンの残存を検出する                                                                                                  |
 
-#### S5: Phase 11 実画面証跡不足
-- **症状**: Phase 11 が自動テスト代替に寄り、実画面証跡が不足しやすい
-- **根本原因**: UI構造変更なしという前提で screenshot を省略する運用が残っていた
-- **解決策**: `capture-task-06-settings-apikey-contract-guard-phase11.mjs` を追加し、TC-11-01〜03 を取得して manual-test-result へ証跡リンクを記録
-- **標準ルール**: ユーザーが画面検証を要求した場合、`SCREENSHOT` を必須に切り替える
+**関連パターン**: [06-known-pitfalls.md#P48](../../rules/06-known-pitfalls.md)（non-null assertion 禁止）
 
-#### S6: Phase 11 証跡表ヘッダの validator 不一致
-- **症状**: `validate-phase11-screenshot-coverage` が `manual-test-result.md` の証跡列を抽出できず失敗
-- **根本原因**: 証跡テーブルが validator 期待ヘッダ（`テストケース` / `証跡`）を満たしていなかった
-- **解決策**: Phase 11成果物に validator互換テーブルを追加し、TC-11-01〜03 の `.png` を1:1で紐付け
-- **再発条件**: 手動テスト結果の表形式を独自変更した場合
-- **標準ルール**: Phase 11完了前に `validate-phase11-screenshot-coverage` を必ず実行し、表形式を機械検証で固定
+### 苦戦箇所: CLI 環境でのスクリーンショット取得制約（P53）
 
-#### S7: screenshot 再取得時の依存欠落（Rollup optional dependency）
-- **症状**: capture script 実行時に `Cannot find module @rollup/rollup-darwin-x64` で停止
-- **根本原因**: worktree の optional dependency が欠落したまま Vite 起動を試行した
-- **解決策**: `pnpm install` 後に capture script を再実行し、`phase11-capture-metadata.json` を更新
-- **再発条件**: worktree切替直後や node_modules 再構成後に preview/capture を即実行する場合
-- **標準ルール**: screenshot 再取得前に依存解決（`pnpm install`）と preflight（preview疎通）を先に実施
+| 項目       | 内容                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 課題       | Phase 11（手動テスト）でスクリーンショット取得が指示されたが、CLI 環境では Electron アプリの実画面キャプチャができない                                 |
+| 再発条件   | CLI 専用環境で Phase 11 を実行し、スクリーンショットが必要な場合                                                                                       |
+| 対処       | 自動テスト結果を「間接的な視覚検証」として代替記録した                                                                                                 |
+| 標準ルール | Phase 11 にスクリーンショットが必要な場合、Playwright の `page.screenshot()` または Electron の `webContents.capturePage()` をスクリプト化して取得する |
 
-### 同種課題の5分解決カード
+### 同種課題の簡潔解決手順（4ステップ）
 
-| ステップ | 操作 | 目的 |
-|----------|------|------|
-| 1 | `grep -rn "result.data\." apps/desktop/src/renderer/` で Renderer 側の data アクセスを検索 | 未防御の shape アクセスを発見 |
-| 2 | `result?.data` + `Array.isArray(result.data.xxx)` の2段チェックを追加 | nullish + 非配列を同時に防御 |
-| 3 | type predicate フィルタで要素 shape を検証（`in` 演算子 + `typeof`） | malformed 要素を安全に除外 |
-| 4 | Main ハンドラ側にも `Array.isArray` バリデーションを追加 | 多層防御の実現 |
-| 5 | テスト追加（undefined/null/空配列/malformed/reject の5パターン） | 回帰防止 |
-
-### 検証ゲート
-- `cd apps/desktop && pnpm vitest run src/renderer/components/organisms/ApiKeysSection/__tests__/`
-- `cd apps/desktop && pnpm exec tsc --noEmit`
-
-### 同期先
-- `references/security-electron-ipc.md`: apiKeyAPI セクション追加
-- `references/ui-ux-settings.md`: ApiKeysSection 異常系表示仕様
-- `.claude/rules/06-known-pitfalls.md`: P49 候補（type predicate の `as` vs `in`）
+1. Phase 1 で `git log` と現在のコードを確認し、既実装状態を判定する。差分ゼロなら Phase 4-5 を検証モードに転換する。
+2. Phase 12 の documentation-changelog は Step 完了後に「事後記録」する。サブエージェント完了後に `git diff --stat` で実変更を検証する。
+3. 防御ガード実装時は対象ファイル全体を `grep -n '!'` でスキャンし、non-null assertion の残存を検出する。スコープ外は未タスク化する。
+4. CLI 環境での Phase 11 は `page.screenshot()` / `webContents.capturePage()` のスクリプト化で対応する。

--- a/.claude/skills/aiworkflow-requirements/references/task-workflow.md
+++ b/.claude/skills/aiworkflow-requirements/references/task-workflow.md
@@ -285,6 +285,61 @@
 | `phase-11-manual-testing.md` と validator 期待名 `phase-11-manual-test.md` の不一致 | 手動テスト文書名が workflow ごとに揺れる | `phase-11-manual-test.md` を正本として固定し、証跡11件を TC と1:1で同期 |
 | Phase 12 changelog が「対象/予定」表現のまま残る | 実更新前に changelog を先行記述する | Step 1-A〜Step 2 を完了ベースで再記録し、予定表現を削除 |
 
+### タスク: TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 settings persist iterable hardening（2026-03-07）
+
+| 項目       | 内容                                                   |
+| ---------- | ------------------------------------------------------ |
+| タスクID   | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001       |
+| 完了日     | 2026-03-07                                             |
+| ステータス | **完了（Phase 1-12 出力 + 画面証跡 + 仕様同期）**      |
+| 対象       | `expandedFolders` / `viewHistory` の iterable 崩れ耐性 |
+
+#### 仕様書別SubAgent分担（関心ごと分離）
+
+| SubAgent   | 担当仕様書                            | 主担当作業                    | 完了条件                                          |
+| ---------- | ------------------------------------- | ----------------------------- | ------------------------------------------------- |
+| SubAgent-A | `references/arch-state-management.md` | persist 復旧契約を追記        | DD-01..DD-05 の防御境界が明文化される             |
+| SubAgent-B | `references/lessons-learned.md`       | 再発条件と5分解決カードを追記 | 同種課題へ再利用できる手順が残る                  |
+| SubAgent-C | `outputs/phase-11/*`                  | screenshot 2件とTC紐付け      | `validate-phase11-screenshot-coverage` で証跡確認 |
+
+#### 検証証跡
+
+| コマンド                                                                                                                                                                           | 結果             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `pnpm --filter @repo/desktop exec vitest run src/renderer/store/slices/navigationSlice.test.ts src/renderer/store/__tests__/customStorage.test.ts`                                 | PASS（42 tests） |
+| `node .claude/skills/task-specification-creator/scripts/validate-phase-output.js docs/30-workflows/07-TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001`                            | PASS             |
+| `node .claude/skills/task-specification-creator/scripts/validate-phase11-screenshot-coverage.js --workflow docs/30-workflows/07-TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001`  | PASS             |
+| `node .claude/skills/task-specification-creator/scripts/validate-phase12-implementation-guide.js --workflow docs/30-workflows/07-TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001` | PASS             |
+
+#### Phase 12で検出した関連未タスク（branch横断）
+
+| タスクID                                           | 概要                                                 | 参照                                                                                        |
+| -------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| UT-IMP-PHASE12-WORKFLOW10-COMPLIANCE-FIX-001       | Workflow10 の Phase 7/12 準拠不足是正                | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow10-compliance-fix-001.md`       |
+| UT-IMP-PHASE12-WORKFLOW11-COMPLIANCE-FIX-001       | Workflow11 の Phase 1-11 構造不足と Phase 12不足是正 | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow11-compliance-fix-001.md`       |
+| UT-IMP-PHASE12-WORKFLOW12-IMPLEMENTATION-GUIDE-001 | Workflow12 の実装ガイド欠落是正                      | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow12-implementation-guide-001.md` |
+
+#### branch横断再確認（2026-03-08）
+
+| workflow                                                | `verify-all-specs` | `validate-phase-output --phase 12` | `validate-phase12-implementation-guide` |
+| ------------------------------------------------------- | ------------------ | ---------------------------------- | --------------------------------------- |
+| `07-TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001`   | PASS               | PASS                               | PASS                                    |
+| `10-TASK-FIX-IPC-HANDLER-GRACEFUL-DEGRADATION-001`      | PASS               | FAIL（Phase 7 必須節欠落）         | FAIL（implementation-guide 欠落）       |
+| `11-TASK-FIX-SUPABASE-FALLBACK-PROFILE-AVATAR-001`      | PASS               | FAIL（Phase 1-11 必須節欠落）      | FAIL（implementation-guide 欠落）       |
+| `12-TASK-FIX-AGENT-EXECUTE-SKILL-CONCURRENCY-GUARD-001` | PASS               | PASS                               | FAIL（implementation-guide 欠落）       |
+
+> 完了判定は `verify-all-specs` 単独ではなく、Phase 12 2検証を含む3点セットを必須とする。
+
+#### 同種課題の5分解決カード（persist hydrate 破損入力）
+
+| 項目       | 内容                                                                                                                                                                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 症状       | persist 復元後に `is not iterable` / `has no method forEach` 等が発生し、Settings や Navigation が初期化に失敗する                                                                                                                                                       |
+| 根本原因   | `zustand/middleware` の `persist` が localStorage/electron-store から復元した値が `Set` / `Array` ではなく `null` / `object` / `number` 等に破損している                                                                                                                 |
+| 最短4手順  | 1) persist 復元対象に `Array.isArray` / `instanceof Set` ガードを入れる 2) 非正常値は `console.warn` を出して安全既定値にフォールバックする 3) テストで破損値5パターン以上を固定し、回帰を先に防ぐ 4) Phase 11 で最低2枚（light/dark）の画面証跡を残し、TC-ID で紐付ける |
+| 検証ゲート | `validate-phase-output` PASS、`validate-phase11-screenshot-coverage` PASS、`validate-phase12-implementation-guide` PASS、対象テスト PASS（42 tests）                                                                                                                     |
+| 同期先3点  | `references/task-workflow.md` / `references/lessons-learned.md` / `references/arch-state-management.md`                                                                                                                                                                  |
+
 ### タスク: TASK-UI-01-C-NOTIFICATION-HISTORY-DOMAIN 通知履歴・履歴検索ドメイン実装（2026-03-05）
 
 | 項目       | 内容                                                               |
@@ -3472,6 +3527,12 @@ find docs/30-workflows/unassigned-task -maxdepth 1 -name 'task-10a-b-*.md' | wc 
 | UT-IMP-AIWORKFLOW-SKILL-ENTRYPOINT-COVERAGE-GUARD-001          | aiworkflow-requirements の入口導線整流（`SKILL.md` / `quick-reference` / `resource-map` と `quick_validate` の整合）                                                         | 中       | UT-TASK-10A-B-008 Phase 12 追補4-5（system spec 再同期・2026-03-06）                                                                 | `docs/30-workflows/completed-tasks/ut-task-10a-b-008-unassigned-count-resync-guard/unassigned-task/task-imp-aiworkflow-skill-entrypoint-coverage-guard-001.md`                         |
 | ~~UT-IMP-AIWORKFLOW-SPEC-REFERENCE-SYNC-001~~                  | ~~Phase 12 仕様更新リンク同期ガード強化（task-workflow/SKILL/LOGSの3点同期）~~                                                                                               | ~~中~~   | ~~UT-IPC-AUTH-HANDLE-DUPLICATE-001 Phase 12 再確認（苦戦箇所・2026-02-25）~~ **完了: 2026-02-25（spec_created）**                    | `docs/30-workflows/completed-tasks/task-imp-aiworkflow-spec-reference-sync-001.md`                                                                                                     |
 
+| UT-10A-E-D-001                                                 | quality gate lint コマンドパス整合                                                                                                                                           | 中       | TASK-10A-E-D Phase 10 MINOR（2026-03-08）                                                                                            | `docs/30-workflows/unassigned-task/task-10a-e-d-lint-command-path-alignment-001.md`                                                                                                    |
+| UT-IMP-PHASE12-WORKFLOW10-COMPLIANCE-FIX-001                   | Workflow10 の Phase 7/12 準拠不足是正                                                                                                                                        | 中       | TASK-10A-E-D branch横断再監査（2026-03-08）                                                                                          | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow10-compliance-fix-001.md`                                                                                                  |
+| UT-IMP-PHASE12-WORKFLOW11-COMPLIANCE-FIX-001                   | Workflow11 の Phase 1-11 構造不足と Phase 12不足是正                                                                                                                         | 中       | TASK-10A-E-D branch横断再監査（2026-03-08）                                                                                          | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow11-compliance-fix-001.md`                                                                                                  |
+| UT-IMP-PHASE12-WORKFLOW12-IMPLEMENTATION-GUIDE-001             | Workflow12 の実装ガイド欠落是正                                                                                                                                              | 中       | TASK-10A-E-D branch横断再監査（2026-03-08）                                                                                          | `docs/30-workflows/unassigned-task/task-imp-phase12-workflow12-implementation-guide-001.md`                                                                                            |
+| UT-PERSIST-MIGRATION-001                                       | Zustand Persist バージョニングとマイグレーション機構                                                                                                                         | 中       | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001                                                                                     | `docs/30-workflows/unassigned-task/task-persist-migration-versioning.md`                                                                                                               |
+| UT-PERSIST-VALIDATION-002                                      | Zustand Persist 全フィールド iterable ガード拡張                                                                                                                             | 低       | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001                                                                                     | `docs/30-workflows/unassigned-task/task-persist-field-validation-guard.md`                                                                                                             |
 ### 未タスク管理ルール
 
 - 未タスクは `docs/30-workflows/unassigned-task/` に配置
@@ -3509,6 +3570,8 @@ find docs/30-workflows/unassigned-task -maxdepth 1 -name 'task-10a-b-*.md' | wc 
 | **1.67.21** | **2026-03-06** | **TASK-FIX-SKILL-EXECUTOR-AUTHKEY-DI-001 の完了台帳を強化**: 完了タスクセクションを新設し、SubAgent分担・実装反映（`AuthKeyService` 単一生成 + `SkillExecutor` DI）・検証証跡（13/13, 28項目, target監査 current=0）・苦戦箇所（DIシグネチャドリフト、`phase-12-documentation` pending残置、教訓同期漏れ）を記録。Phase 12完了判定を「成果物実体 + 機械検証 + 仕様書ステータス同期」で固定 |
 | バージョン  | 日付           | 変更内容                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | ----------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1.67.35** | **2026-03-08** | **未タスク4件を残課題テーブルへ登録**: `UT-10A-E-D-001`（lint コマンドパス整合）、`UT-IMP-PHASE12-WORKFLOW10-COMPLIANCE-FIX-001`（Workflow 10 Phase 12準拠修正）、`UT-IMP-PHASE12-WORKFLOW11-COMPLIANCE-FIX-001`（Workflow 11 Phase 12準拠修正）、`UT-IMP-PHASE12-WORKFLOW12-IMPLEMENTATION-GUIDE-001`（Workflow 12 実装ガイド作成）を残課題テーブルへ追加。完了タスクセクション内の関連未タスク表に記載済みだったが残課題テーブルへの登録が未実施だったため同期                                   |
+| **1.67.34** | **2026-03-08** | **TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 の5分解決カード追加**: 完了タスク節へ「同種課題の5分解決カード（persist hydrate 破損入力）」を追記。症状/根本原因/最短4手順/検証ゲート/同期先3点を固定化し、persist iterable 崩れの再発時に短手順で対処可能化                                                                                                                                                                                                                                   |
 | **1.67.34** | **2026-03-07** | **TASK-10A-F 完了同期**: スキルライフサイクルUI Store移行（useSkillAnalysis.ts 直接IPC 3箇所排除、Case B方式、52テスト全PASS）の完了記録を追加。仕様書同期4件（arch-state-management/lessons-learned/architecture-implementation-patterns/task-workflow）を実施                                                                                                                                                                                                                                    |
 | **1.67.33** | **2026-03-06** | **UT-IMP-AIWORKFLOW-SKILL-ENTRYPOINT-COVERAGE-GUARD-001 を登録**: `aiworkflow-requirements` の `quick_validate` warning 145件を「SKILL.md 全列挙」で雑に解消せず、`SKILL.md` / `indexes/quick-reference.md` / `indexes/resource-map.md` の入口設計と validator 判定を両立させる未タスクを残課題テーブルへ追加。苦戦箇所と再利用方針を `lessons-learned.md` / `SKILL.md` / `LOGS.md` へ同期                                                                                                         |
 | **1.67.32** | **2026-03-06** | **UT-TASK-10A-B-008 追補3を skill-creator 導線改善まで拡張**: repo 内 `skill-creator/SKILL.md` に未リンク reference 群の直接参照導線を追加し、`resource-map` 偏重で残っていた `quick_validate` warning 26件を 0 件へ解消。system spec には「Task本体の実装 + 再発防止スキル改善」を同一ターンで残す運用を追記                                                                                                                                                                                      |

--- a/docs/30-workflows/unassigned-task/task-persist-field-validation-guard.md
+++ b/docs/30-workflows/unassigned-task/task-persist-field-validation-guard.md
@@ -1,0 +1,195 @@
+# UT-PERSIST-VALIDATION-002: Zustand Persist 全フィールド iterable ガード拡張
+
+## メタ情報
+
+```yaml
+issue_number: 1071
+```
+
+## メタ情報
+
+| 項目         | 内容                                                                       |
+| ------------ | -------------------------------------------------------------------------- |
+| タスクID     | UT-PERSIST-VALIDATION-002                                                  |
+| タスク名     | Zustand Persist 全フィールド iterable ガード拡張                           |
+| 分類         | 改善                                                                       |
+| 対象機能     | Zustand Store persist state の型安全性                                     |
+| 優先度       | 低                                                                         |
+| 見積もり規模 | 小規模                                                                     |
+| ステータス   | 未実施                                                                     |
+| 発見元       | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 Phase 10（最終レビュー）  |
+| 発見日       | 2026-03-08                                                                 |
+| 関連タスク   | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001, UT-PERSIST-MIGRATION-001 |
+
+## 1. Why（背景）
+
+TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001では、`viewHistory`（Array）と`expandedFolders`（Set）に対するiterableガードを実装した。しかし、persist対象のstateには他にも配列やオブジェクト型のフィールドが存在し（例: `recentExecutions`, `importedSkills`, `pinnedSkills`等）、これらが同様の破損リスクを持つ。Phase 10の最終レビューでMINOR判定として指摘された。
+
+## 2. 問題点・課題
+
+1. **ガード範囲の不完全性**: viewHistory/expandedFolders以外のpersist対象フィールドにiterableガードがない
+2. **破損パターンの網羅不足**: 配列型フィールドが`null`や`undefined`に破損した場合、`.map()`や`.filter()`で例外が発生する
+3. **一貫性の欠如**: 一部フィールドにのみガードがあり、他にはない状態は保守性が低い
+
+## 3. 放置した場合の影響
+
+- `recentExecutions`等の配列フィールドが破損した場合、UIコンポーネントがクラッシュする
+- 特にagentSliceのフィールド（`importedSkills`, `availableSkills`等）は頻繁にアクセスされるため影響が大きい
+
+## 4. What（達成目標）
+
+### 4.1 目的
+
+persist対象の全配列/Set型フィールドに対して、customStorage.getItemでの復元時にiterableガードを適用し、破損入力に対する耐性を確保する。
+
+### 4.2 最終ゴール
+
+- persist対象の全配列フィールドに`Array.isArray`ガードが適用されている
+- persist対象のSetフィールドに`instanceof Set`ガードが適用されている
+- 各ガードに対応するユニットテストが存在する
+
+### 4.3 スコープ
+
+**含むもの:**
+
+- `customStorage.getItem`内で全persist対象フィールドのiterableガード追加
+- ガードをヘルパー関数化して再利用可能にする
+- 各フィールドの破損テスト追加
+
+**含まないもの:**
+
+- persist対象フィールドの追加・削除
+- sliceアクション内のガード追加（既にviewHistoryで実施済みパターンの横展開は含まない）
+- UIコンポーネント側のnullish防御
+
+### 4.4 成果物
+
+| 種別   | 成果物                    | 配置先                                                             |
+| ------ | ------------------------- | ------------------------------------------------------------------ |
+| 実装   | ガードヘルパー関数        | `apps/desktop/src/renderer/store/persist-guards.ts`（新規）        |
+| 実装   | customStorage.getItem拡張 | `apps/desktop/src/renderer/store/index.ts`                         |
+| テスト | 破損フィールドテスト      | `apps/desktop/src/renderer/store/__tests__/persist-guards.test.ts` |
+
+## 5. How（実行方法）
+
+### 5.1 前提条件
+
+- TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001が完了していること
+- customStorage.getItemにviewHistory/expandedFoldersのガードが実装済みであること
+
+### 5.2 推奨アプローチ
+
+```typescript
+// persist-guards.ts - 再利用可能なガードヘルパー
+export function ensureArray<T>(value: unknown, fallback: T[] = []): T[] {
+  return Array.isArray(value) ? value : fallback;
+}
+
+export function ensureSet<T>(
+  value: unknown,
+  fallback: Set<T> = new Set(),
+): Set<T> {
+  if (value instanceof Set) return value;
+  if (Array.isArray(value))
+    return new Set(value.filter((v): v is T => v != null));
+  return fallback;
+}
+
+export function ensureString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+// customStorage.getItem での適用
+getItem: (name: string) => {
+  // ... 既存のパース処理
+  if (parsed.state) {
+    parsed.state.viewHistory = ensureArray(parsed.state.viewHistory, [
+      "dashboard",
+    ]);
+    parsed.state.expandedFolders = ensureSet(parsed.state.expandedFolders);
+    parsed.state.recentExecutions = ensureArray(parsed.state.recentExecutions);
+    parsed.state.importedSkills = ensureArray(parsed.state.importedSkills);
+    // ... 他のフィールド
+  }
+};
+```
+
+### 5.3 Phase構成
+
+| Phase   | 内容                                          |
+| ------- | --------------------------------------------- |
+| Phase 1 | persist対象フィールドの棚卸しとガード関数設計 |
+| Phase 2 | ガードヘルパー関数の実装・テスト作成（TDD）   |
+| Phase 3 | customStorage.getItemへの統合                 |
+| Phase 4 | 品質検証・ドキュメント更新                    |
+
+## 6. 実装課題と解決策（親タスクからの教訓）
+
+### 課題1: 全アクセスパスの網羅
+
+| 項目     | 内容                                                                                                            |
+| -------- | --------------------------------------------------------------------------------------------------------------- |
+| 課題     | stateフィールドへのアクセスパスがslice内アクションだけでなく、store/index.tsのセレクタHookにも存在する          |
+| 発見経緯 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001で`useCanGoBack`セレクタにガード漏れを発見                      |
+| 解決策   | `grep -rn "フィールド名" apps/desktop/src/renderer/`で全アクセスパスを検出し、ガード適用範囲を決定              |
+| 教訓     | customStorage.getItemでガードすればslice/セレクタ側のガードは冗長だが、多層防御として両方維持する               |
+| 参照     | [arch-state-management.md](/.claude/skills/aiworkflow-requirements/references/arch-state-management.md) v3.11.0 |
+
+### 課題2: Set/Array 変換の一貫性
+
+| 項目     | 内容                                                                                                |
+| -------- | --------------------------------------------------------------------------------------------------- |
+| 課題     | `expandedFolders`のgetItem（Array→Set変換）とsetItem（Set→Array変換）が対称でないとデータ損失が発生 |
+| 発見経緯 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001のPhase 5でgetItem/setItem両方の実装が必要と判明    |
+| 解決策   | `ensureSet`ヘルパーでArray入力も受け付けるようにし、getItem側のみでSet化を行う                      |
+| 教訓     | JSON永続化ではSetは自動的にArrayに変換される。復元パスでのSet化は1箇所に集約する                    |
+
+### 課題3: テスト設計における破損値の選択
+
+| 項目     | 内容                                                                                                       |
+| -------- | ---------------------------------------------------------------------------------------------------------- |
+| 課題     | 破損値として何をテストすべきか（null, undefined, 数値, 文字列, オブジェクト等）                            |
+| 発見経緯 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001のテストで5種類の破損値を使用                              |
+| 解決策   | 最低限 null, undefined, 非対象型（数値/文字列/オブジェクト）の3パターンをテスト                            |
+| 教訓     | persist破損の最も一般的なケースはnull/undefinedだが、型混在（数値がArrayフィールドに入る等）もカバーすべき |
+
+## 7. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] persist対象の全配列フィールドに`ensureArray`ガードが適用されている
+- [ ] persist対象のSetフィールドに`ensureSet`ガードが適用されている
+- [ ] 破損入力時にデフォルト値へフォールバックする
+
+### 品質要件
+
+- [ ] ガードヘルパー関数のユニットテストが全PASS
+- [ ] 各フィールドの破損テスト（最低3パターン）が全PASS
+- [ ] 既存テストが回帰なし
+- [ ] TypeScript型エラーなし
+
+### ドキュメント要件
+
+- [ ] persist-guards.ts のインターフェースがドキュメント化されている
+- [ ] arch-state-management.md にガードパターンが記載されている
+
+## 8. リスクと対策
+
+| リスク                           | 影響度 | 発生確率 | 対策                                                              |
+| -------------------------------- | ------ | -------- | ----------------------------------------------------------------- |
+| ガード対象フィールドの見落とし   | 中     | 中       | partialize関数の対象フィールドを全列挙して照合                    |
+| ガードによるパフォーマンス低下   | 低     | 低       | getItem時のみ実行されるため影響は起動時のみ                       |
+| UT-PERSIST-MIGRATION-001との競合 | 中     | 中       | migration側はバージョン管理、本タスクはフィールド検証と責務を分離 |
+
+## 9. 参照情報
+
+### 関連ドキュメント
+
+- [arch-state-management.md](/.claude/skills/aiworkflow-requirements/references/arch-state-management.md) - customStorage 3段ガードパターン
+- [06-known-pitfalls.md](/.claude/rules/06-known-pitfalls.md) - P19（型キャストバイパス）, P48（non-null assertion）
+- TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 outputs/phase-12/implementation-guide.md
+
+## 10. 備考
+
+- UT-PERSIST-MIGRATION-001と並行実施可能だが、本タスクが先に完了していることが望ましい（migrate関数がガードヘルパーを利用できる）
+- ガードヘルパー関数は将来の新規Sliceフィールド追加時にも再利用可能な設計とする

--- a/docs/30-workflows/unassigned-task/task-persist-migration-versioning.md
+++ b/docs/30-workflows/unassigned-task/task-persist-migration-versioning.md
@@ -1,0 +1,214 @@
+# UT-PERSIST-MIGRATION-001: Zustand Persist バージョニングとマイグレーション機構
+
+## メタ情報
+
+```yaml
+issue_number: 1072
+```
+
+## メタ情報
+
+| 項目         | 内容                                                      |
+| ------------ | --------------------------------------------------------- |
+| タスクID     | UT-PERSIST-MIGRATION-001                                  |
+| タスク名     | Zustand Persist バージョニングとマイグレーション機構      |
+| 分類         | 改善                                                      |
+| 対象機能     | Zustand Store persist ミドルウェア                        |
+| 優先度       | 中                                                        |
+| 見積もり規模 | 中規模                                                    |
+| ステータス   | 未実施                                                    |
+| 発見元       | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 Phase 12 |
+| 発見日       | 2026-03-08                                                |
+| 関連タスク   | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001          |
+
+---
+
+## 1. Why（背景）
+
+TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001で、Zustand persistミドルウェアによって永続化されたstateが破損（null, undefined, 数値, 文字列, オブジェクトなど非配列値）した場合にアプリがクラッシュする問題を修正した。現在は各アクション内で`Array.isArray`ガードを設置しているが、persist stateの「バージョン」管理とマイグレーション機構がないため、将来のstate構造変更時に同様の破損が発生するリスクが残存している。
+
+### 問題点・課題
+
+1. **バージョン管理なし**: persistされたstateにバージョン番号がなく、構造変更を検知できない
+2. **マイグレーション未実装**: Zustand persistの`migrate`オプションが未使用。古い構造のstateを新しい構造に変換する仕組みがない
+3. **リセット手段なし**: 破損stateを検知した場合に、ユーザー操作でstateをリセットする手段がない
+
+### 放置した場合の影響
+
+- state構造変更（フィールド追加・型変更）時に既存ユーザーのローカルストレージデータが破損し、`object is not iterable`等のランタイムエラーが発生する
+- 破損時の復旧にはDevToolsでのlocalStorage手動クリアが必要で、非技術者ユーザーには対応不可
+
+---
+
+## 2. What（達成目標）
+
+### 目的
+
+Zustand persistミドルウェアに`version`と`migrate`オプションを導入し、state構造変更時の安全なマイグレーションを実現する。
+
+### 最終ゴール
+
+- persistされたstateにバージョン番号が付与されている
+- バージョン不一致時にマイグレーション関数が実行される
+- 破損stateの検知と自動復旧が機能する
+
+### スコープ
+
+**含むもの:**
+
+- `store/index.ts`のpersist設定に`version`オプション追加
+- `migrate`関数の実装（現在のstateをv1として定義）
+- 破損検知時のフォールバック（デフォルト値へのリセット）
+- マイグレーションのユニットテスト
+
+**含まないもの:**
+
+- UIからのstate手動リセット機能（別タスク化）
+- 他のelectron-store永続化パターンの変更
+- バックエンドとのstate同期
+
+### 成果物
+
+| 種別         | 成果物                      | 配置先                                                         |
+| ------------ | --------------------------- | -------------------------------------------------------------- |
+| 実装         | persist version/migrate設定 | `apps/desktop/src/renderer/store/index.ts`                     |
+| 実装         | マイグレーション関数        | `apps/desktop/src/renderer/store/migrations.ts`（新規）        |
+| テスト       | マイグレーションテスト      | `apps/desktop/src/renderer/store/__tests__/migrations.test.ts` |
+| ドキュメント | 実装ガイド                  | `outputs/phase-12/implementation-guide.md`                     |
+
+---
+
+## 3. How（実行方法）
+
+### 前提条件
+
+- TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001が完了していること
+- `customStorage`のgetItem/setItemにiterableガードが実装済みであること
+
+### 推奨アプローチ
+
+```typescript
+// store/index.ts - persist設定にversion/migrateを追加
+persist((set, get, api) => ({ ...createAllSlices(set, get, api) }), {
+  name: "app-store",
+  version: 1, // 現在のstate構造バージョン
+  storage: customStorage,
+  migrate: (persistedState: unknown, version: number) => {
+    // v0 → v1: 初回マイグレーション（既存stateの正規化）
+    if (version === 0) {
+      const state = persistedState as Record<string, unknown>;
+      return {
+        ...state,
+        viewHistory: Array.isArray(state?.viewHistory)
+          ? state.viewHistory
+          : ["dashboard"],
+        expandedFolders:
+          state?.expandedFolders instanceof Set
+            ? state.expandedFolders
+            : new Set<string>(),
+      };
+    }
+    return persistedState as AppState;
+  },
+  partialize: (state) => ({
+    /* 永続化対象フィールド */
+  }),
+});
+```
+
+### Phase構成
+
+| Phase   | 内容                                              |
+| ------- | ------------------------------------------------- |
+| Phase 1 | マイグレーション関数の設計・テスト作成（TDD Red） |
+| Phase 2 | persist設定への version/migrate 統合（TDD Green） |
+| Phase 3 | 既存customStorageガードとの統合テスト             |
+| Phase 4 | リファクタリング・品質検証                        |
+| Phase 5 | ドキュメント更新                                  |
+
+### 3.5 実装課題と解決策（親タスクからの教訓）
+
+#### 課題1: customStorage.getItem での Set/Array 変換境界
+
+| 項目     | 内容                                                                                                                  |
+| -------- | --------------------------------------------------------------------------------------------------------------------- |
+| 課題     | `expandedFolders`はSetだがJSON永続化時にArrayに変換される。復元時にSetに戻す処理が複数箇所に分散                      |
+| 発見経緯 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001のPhase 5で、customStorage.getItemとsetItemの両方にガードが必要と判明 |
+| 解決策   | `migrate`関数に集約し、customStorageのガードはフォールバック専用に限定                                                |
+| 教訓     | Set/Array変換は1箇所に集約する。getItemとsetItemに分散すると保守コストが倍増する                                      |
+| 参照     | [arch-state-management.md](/.claude/skills/aiworkflow-requirements/references/arch-state-management.md) v3.11.0       |
+
+#### 課題2: canGoBack セレクタの防御漏れ
+
+| 項目     | 内容                                                                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 課題     | navigationSlice内のガードは完璧でも、store/index.tsの`useCanGoBack`セレクタにArray.isArrayガードがなかった                                       |
+| 発見経緯 | SubAgentがnavigationSlice修正を完了した後、メインエージェントがstore/index.tsのセレクタを確認して発見                                            |
+| 解決策   | 全アクセスパス（slice内アクション＋外部セレクタ）を網羅的に検証する                                                                              |
+| 教訓     | Zustand stateへのアクセスパスはslice内だけでなく、外部セレクタHookにも存在する。`grep -rn "viewHistory" apps/desktop/src/`で全参照を検出すること |
+| 参照     | [06-known-pitfalls.md P19](/.claude/rules/06-known-pitfalls.md)（型キャストバイパス）                                                            |
+
+#### 課題3: 多層防御の設計原則
+
+| 項目     | 内容                                                                                                                                                                 |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 課題     | どの層（hydrate/serialize/action）にガードを置くべきか判断が必要                                                                                                     |
+| 発見経緯 | TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001の設計Phase                                                                                                          |
+| 解決策   | 3層全てにガードを設置（Defense in Depth）: Store Hydrate（customStorage.getItem） → Store Serialize（customStorage.setItem） → Navigation Actions（navigationSlice） |
+| 教訓     | persist破損は予測不可能なため、1層だけのガードでは不十分。各層で独立して安全性を保証する                                                                             |
+| 参照     | [04-electron-security.md](/.claude/rules/04-electron-security.md)（多層防御原則）                                                                                    |
+
+---
+
+## 4. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] persist設定に`version: 1`が設定されている
+- [ ] `migrate`関数がv0→v1のマイグレーションを処理する
+- [ ] 破損stateからデフォルト値へのフォールバックが機能する
+- [ ] 既存のcustomStorageガードとの共存が正常動作する
+
+### 品質要件
+
+- [ ] マイグレーション関数のユニットテストが全PASS
+- [ ] 既存の全テスト（81件+α）が回帰なし
+- [ ] TypeScript型エラーなし
+- [ ] カバレッジ: Line 80%以上
+
+### ドキュメント要件
+
+- [ ] implementation-guide.md に persist versioning パターンを記載
+- [ ] arch-state-management.md にマイグレーション設計を反映
+
+---
+
+## 5. リスクと対策
+
+| リスク                                  | 影響度 | 発生確率 | 対策                                                         |
+| --------------------------------------- | ------ | -------- | ------------------------------------------------------------ |
+| 既存ユーザーのstateがv0として扱われない | 高     | 中       | version未設定時はv0とみなすデフォルト動作を確認              |
+| migrate関数内の例外でアプリ起動不能     | 高     | 低       | try-catchでデフォルトstateへフォールバック                   |
+| customStorageガードとmigrateの二重処理  | 低     | 中       | 責務境界を明確化（migrateは構造変換、customStorageは型安全） |
+
+---
+
+## 6. 参照情報
+
+### 関連ドキュメント
+
+- [arch-state-management.md](/.claude/skills/aiworkflow-requirements/references/arch-state-management.md) - 状態管理パターン
+- [06-known-pitfalls.md](/.claude/rules/06-known-pitfalls.md) - P19, P48
+- [architecture-implementation-patterns.md](/.claude/skills/aiworkflow-requirements/references/architecture-implementation-patterns.md)
+- TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001 outputs/phase-12/implementation-guide.md
+
+### 参考資料
+
+- [Zustand persist middleware - Migration](https://docs.pmnd.rs/zustand/integrations/persisting-store-data#migrate)
+
+---
+
+## 7. 備考
+
+- Zustand persist の `version` オプションは、persistされたstateのバージョンが現在のバージョンより低い場合に `migrate` を自動実行する
+- `version` 未指定時のデフォルトは `0` であるため、初回設定で `version: 1` とすれば既存stateは自動的にマイグレーション対象となる


### PR DESCRIPTION
## 概要

`TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001` の Phase 12/13 同期として、aiworkflow 系仕様書と task workflow 台帳を更新し、派生未タスク 2 件を PR に載せます。
今回の commit は runtime 実装変更ではなく、persist hardening の教訓・未タスク・PR 連携情報をレビュー可能な形に整理することが目的です。

## 変更内容

- `lessons-learned.md` に persist hardening の追補と ApiKeys contract guard 再監査教訓を統合
- `task-workflow.md` に persist hardening 完了記録、branch 横断未タスク、変更履歴を同期
- `UT-PERSIST-MIGRATION-001` と `UT-PERSIST-VALIDATION-002` の unassigned task 指示書を追加
- 新規タスク仕様書の Issue 参照済み状態を PR に反映

## 変更タイプ

- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [x] 📝 ドキュメント (documentation)
- [ ] 🧪 テスト (test)
- [ ] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test`)
- [x] 型チェック実行 (`pnpm typecheck`)
- [x] ESLint チェック実行 (`pnpm lint`)
- [x] ビルド確認 (`pnpm build`)
- [ ] 手動テスト実施

補足: ユーザーが直前に `pnpm typecheck` / `pnpm lint` / `pnpm --filter @repo/shared build` / `pnpm --filter @repo/desktop build` / `pnpm test --testTimeout=900000` を実行済みで、履歴も確認済みです。今回の commit は Markdown/タスク仕様書のみのため再実行は省略しました。

## 関連 Issue

Refs #1071, Refs #1072

## 破壊的変更

- [ ] この PR には破壊的変更が含まれます

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [ ] 新規・変更機能にテストを追加した
- [x] すべてのテストがローカルで成功する
- [x] Pre-commit hooks が成功する

## その他

- Phase 12 実装ガイド反映元: `docs/30-workflows/completed-tasks/07-TASK-FIX-SETTINGS-PERSIST-ITERABLE-HARDENING-001/outputs/phase-12/implementation-guide.md`
- 反映ポイント 1: 保存データが壊れていても設定画面遷移を止めず、安全既定値へフォールバックする方針を PR 説明に反映
- 反映ポイント 2: `expandedFolders` / `viewHistory` を `unknown` 起点で検証し、`Array.isArray` と `Set` 変換で正規化する設計意図を明記
- 反映ポイント 3: `null` / 数値 / オブジェクト / 混合配列などの edge case を仕様と未タスクへ分離した点を記載

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
