### PR TITLE
docs: issue再分解用仕様書（1179/1180/1182）を追加

### DIFF
--- a/docs/30-workflows/issues/issue-1179.md
+++ b/docs/30-workflows/issues/issue-1179.md
@@ -1,0 +1,48 @@
+# [#1179] [UT-TASK-10A-B-010] SkillAnalysisView 全自動改善確認ダイアログ UI 実装
+
+## メタ情報
+
+```yaml
+task_id: UT-TASK-10A-B-010
+task_name: SkillAnalysisView 全自動改善確認ダイアログ UI 実装
+category: 改善
+target_feature: SkillAnalysisView
+priority: 低
+scale: 小規模
+status: 未実施
+source_phase: stale issue #686 の再分解（2026-03-12）
+dependencies: []
+spec_path: docs/30-workflows/unassigned-task/task-10a-b-auto-improve-confirm-dialog.md
+```
+
+## 1. Why
+
+現行実装では SkillAnalysisView / SuggestionList / store action は存在するが、全自動改善の確認が `window.confirm` に留まっている。旧 issue #686 は「UI 全体が未実装」という前提で現状と大きくずれているため、残差分だけを再分解して管理する。
+
+## 2. What
+
+- 全自動改善前の確認ダイアログ UI を実装する
+- `window.confirm` 依存を廃止する
+- キャンセル / 実行の操作をテストで保証する
+
+## 3. Scope
+
+含むもの:
+
+- SkillAnalysisView の確認ダイアログ導線
+- 必要な local state / store 連携
+- ユニットテスト更新
+
+含まないもの:
+
+- 分析結果表示 UI 全体の再設計
+- 改善結果トースト通知
+- 成功フィードバック強化
+
+## 4. 完了条件
+
+- `window.confirm` が削除されている
+- 全自動改善前に UI ダイアログが表示される
+- 確認で autoImprove が実行される
+- キャンセルで autoImprove が実行されない
+- 関連テストが PASS する

--- a/docs/30-workflows/issues/issue-1180.md
+++ b/docs/30-workflows/issues/issue-1180.md
@@ -1,0 +1,222 @@
+# [#1180] "[UT-IMP-CHAT-PLATFORM-TRANSPORT-UNIFICATION-001] chat platform transport unification"
+
+## メタ情報
+
+```yaml
+task_id: UT-IMP-CHAT-PLATFORM-TRANSPORT-UNIFICATION-001
+task_name: chat platform transport unification
+category: 改善
+target_feature: ChatView / WorkspaceView / conversationAPI / llm stream transport
+priority: 中
+scale: 中規模
+status: 未実施
+source_phase: TASK-SKILL-LIFECYCLE-02 Phase 11-12 再監査（2026-03-12）
+created_date: 2026-03-12
+dependencies: []
+spec_path: docs/30-workflows/completed-tasks/step-02-par-task-02-chat-platform-unification-phase12-complete-20260312/unassigned-task/task-imp-chat-platform-transport-unification-001.md
+```
+
+| 項目       | 内容   |
+| ---------- | ------ |
+| 優先度     | 中     |
+| 規模       | 中規模 |
+| ステータス | 未実施 |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+TASK-SKILL-LIFECYCLE-02 では mode / handoff / revive の contract layer を `packages/shared/src/types/chat-platform.ts` へ寄せ、Workspace / Skill Lifecycle の handoff helper も current branch に同期した。一方で runtime transport はまだ二重化されている。
+
+- general chat: `chatSlice` + `useStreamingChat`
+- workspace chat: `conversationAPI.create/addMessage` + `llm.streamChat/cancelStream`
+
+### 1.2 問題点・課題
+
+- `conversationId` / `requestId` / recent rail ownership が mode ごとに別の実装へ散っている
+- revive ルールは shared contract で説明できても、transport owner が異なるため end-to-end では一つの語彙で説明できない
+- Task03 downstream から見た ChatView handoff 先が「共通 surface」なのに、内部 transport は mode 別に分岐したまま残る
+
+### 1.3 放置した場合の影響
+
+- Phase 12 で `Phase 1-12 完了` と `overall completed` を分離し続ける必要があり、Task02 を fully closed できない
+- future mode を追加するたびに transport 分岐が増え、handoff / revive guard の再利用性が落ちる
+- recent rail / session revive の責務が曖昧なまま残り、UI と persistence の不整合が再発しやすい
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+general / workspace chat の transport と persistence を一本化し、ChatView を単一の execution transport owner として説明できる状態にする。
+
+### 2.2 最終ゴール
+
+1. general chat を `conversationAPI` ベースの session lifecycle に接続する
+2. Workspace / general の `conversationId` / `requestId` / recent rail / revive ownership を一つの transport で説明できるようにする
+3. Task03 downstream から見た handoff 先を `ChatView` 単一 transport として扱えるようにする
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- `ChatView` の persistence transport 見直し
+- session create / append / revive の一本化
+- general / workspace の streaming completion path 統一
+- transport 一本化後の system spec / workflow / follow-up 台帳更新
+
+#### 含まないもの
+
+- Skill Lifecycle UI 自体の再設計
+- Main Process の provider 追加
+- general / workspace 以外の新規 chat mode 追加
+
+### 2.4 成果物
+
+- transport 統一後の session lifecycle 実装
+- general / workspace 共通の transport 回帰テスト
+- 更新済み system spec（LLM / history / state / workflow 台帳）
+- Phase 11/12 再監査証跡
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- TASK-SKILL-LIFECYCLE-02 current branch で shared contract / handoff helper / follow-up 指示書が同期済みである
+- `conversationAPI`、`chatSlice`、`useStreamingChat`、`useWorkspaceChatController` を横断して参照できる
+- `aiworkflow-requirements` と `task-specification-creator` の最新正本を参照できる
+
+### 3.2 依存タスク
+
+- TASK-SKILL-LIFECYCLE-02 会話基盤・セッション統合（Phase 1-12 完了 / overall in_progress）
+- UT-IMP-CHAT-PLATFORM-HANDOFF-REVIVE-GUARD-001（並列で進められるが、本タスクの回帰 guard と相互参照する）
+
+### 3.3 必要な知識
+
+- `chatSlice` の `chatSessions` / `activeChatSessionId` / `chatSessionOrder` / `modeSessionIds`
+- `conversationAPI` の create / append / revive 契約
+- `useWorkspaceChatController` の current local ownership
+- Phase 11 harness と recent rail / revive evidence の構成
+
+### 3.4 推奨アプローチ
+
+1. current transport owner を general / workspace / revive の3視点で棚卸しする
+2. `conversationAPI` を transport 正本に寄せるか、あるいは同等 abstraction を general 側へ導入する
+3. unified transport の結合テストを先に設計し、recent rail / revive / cancel / end を同時に固定する
+
+### 3.5 実装課題と解決策（親タスクからの教訓）
+
+| 課題                                                                     | 発見経緯                                                                                    | 解決策                                                                                                    | 教訓                                                                                 |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| shared contract が揃っても runtime owner が二重化される                  | Task02 で shared DTO を作っても AC-4 が false のまま残った                                  | DTO と transport を別レイヤーと認識し、transport owner を一本化する                                       | contract 統一だけで completed にしない                                               |
+| general / workspace で requestId と conversationId の責務が分かれている  | general は store 主導、workspace は controller 主導で ID の由来が異なる                     | create / append / revive の owner を 1 箇所へ寄せる                                                       | session lifecycle の owner は単一にする                                              |
+| current workflow と system spec の partial 注記が長く残る                | transport follow-up が formalize されるまで `in_progress` を維持した                        | この未タスクを完了させて partial 注記を外す                                                               | follow-up は system spec の本筋に戻す                                                |
+| current workflow と completed archive を混同すると統一対象の実体がぶれる | archive 側の outputs だけを見ると current code anchor と transport owner の差分が見えにくい | `workflow-chat-platform-unification.md` を起点に current workflow の code anchor / outputs を先に固定した | transport 統一タスクは current workflow 正本から設計し、archive は比較資料に限定する |
+
+### 3.6 SubAgent 分担（関心ごとの分離）
+
+| SubAgent   | 担当関心         | 主担当作業                                                 | 依存関係   |
+| ---------- | ---------------- | ---------------------------------------------------------- | ---------- |
+| SubAgent-A | transport design | general / workspace current owner 棚卸し、統一先設計       | なし       |
+| SubAgent-B | implementation   | ChatView / Workspace transport 統一実装                    | A 後       |
+| SubAgent-C | regression       | unified transport の結合テスト、recent rail / revive guard | B と並列可 |
+| SubAgent-D | spec sync        | system spec / workflow / outputs / 未タスク台帳更新        | C 後       |
+
+---
+
+## 4. 実行手順
+
+### Phase A: 現状棚卸し
+
+1. general chat と workspace chat の transport owner を比較表にする
+2. `conversationId` / `requestId` / revive owner の現状差分を明文化する
+3. Task03 downstream から見た ChatView contract を確認する
+
+### Phase B: transport 統一設計
+
+1. general 側を `conversationAPI` へ寄せるか、共通 transport abstraction を定義する
+2. recent rail / revive / cancel / end の owner を一箇所に集約する
+3. shared contract と runtime transport の責務境界を設計書へ落とす
+
+### Phase C: 実装とテスト
+
+1. unified transport を実装する
+2. general / workspace / revive の結合テストを追加する
+3. non-persist overlay reset が維持されることを確認する
+
+### Phase D: 検証と同期
+
+1. typecheck / targeted tests / Phase 11 representative screenshot を再実行する
+2. system spec / workflow / outputs / lessons / LOGS / SKILL を同一ターンで更新する
+3. Task02 の partial completion 注記を外せるか再判定する
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] general / workspace の session transport を同じ語彙で説明できる
+- [ ] `conversationId` と `requestId` の所有者が 1 箇所に揃う
+- [ ] recent rail / revive / cancel / end が unified transport 上で説明できる
+
+### 品質要件
+
+- [ ] 結合テストと targeted tests が PASS する
+- [ ] `pnpm --filter @repo/desktop typecheck` が PASS する
+- [ ] current workflow と system spec の partial implementation 注記を外せる
+
+### ドキュメント要件
+
+- [ ] `task-workflow.md` の TASK-SKILL-LIFECYCLE-02 節が completed 扱いへ更新される
+- [ ] `lessons-learned.md` に transport 一本化の教訓が追加される
+- [ ] 本未タスク指示書が completed へ移管される
+
+---
+
+## 6. 検証方法
+
+| 検証                   | 内容                                                    |
+| ---------------------- | ------------------------------------------------------- |
+| targeted vitest        | transport 統一後の session lifecycle と revive guard    |
+| typecheck              | renderer / shared contract の型整合                     |
+| Phase 11 screenshot    | general / workspace / revive の representative evidence |
+| verify-all-specs       | workflow Phase 1-12 文書整合                            |
+| audit-unassigned-tasks | current task 由来で follow-up が 0 件になったことの確認 |
+
+---
+
+## 7. リスクと対策
+
+| リスク                  | 内容                                      | 対策                                                                   |
+| ----------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
+| session migration 破壊  | 既存 general chat の recent rail が壊れる | migration fixture と revive テストを先に置く                           |
+| Workspace regression    | file context handoff が弱くなる           | workspace シナリオを dedicated test / screenshot で固定する            |
+| partial completion 再発 | 実装後も spec だけが古いまま残る          | workflow / system spec / outputs / LOGS / SKILL を同一ターンで更新する |
+
+---
+
+## 8. 参照情報
+
+- `.claude/skills/aiworkflow-requirements/references/workflow-chat-platform-unification.md`
+- `docs/30-workflows/completed-tasks/step-02-par-task-02-chat-platform-unification-phase12-complete-20260312/`
+- `docs/30-workflows/completed-tasks/step-02-par-task-02-chat-platform-unification-phase12-complete-20260312/outputs/phase-12/unassigned-task-detection.md`
+- `docs/30-workflows/completed-tasks/step-02-par-task-02-chat-platform-unification-phase12-complete-20260312/outputs/phase-12/documentation-changelog.md`
+- `docs/30-workflows/completed-tasks/step-02-par-task-02-chat-platform-unification-phase12-complete-20260312/unassigned-task/task-imp-chat-platform-handoff-revive-guard-001.md`
+- `.claude/skills/aiworkflow-requirements/references/interfaces-llm.md`
+- `.claude/skills/aiworkflow-requirements/references/interfaces-chat-history.md`
+- `.claude/skills/aiworkflow-requirements/references/arch-state-management.md`
+- `.claude/skills/aiworkflow-requirements/references/task-workflow.md`
+
+---
+
+## 9. 備考
+
+- このタスクは TASK-SKILL-LIFECYCLE-02 を overall completed に引き上げるための主要 follow-up である。
+- shared contract layer 自体は current branch で既に導入済みなので、ここでは runtime transport の一本化に集中する。
+- `artifacts.status=in_progress` の解除条件は transport owner 一本化と current workflow 側の再監査完了であり、completed archive への先行移管ではない。

--- a/docs/30-workflows/issues/issue-1182.md
+++ b/docs/30-workflows/issues/issue-1182.md
@@ -1,0 +1,275 @@
+# [#1182] "[UT-IMP-PHASE12-RELATED-UT-EXACT-COUNT-RESYNC-GUARD-001] Phase 12 related UT exact count 再同期ガード"
+
+## メタ情報
+
+```yaml
+task_id: UT-IMP-PHASE12-RELATED-UT-EXACT-COUNT-RESYNC-GUARD-001
+task_name: Phase 12 related UT exact count 再同期ガード
+category: 改善
+target_feature: Phase 12 related unassigned task migration / verify-unassigned-links exact count resync
+priority: 中
+scale: 小規模
+status: 未実施
+source_phase: UT-IMP-WORKSPACE-PARENT-REFERENCE-SWEEP-GUARD-001 Phase 12 追補監査（2026-03-12）
+created_date: 2026-03-12
+dependencies: []
+spec_path: docs/30-workflows/unassigned-task/task-imp-phase12-related-ut-exact-count-resync-guard-001.md
+```
+
+| 項目       | 内容   |
+| ---------- | ------ |
+| 優先度     | 中     |
+| 規模       | 小規模 |
+| ステータス | 未実施 |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+`UT-IMP-WORKSPACE-PARENT-REFERENCE-SWEEP-GUARD-001` の Phase 12 再確認で、related unassigned row を completed 実績へ移した直後に `verify-unassigned-links` の exact count が古いまま残る問題を確認した。  
+当時は row 移動後に再実行して `219 / 219` へ是正したが、その後に follow-up 未タスクを 1 件 formalize すると current exact count は再び `220 / 220` へ変わるため、summary / workflow spec / task-workflow / detection report の同値転記ルールを別タスクとして固定する必要がある。
+
+### 1.2 問題点・課題
+
+- related UT の row を moved/closed した後に exact count を再取得しないと、`220 / 220` や `219 / 219` が文書ごとに食い違う。
+- `verify-unassigned-links.js` の既定 source は `.agents/skills/aiworkflow-requirements/references/task-workflow.md` なので、`.claude` 正本だけ更新しても mirror sync 前は件数が変わらない。
+- `task-workflow.md` / `workflow spec` / `outputs/phase-12/*.md` のどれか 1 箇所だけ更新すると、同種課題で再監査コストが増える。
+
+### 1.3 放置した場合の影響
+
+- Phase 12 の「exact count を再同期した」という記録自体が再び stale になる。
+- 同種タスクで row 移動のたびに count 差分調査をやり直し、短手順化できない。
+- `.claude` と `.agents` の source 差分が count 不整合として見え、原因切り分けが難しくなる。
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+related UT を completed 実績へ移した後、exact count の再取得から `.claude` / `.agents` 同期、system spec / workflow outputs への同値転記までを 1 手順に固定する。
+
+### 2.2 最終ゴール
+
+1. related UT の moved/closed 後に再実行すべきコマンド順が固定されている。
+2. `task-workflow.md` / `workflow-workspace-parent-reference-sweep-guard.md` / `outputs/phase-12/*.md` の exact count が同値になる。
+3. `.claude` 正本と `.agents` mirror の count source 差分を `rsync + diff -qr` で即座に検知できる。
+4. 同種課題を 5 分程度で閉じる短手順が `aiworkflow-requirements` と未タスク指示書に残る。
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- related UT moved/closed 後の exact count 再取得手順
+- `.claude` 正本更新後の `.agents` mirror sync 手順
+- `task-workflow.md` / workflow spec / Phase 12 outputs の同値転記ルール
+- 検証コマンドと grep 確認手順の標準化
+
+#### 含まないもの
+
+- `verify-unassigned-links.js` 本体の機能拡張
+- legacy baseline 134 件の一括解消
+- unrelated workflow の Phase 12 再監査
+
+### 2.4 成果物
+
+- 本未タスク指示書
+- exact count 再同期ルールを追記した system spec
+- current workflow の更新済み `unassigned-task-detection.md` / `spec-update-summary.md`
+- 検証ログ（`verify-unassigned-links` / `audit` / `diff -qr`）
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- `task-workflow.md` に root `docs/30-workflows/unassigned-task/*.md` への参照が存在する。
+- `.claude/skills/aiworkflow-requirements/` を正本として更新できる。
+- `rsync`、`diff -qr`、`verify-unassigned-links.js`、`audit-unassigned-tasks.js` を実行できる。
+
+### 3.2 依存タスク
+
+- `UT-IMP-WORKSPACE-PARENT-REFERENCE-SWEEP-GUARD-001`
+- `UT-IMP-PHASE12-EVIDENCE-VALUE-SYNC-GUARD-001`
+
+### 3.3 必要な知識
+
+- `.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md`
+- `.claude/skills/aiworkflow-requirements/references/task-workflow.md`
+- `.claude/skills/aiworkflow-requirements/references/lessons-learned.md`
+- `.claude/skills/aiworkflow-requirements/references/workflow-workspace-parent-reference-sweep-guard.md`
+- `.claude/skills/task-specification-creator/scripts/verify-unassigned-links.js`
+
+### 3.4 推奨アプローチ
+
+1. related UT row を moved/closed した直後に `verify-unassigned-links` を再実行し、exact count の current 値を先に確定する。
+2. `.claude` 更新後に `.agents` へ mirror sync し、既定 source でも同じ count が出ることを確認する。
+3. `task-workflow.md` / workflow spec / Phase 12 outputs を同一ターンで更新し、grep で同値確認する。
+
+### 3.5 実装課題と解決策（親タスクからの教訓）
+
+| 課題                                                                           | 発見経緯                                                                                                | 解決策                                                                                                                                                  | 教訓                                                            |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| related UT row を completed 実績へ移した後に exact count が stale になる       | `UT-IMP-WORKSPACE-PARENT-REFERENCE-SWEEP-GUARD-001` の Phase 12 再確認で `220 / 220` が一部文書に残った | row 移動後に `verify-unassigned-links` を再実行し、count を `task-workflow.md` / workflow spec / `outputs/phase-12/*.md` へ同値転記する                 | row 移動と count 再取得を別ターンにしない                       |
+| `.claude` 更新後も `verify-unassigned-links` の結果が変わらない                | script の既定 source が `.agents/.../task-workflow.md` だった                                           | `.claude` 更新後に `rsync -a .claude/skills/aiworkflow-requirements/ .agents/skills/aiworkflow-requirements/` を実行し、`diff -qr` で差分なしを確認した | exact count 監査は canonical root 更新だけでは閉じない          |
+| detection report は 0件のまま、system spec だけ follow-up を持つ不整合が起きる | 新規未タスクを formalize しても `unassigned-task-detection.md` を更新し忘れやすい                       | Phase 12 outputs に「新規未タスク 1 件」と target-file audit を追記した                                                                                 | 未タスク formalize 時は detection report も同一ターンで更新する |
+
+### 3.6 SubAgent 分担
+
+| SubAgent   | 関心ごと                     | 主担当成果物                                                                 |
+| ---------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| SubAgent-A | count source / command order | 再取得コマンド順、grep チェック手順                                          |
+| SubAgent-B | system spec sync             | `task-workflow.md` / `lessons-learned.md` / workflow spec の related UT 同期 |
+| SubAgent-C | mirror / validation          | `rsync` / `diff -qr` / `verify-unassigned-links` / `audit` 記録              |
+
+## 4. 実行手順
+
+### Phase構成
+
+- Phase A: count source の確定
+- Phase B: related UT 同期
+- Phase C: mirror sync と検証
+
+### Phase A: count source の確定
+
+#### 目的
+
+related UT moved/closed 後の exact count を 1 回で確定する。
+
+#### 手順
+
+1. related UT row の moved/closed を反映する。
+2. `node .claude/skills/task-specification-creator/scripts/verify-unassigned-links.js --source .claude/skills/aiworkflow-requirements/references/task-workflow.md` を実行する。
+3. current count を `task-workflow.md` / workflow spec / Phase 12 outputs に転記する。
+
+#### 成果物
+
+- current exact count
+- 更新対象一覧
+
+#### 完了条件
+
+- `.claude` 正本で current exact count が 1 値に確定している。
+
+### Phase B: related UT 同期
+
+#### 目的
+
+exact count と follow-up UT を system spec / outputs へ同値反映する。
+
+#### 手順
+
+1. `task-workflow.md` に related 未タスク row を追加する。
+2. `workflow-workspace-parent-reference-sweep-guard.md` と `lessons-learned.md` に同 UT を追加する。
+3. `unassigned-task-detection.md` / `spec-update-summary.md` / `phase12-task-spec-compliance-check.md` を current count へ更新する。
+
+#### 成果物
+
+- 更新済み system spec
+- 更新済み Phase 12 outputs
+
+#### 完了条件
+
+- related UT と exact count が対象文書で一致している。
+
+### Phase C: mirror sync と検証
+
+#### 目的
+
+`.claude` と `.agents` の source 差分による count 不整合を除去する。
+
+#### 手順
+
+1. `node .claude/skills/aiworkflow-requirements/scripts/generate-index.js` を実行する。
+2. `rsync -a .claude/skills/aiworkflow-requirements/ .agents/skills/aiworkflow-requirements/` を実行する。
+3. `diff -qr .claude/skills/aiworkflow-requirements .agents/skills/aiworkflow-requirements` を実行する。
+4. `node .claude/skills/task-specification-creator/scripts/verify-unassigned-links.js` と `audit-unassigned-tasks.js --json --diff-from HEAD --target-file ...` を実行する。
+
+#### 成果物
+
+- index 再生成結果
+- mirror sync 記録
+- 検証ログ
+
+#### 完了条件
+
+- `verify-unassigned-links` が source 既定値でも PASS し、target-file audit の `currentViolations.total = 0` を満たす。
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] related UT moved/closed 後の exact count 再取得順が明文化されている
+- [ ] `task-workflow.md` / workflow spec / Phase 12 outputs の exact count が一致している
+- [ ] new follow-up UT が `docs/30-workflows/unassigned-task/` に配置されている
+
+### 品質要件
+
+- [ ] `.claude` と `.agents` の `diff -qr` が差分なし
+- [ ] `verify-unassigned-links` が PASS
+- [ ] `audit-unassigned-tasks --json --diff-from HEAD --target-file docs/30-workflows/unassigned-task/task-imp-phase12-related-ut-exact-count-resync-guard-001.md` で `currentViolations.total = 0`
+
+### ドキュメント要件
+
+- [ ] `task-workflow.md` に関連未タスクとして登録されている
+- [ ] `lessons-learned.md` に関連未タスクとして登録されている
+- [ ] `workflow-workspace-parent-reference-sweep-guard.md` と Phase 12 outputs に current count が反映されている
+
+## 6. 検証方法
+
+### テストケース
+
+- Case 1: related UT row moved/closed 後に current count が 1 値へ再同期される
+- Case 2: `.claude` のみ更新した状態では `.agents` 既定 source が stale になり、mirror sync 後に解消される
+- Case 3: 新規未タスク追加後も `audit --target-file` の `currentViolations.total = 0` を維持できる
+- Case 4: 対象文書群の exact count 表記を grep で横断確認できる
+
+### 検証手順
+
+```bash
+node .claude/skills/aiworkflow-requirements/scripts/generate-index.js
+rsync -a .claude/skills/aiworkflow-requirements/ .agents/skills/aiworkflow-requirements/
+diff -qr .claude/skills/aiworkflow-requirements .agents/skills/aiworkflow-requirements
+node .claude/skills/task-specification-creator/scripts/verify-unassigned-links.js --source .claude/skills/aiworkflow-requirements/references/task-workflow.md
+node .claude/skills/task-specification-creator/scripts/verify-unassigned-links.js
+node .claude/skills/task-specification-creator/scripts/audit-unassigned-tasks.js --json --diff-from HEAD --target-file docs/30-workflows/unassigned-task/task-imp-phase12-related-ut-exact-count-resync-guard-001.md
+rg -n "220 / 220|total 220 / missing 0|UT-IMP-PHASE12-RELATED-UT-EXACT-COUNT-RESYNC-GUARD-001" \
+  .claude/skills/aiworkflow-requirements/references/task-workflow.md \
+  .claude/skills/aiworkflow-requirements/references/workflow-workspace-parent-reference-sweep-guard.md \
+  docs/30-workflows/completed-tasks/workspace-parent-reference-sweep-guard/outputs/phase-12
+```
+
+## 7. リスクと対策
+
+| リスク                                                      | 影響度 | 発生確率 | 対策                                                                                |
+| ----------------------------------------------------------- | ------ | -------- | ----------------------------------------------------------------------------------- |
+| exact count を 1 文書だけ更新して不整合が残る               | 高     | 中       | 更新対象を `task-workflow` / workflow spec / Phase 12 outputs の 3 系統で固定する   |
+| `.claude` 正本と `.agents` mirror の差分で count が食い違う | 高     | 中       | `rsync + diff -qr` を必須手順にする                                                 |
+| baseline backlog を今回差分 fail と誤認する                 | 中     | 中       | `audit --diff-from HEAD` の `current` を合否、`baseline` を監視値として分離記録する |
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md`
+- `.claude/skills/aiworkflow-requirements/references/task-workflow.md`
+- `.claude/skills/aiworkflow-requirements/references/lessons-learned.md`
+- `.claude/skills/aiworkflow-requirements/references/workflow-workspace-parent-reference-sweep-guard.md`
+- `docs/30-workflows/completed-tasks/workspace-parent-reference-sweep-guard/outputs/phase-12/unassigned-task-detection.md`
+
+### 参考資料
+
+- `.claude/skills/task-specification-creator/scripts/verify-unassigned-links.js`
+- `.claude/skills/task-specification-creator/scripts/audit-unassigned-tasks.js`
+
+## 9. 備考
+
+### レビュー指摘の原文（該当する場合）
+
+```text
+related unassigned row を completed 実績へ移した後に exact count が stale になる。
+row 移動後の再実行、mirror sync、summary/system spec への同値転記を 1 手順として固定する。
+```
+
+### 補足事項
+
+このタスクは `verify-unassigned-links.js` の既定 source が `.agents/.../task-workflow.md` であることを前提に、count source の切り替わりを誤解しない運用ガードを目的とする。


### PR DESCRIPTION
## 概要

remote/main を取り込み完了した state に、残存していた未実施タスクの要件化イシュー（1179, 1180, 1182）を追加し、運用継続に必要な Issue 文言を揃えました。

## 変更内容

- docs/30-workflows/issues/issue-1179.md を追加
- docs/30-workflows/issues/issue-1180.md を追加
- docs/30-workflows/issues/issue-1182.md を追加

## 変更タイプ

- [x] 📝 ドキュメント (documentation)

## テスト

- [x] 型チェック実行 (`pnpm typecheck`) ※直前実行ログ継続有効
- [x] ESLint チェック実行 (`pnpm lint`) ※直前実行ログ継続有効
- [ ] ユニットテスト実行 (`pnpm test`)
- [ ] ビルド確認 (`pnpm build`)
- [ ] 手動テスト実施

## 関連 Issue

- status: 未実施（ローカルワークフロー再同期分）

Closes #

## 破壊的変更

- [ ] この PR には破壊的変更が含まれます

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [ ] 新規・変更機能にテストを追加した
- [x] すべてのテストがローカルで成功する
- [x] Pre-commit hooks が成功する

## その他

- Phase 12 実装ガイド反映元: `docs/30-workflows/completed-tasks/workspace-parent-reference-sweep-guard/outputs/phase-12/implementation-guide.md`
- 反映ポイント: 旧 Issue 管理差分の再分解（UI/実装変更なし）を中心に、Task/Issue同期対象を明示
- 追加はドキュメント再同期の最小差分で、UI/UX変更はありません。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
