### PR TITLE
docs(spec): onboarding wizard follow-up task を同期

### DIFF
--- a/.claude/skills/aiworkflow-requirements/references/lessons-learned.md
+++ b/.claude/skills/aiworkflow-requirements/references/lessons-learned.md
@@ -525,11 +525,11 @@
 
 #### 同種課題の簡潔解決手順（5ステップ）
 
-1. UIタスクの preflight で install / port / screenshot script を先に確認する。  
-2. timeline UI は initial loading / load more / empty を別 state で設計する。  
-3. cross-view 導線は `pending payload + view 遷移` の二段構成に分離する。  
-4. screenshot script は一意 selector を ready condition にする。  
-5. Phase 12 では `.claude` 正本、domain spec、workflow outputs、未タスク、skill docs を同一ターンで同期する。  
+1. UIタスクの preflight で install / port / screenshot script を先に確認する。
+2. timeline UI は initial loading / load more / empty を別 state で設計する。
+3. cross-view 導線は `pending payload + view 遷移` の二段構成に分離する。
+4. screenshot script は一意 selector を ready condition にする。
+5. Phase 12 では `.claude` 正本、domain spec、workflow outputs、未タスク、skill docs を同一ターンで同期する。
 
 ### 2026-03-10 TASK-10A-G 再監査追補
 
@@ -1299,11 +1299,11 @@ expect(element.className).toContain(statusStyles.primary);
 
 ### 同種課題の簡潔解決手順（5ステップ）
 
-1. Utility action を追加したら `ui-ux-components` / `ui-ux-feature-components` / `ui-ux-navigation` / `ui-ux-portal-patterns` の4入口を先に洗い出す。  
-2. Phase 11 文書は `テストケース` / `画面カバレッジマトリクス` / `証跡` 列を literal で揃える。  
-3. destructive affordance は screenshot を 1枚追加して、通常状態との差を目視で確認する。  
-4. `validate-phase11-screenshot-coverage` / `verify-unassigned-links` / `validate-phase-output` を同一ターンで回す。  
-5. 最後に `task-workflow.md` と `lessons-learned.md` に再発条件付きで転記し、再監査の入口を閉じる。  
+1. Utility action を追加したら `ui-ux-components` / `ui-ux-feature-components` / `ui-ux-navigation` / `ui-ux-portal-patterns` の4入口を先に洗い出す。
+2. Phase 11 文書は `テストケース` / `画面カバレッジマトリクス` / `証跡` 列を literal で揃える。
+3. destructive affordance は screenshot を 1枚追加して、通常状態との差を目視で確認する。
+4. `validate-phase11-screenshot-coverage` / `verify-unassigned-links` / `validate-phase-output` を同一ターンで回す。
+5. 最後に `task-workflow.md` と `lessons-learned.md` に再発条件付きで転記し、再監査の入口を閉じる。
 
 ---
 
@@ -7435,3 +7435,56 @@ function getAuthState(isTimedOut: boolean, isLoading: boolean, isAuthenticated: 
 | 未タスクID | 目的 | タスク仕様書 |
 | --- | --- | --- |
 | UT-IMP-WORKSPACE-PREVIEW-SEARCH-RESILIENCE-GUARD-001 | Workspace Preview / QuickFileSearch の fuzzy no-match、renderer timeout+retry、parse/transport 分離を共通ガードへ昇格し、次回類似タスクの初動を短縮する | `docs/30-workflows/unassigned-task/task-imp-workspace-preview-search-resilience-guard-001.md` |
+
+## TASK-UI-09-ONBOARDING-WIZARD 実装教訓（2026-03-13）
+
+### 苦戦箇所: onboarding completed flag と rerun handoff が分離しやすい
+
+| 項目 | 内容 |
+| --- | --- |
+| 課題 | completed flag の reset と view handoff を別イベントとして扱うと、rerun しても overlay が期待通り再表示されない |
+| 再発条件 | Settings 側と onboarding 側が同じ責務を持つ |
+| 対処 | Settings は `onboarding.completed=false` の reset と dashboard handoff だけを担当し、表示条件判定は onboarding 側に残した |
+| 標準ルール | rerun 導線は「reset 起点」と「表示判定」を分離する |
+
+### 苦戦箇所: representative screenshot の名前と matrix がずれる
+
+| 項目 | 内容 |
+| --- | --- |
+| 課題 | screenshot 実体名、manual result、coverage matrix の命名が揃っていないと validator が通らない |
+| 再発条件 | 画像を先に撮って後から TC 台帳を書く |
+| 対処 | `TC-11-01..05` を `screenshots/*.png` と 1 対 1 で同期し、非視覚 TC は matrix から分離した |
+| 標準ルール | 画面検証を要求された UI は `phase-11-manual-test.md` の matrix を最初に正す |
+
+### 苦戦箇所: warning / coverage 不足が「あとで直す」で埋もれる
+
+| 項目 | 内容 |
+| --- | --- |
+| 課題 | `act(...)` warning や function coverage 76.92% を本体 report の末尾に残すだけだと、次回に継承されにくい |
+| 再発条件 | Phase 12 で MINOR の formalize 判断をしない |
+| 対処 | test hardening task と discoverability task の 2 件へ切り分けた |
+| 標準ルール | MINOR は「report」「system spec」「unassigned task」の3面同期を取る |
+
+### 苦戦箇所: Settings rerun card は isolated では明快でも page 全体では埋もれる
+
+| 項目 | 内容 |
+| --- | --- |
+| 課題 | 機能としては完成していても、full settings page で card が fold 下へ落ちやすい |
+| 再発条件 | representative surface だけで UI 完了判定を出す |
+| 対処 | 実装完了は維持しつつ、IA 改善は follow-up backlog として分離した |
+| 標準ルール | 「動くが見つけにくい」問題は discoverability task に分ける |
+
+### 同種課題の5分解決カード
+
+1. rerun は `persist reset` と `display condition` の責務を分離する。
+2. screenshot 取得前に `TC-ID ↔ screenshots/*.png` の台帳を決める。
+3. 非視覚 TC は visual matrix に混ぜない。
+4. warning / coverage 不足は Phase 12 で必ず formalize 判断する。
+5. 動作完了と discoverability 改善は別タスクとして扱う。
+
+### 関連未タスク
+
+| 未タスクID | 目的 | タスク仕様書 |
+| --- | --- | --- |
+| UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001 | Onboarding test harness、coverage、`act(...)` warning を hardening する | `docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md` |
+| UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001 | Settings rerun card の情報設計を改善する | `docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md` |

--- a/.claude/skills/aiworkflow-requirements/references/task-workflow.md
+++ b/.claude/skills/aiworkflow-requirements/references/task-workflow.md
@@ -4913,6 +4913,7 @@ find docs/30-workflows/unassigned-task -maxdepth 1 -name 'task-10a-b-*.md' | wc 
 | **1.45.0** | **2026-02-21** | **UT-FIX-SKILL-IMPORT-RETURN-TYPE-001登録**: skill:import IPCハンドラ戻り値型不整合修正タスクを残課題テーブルに追加。20フレームワーク多角的分析で発見されたImportResult→ImportedSkill変換漏れの修正 |
 | **1.44.0** | **2026-02-20** | **UT-FIX-SKILL-REMOVE-INTERFACE-001派生未タスク2件登録**: UT-FIX-SKILL-VALIDATION-P42-001（P42バリデーション横展開）、UT-FIX-SKILL-IPC-ERROR-RESPONSE-001（エラー応答パターン統一）を残課題テーブルに追加。実装苦戦箇所（P23/P42/P44/P45）を未タスク指示書に反映 |
 | **1.43.0** | **2026-02-20** | **未タスク配置ディレクトリ整合を是正**: 未実施タスク（task-imp-vitest-alias-sync-automation-001 / UT-9A-B-001〜003）の参照先を `docs/30-workflows/unassigned-task/` に統一。完了済み UT-9B-H-003 の参照を `completed-tasks/ut-9b-h-003-security-hardening/index.md` に更新。`verify-unassigned-links.js` で再検証 |
+| **1.44.0** | **2026-03-13** | **TASK-UI-09-ONBOARDING-WIZARD を反映**: Onboarding Wizard の初回オーバーレイ、multi-step 導線、Settings rerun、Phase 11 screenshot 5件、検証値 `13/13 phases` / `28項目` / `TC 5/5` / `currentViolations 0` を追加。実装時の苦戦箇所 4 件と follow-up 未タスク 2 件を formalize した |
 | **1.43.0** | **2026-02-20** | **未タスク2件登録**: TASK-REFACTOR-SHARED-SOURCE-STRUCTURE-001（@repo/shared ソース構造二重性統一、中優先度）、TASK-IMP-MODULE-RESOLUTION-CI-GUARD-001（3層整合CIガード、高優先度）をP3準拠で残課題テーブルに追加。architecture-monorepo.mdに参照リンク追加 |
 | **1.42.1** | **2026-02-20** | **TASK-FIX-TS-SHARED-MODULE-RESOLUTION-001記録強化**: 完了タスク記録に品質ゲート達成状況テーブル（typecheck 228→0、vitest 224/224 PASS、shared build成功、lint PASS）、変更ファイル詳細（tsconfig +27 paths、package.json +26 typesVersions、vitest.config +3 alias）、変更行数（+353行/17ファイル）、テスト数（224テスト/3スイート）を追記。残課題 UT-FIX-TS-VITEST-TSCONFIG-PATHS-001 の説明を詳細化（背景・提案解決策・スコープ追記） |
 | **1.42.0** | **2026-02-20** | **UT-FIX-SKILL-REMOVE-INTERFACE-001完了反映**: 残課題テーブルの同タスクを完了（取り消し線 + 完了日）へ更新。参照先を `skill-import-agent-system/tasks/completed-task/` に変更。UT-FIX-SKILL-IMPORT-INTERFACE-001 の参照先も実ファイルパスへ修正 |
@@ -5032,3 +5033,48 @@ find docs/30-workflows/unassigned-task -maxdepth 1 -name 'task-10a-b-*.md' | wc 
 - `docs/30-workflows/completed-tasks/TASK-FIX-SAFEINVOKE-TIMEOUT-001/unassigned-task/task-imp-preload-skill-creator-api-safeinvoke-timeout-001.md`
 - `docs/30-workflows/completed-tasks/TASK-FIX-SAFEINVOKE-TIMEOUT-001/unassigned-task/task-fix-settings-light-theme-contrast-001.md`
 - `docs/30-workflows/completed-tasks/TASK-FIX-SAFEINVOKE-TIMEOUT-001/unassigned-task/task-fix-accountsection-linked-provider-key-warning-001.md`
+
+## TASK-UI-09-ONBOARDING-WIZARD 完了記録（2026-03-13）
+
+### 実装内容（要点）
+
+| 観点 | 内容 | 反映先 |
+| --- | --- | --- |
+| 初回導線 | 初回起動時に Onboarding Wizard をオーバーレイ表示し、完了後は通常画面へ戻す | `OnboardingGate` / workflow `docs/30-workflows/task-061-ui-09-onboarding-wizard/` |
+| multi-step 体験 | desktop / tablet / mobile / theme 差分を representative screenshot で確認できる multi-step 導線を用意 | `outputs/phase-11/screenshots/TC-11-01..05` |
+| Settings rerun | Settings から `onboarding.completed=false` へ戻し、dashboard に handoff して wizard を再表示できるようにした | `apps/desktop/src/renderer/views/SettingsView/index.tsx` |
+| Phase 12 同期 | implementation-guide / spec-update-summary / documentation-changelog / unassigned-task-detection / skill-feedback-report / compliance-check を揃えた | `outputs/phase-12/` |
+
+### 検証証跡
+
+| 項目 | 結果 |
+| --- | --- |
+| `verify-all-specs.js --workflow docs/30-workflows/task-061-ui-09-onboarding-wizard --json` | `13/13 phases pass`, `errors=0`, `warnings=0` |
+| `validate-phase-output.js docs/30-workflows/task-061-ui-09-onboarding-wizard` | `28項目 pass`, `0 error`, `0 warning` |
+| `validate-phase11-screenshot-coverage.js --workflow docs/30-workflows/task-061-ui-09-onboarding-wizard` | `expected TC=5`, `covered TC=5`, `PASS` |
+| `verify-unassigned-links.js` | `existing=216`, `missing=0` |
+| `audit-unassigned-tasks.js --json --diff-from HEAD` | `currentViolations=0`, `baselineViolations=134` |
+
+### 苦戦箇所（再発条件付き）
+
+| 苦戦箇所 | 再発条件 | 対処 | 標準ルール |
+| --- | --- | --- | --- |
+| 完了状態と rerun の handoff がずれる | `onboarding.completed` の reset と view handoff を別々に扱う | flag reset と dashboard handoff を一連の操作として扱った | rerun は「persist reset → handoff → overlay 再表示」を 1 契約として記録する |
+| representative screenshot と台帳名がずれる | matrix / result / png 実体を別命名で管理する | `TC-ID ↔ screenshots/*.png` を再同期した | 画面検証を求められた UI は coverage matrix を正本にする |
+| テスト warning と coverage 不足を本体タスクへ抱え込みやすい | `act(...)` warning と function coverage 76.92% を report 止まりで残す | follow-up 2 件へ formalize した | MINOR は report だけで終わらせず unassigned task へ昇格する |
+| Settings 内 rerun card の発見性が落ちる | isolated screenshot だけで UI 完了判定を出す | Settings 導線の discoverability を別 backlog 化した | 動作するが見つけにくい UI は IA 改善タスクとして切り出す |
+
+### 同種課題の5分解決カード
+
+1. `onboarding.completed` の保存キーと表示条件を先に固定する。
+2. rerun は flag reset と dashboard handoff を同一操作として設計する。
+3. Phase 11 は `TC-ID ↔ screenshots/*.png` を coverage matrix で固定する。
+4. `verify-all-specs` / `validate-phase-output` / `validate-phase11-screenshot-coverage` / `audit --diff-from HEAD` を同一ターンで記録する。
+5. `act(...)` warning、coverage 不足、discoverability のような MINOR は unassigned task に formalize する。
+
+### 関連未タスク
+
+| 未タスクID | 概要 | 参照 |
+| --- | --- | --- |
+| UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001 | function coverage / `act(...)` warning / harness hardening を統合して改善する | `docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md` |
+| UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001 | Settings 内 rerun card の配置・文言・導線の発見性を改善する | `docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md` |

--- a/.claude/skills/aiworkflow-requirements/references/ui-ux-feature-components.md
+++ b/.claude/skills/aiworkflow-requirements/references/ui-ux-feature-components.md
@@ -1162,10 +1162,10 @@ AgentView の「実行」責務と分離し、ツールの探索・追加・詳�
 
 ### 同種課題の簡潔解決手順（4ステップ）
 
-1. UI責務を `view / organism / molecule / hook` に分解し、拡張点を先に決める。  
-2. 未タスク候補を `docs/30-workflows/unassigned-task/` に分離登録する。  
-3. `verify-unassigned-links` と `audit --target-file` で参照と形式を機械確認する。  
-4. `task-workflow.md` と `lessons-learned.md` に苦戦箇所を同一ターンで同期する。  
+1. UI責務を `view / organism / molecule / hook` に分解し、拡張点を先に決める。
+2. 未タスク候補を `docs/30-workflows/unassigned-task/` に分離登録する。
+3. `verify-unassigned-links` と `audit --target-file` で参照と形式を機械確認する。
+4. `task-workflow.md` と `lessons-learned.md` に苦戦箇所を同一ターンで同期する。
 
 ### 関連ドキュメント
 
@@ -1227,11 +1227,11 @@ UI 実装コード・IPC 統合・自動テスト・画面検証証跡を正本�
 
 ### 同種課題の簡潔解決手順（5ステップ）
 
-1. 更新対象を 1仕様書=1SubAgent で分割し、担当責務を先に固定する。  
-2. `verify-all-specs` と `validate-phase-output` を実行し、warning/error の根拠を抽出する。  
-3. Phase 12 文書の参照資料に依存Phase成果物を追加して再検証する。  
-4. UI画面はスクリーンショットを再撮影し、更新時刻で当日証跡を固定する。  
-5. 未タスク監査結果は `current` を合否、`baseline` を改善バックログとして分離記録する。  
+1. 更新対象を 1仕様書=1SubAgent で分割し、担当責務を先に固定する。
+2. `verify-all-specs` と `validate-phase-output` を実行し、warning/error の根拠を抽出する。
+3. Phase 12 文書の参照資料に依存Phase成果物を追加して再検証する。
+4. UI画面はスクリーンショットを再撮影し、更新時刻で当日証跡を固定する。
+5. 未タスク監査結果は `current` を合否、`baseline` を改善バックログとして分離記録する。
 
 ### 実装着手前のガード条件
 
@@ -1312,11 +1312,11 @@ TASK-10A-B で `SkillAnalysisView`（分析結果の可視化と改善操作UI�
 
 ### 同種課題の簡潔解決手順（5ステップ）
 
-1. 画面証跡を先に再取得し、`outputs/phase-11/screenshots` を更新する。  
-2. `manual-test-result` と `discovered-issues` を実証跡ベースに書き換える。  
-3. `verify-all-specs` と `validate-phase-output` を実行し、不足セクションを埋める。  
-4. 未タスク台帳（作成済みID）を再計算し、`task-workflow.md` と同期する。  
-5. 苦戦箇所を `lessons-learned.md` に転記して再利用ルール化する。  
+1. 画面証跡を先に再取得し、`outputs/phase-11/screenshots` を更新する。
+2. `manual-test-result` と `discovered-issues` を実証跡ベースに書き換える。
+3. `verify-all-specs` と `validate-phase-output` を実行し、不足セクションを埋める。
+4. 未タスク台帳（作成済みID）を再計算し、`task-workflow.md` と同期する。
+5. 苦戦箇所を `lessons-learned.md` に転記して再利用ルール化する。
 
 ### 関連未タスク（active set）
 
@@ -1504,11 +1504,11 @@ TASK-UI-00-ORGANISMS で、Renderer横断で再利用する Organisms 3コンポ
 
 ### 同種課題の最短解決テンプレート（5分）
 
-1. `verify-all-specs` と `validate-phase-output` で構造合否を先に確定する。  
-2. UI再撮影を実行し、`validate-phase11-screenshot-coverage` をPASSさせる。  
-3. `stat` 時刻を `manual-test-result.md` と仕様書へ同期する。  
-4. `verify-unassigned-links` と `audit --diff-from HEAD` を連続実行し、`currentViolations=0` を合否に使う。  
-5. `task-workflow.md` / `lessons-learned.md` へ実装内容・苦戦箇所・検証値を同時転記する。  
+1. `verify-all-specs` と `validate-phase-output` で構造合否を先に確定する。
+2. UI再撮影を実行し、`validate-phase11-screenshot-coverage` をPASSさせる。
+3. `stat` 時刻を `manual-test-result.md` と仕様書へ同期する。
+4. `verify-unassigned-links` と `audit --diff-from HEAD` を連続実行し、`currentViolations=0` を合否に使う。
+5. `task-workflow.md` / `lessons-learned.md` へ実装内容・苦戦箇所・検証値を同時転記する。
 
 ### 関連未タスク（2026-03-04 追補）
 
@@ -1653,11 +1653,11 @@ UI基盤反映監査タスクで、Task 5D語彙具体例と Task 5B適用境界
 
 ### 同種課題の5分解決カード
 
-1. 画面の主目的を「検索画面」ではなく「読む timeline」として先に固定する。  
-2. `hasFetchedHistory` と `isHistoryLoadingMore` を分け、初回/追補/空状態を混同しない。  
-3. cross-view 導線は `pending payload + view 遷移` の二段構成にする。  
-4. screenshot script は一意 selector または `data-testid` を ready condition にする。  
-5. `.claude` 正本、workflow outputs、未タスク、skill docs を同一ターンで同期する。  
+1. 画面の主目的を「検索画面」ではなく「読む timeline」として先に固定する。
+2. `hasFetchedHistory` と `isHistoryLoadingMore` を分け、初回/追補/空状態を混同しない。
+3. cross-view 導線は `pending payload + view 遷移` の二段構成にする。
+4. screenshot script は一意 selector または `data-testid` を ready condition にする。
+5. `.claude` 正本、workflow outputs、未タスク、skill docs を同一ターンで同期する。
 
 ### 関連未タスク
 
@@ -1959,6 +1959,44 @@ TASK-UI-05A-SKILL-EDITOR-VIEW は、SkillEditorView の Phase 1-13 仕様書作�
 
 ## 関連ドキュメント
 
+## Onboarding Wizard UI（TASK-UI-09-ONBOARDING-WIZARD）
+
+### 実装内容（要点）
+
+| 観点 | 内容 |
+| --- | --- |
+| surface | 初回起動時に前面表示される Onboarding Wizard overlay を追加 |
+| flow | multi-step で基本導線を案内し、完了後は通常画面へ復帰する |
+| rerun | Settings の `はじめよう` card から `はじめようを再表示` を実行できる |
+| persist | `onboarding.completed` により再表示抑制と rerun reset を制御する |
+
+### 画面証跡
+
+| TC | 証跡 | 確認内容 |
+| --- | --- | --- |
+| TC-11-01 | `outputs/phase-11/screenshots/TC-11-01-desktop-step1-light.png` | desktop light で Step 1 表示 |
+| TC-11-02 | `outputs/phase-11/screenshots/TC-11-02-tablet-step3-dark.png` | tablet dark で中盤 step 表示 |
+| TC-11-03 | `outputs/phase-11/screenshots/TC-11-03-mobile-step4-kanagawa.png` | mobile kanagawa で最終 step 表示 |
+| TC-11-04 | `outputs/phase-11/screenshots/TC-11-04-settings-rerun-entry-dark.png` | Settings rerun card の表示 |
+| TC-11-05 | `outputs/phase-11/screenshots/TC-11-05-settings-rerun-triggered-dark.png` | rerun 実行後の overlay 表示 |
+
+### 苦戦箇所（再利用形式）
+
+| 苦戦箇所 | 内容 | 解決方針 |
+| --- | --- | --- |
+| overlay と通常画面の境界 | 完了時に overlay を閉じた後の戻り先が曖昧になりやすい | 完了後の戻り先を dashboard 系へ固定する |
+| representative screenshot の粒度 | state 名と png 名がずれると台帳が破綻する | `TC-ID ↔ png` を manual test 台帳で固定する |
+| rerun discoverability | isolated screenshot では明快でも Settings 全体では埋もれる | UI 完了と IA 改善を分離し、未タスク化する |
+| test hardening | warning と coverage 不足が report に残りやすい | follow-up task を発行して本体完了から責務分離する |
+
+### 同種課題の5分解決カード
+
+1. overlay 表示条件と完了後の戻り先を先に固定する。
+2. representative screenshot は desktop / tablet / mobile / rerun の4観点で押さえる。
+3. Settings rerun は動作確認と発見性確認を分けて評価する。
+4. MINOR は report だけで終わらせず unassigned task 化する。
+5. `task-workflow` / `ui-ux-navigation` / `ui-ux-settings` / `lessons-learned` を同一ターンで同期する。
+
 ### 分割ファイル
 
 - [SkillStreamDisplay詳細仕様](./ui-ux-feature-skill-stream.md) - TASK-3-2シリーズの完全な仕様
@@ -2000,6 +2038,7 @@ TASK-UI-05A-SKILL-EDITOR-VIEW は、SkillEditorView の Phase 1-13 仕様書作�
 
 | 日付       | バージョン | 変更内容                                                                                        |
 | ---------- | ---------- | ----------------------------------------------------------------------------------------------- |
+| 2026-03-13 | v1.14.37   | TASK-UI-09-ONBOARDING-WIZARD を反映: Onboarding Wizard overlay / Settings rerun / screenshot 5件 / 苦戦箇所 4件 / related UT 2件を feature 正本へ同期 |
 | 2026-03-12 | v1.14.36   | TASK-SKILL-LIFECYCLE-04 を反映: 収録機能一覧へ Skill Evaluation Gate を追加し、`SkillEvaluationPanel` / Task03-Task05 共通 gate / screenshot 6件 / public preload API 同期漏れ対策 / validator 準拠証跡を専用セクションへ同期 |
 | 2026-03-11 | v1.14.35   | TASK-UI-04C follow-up: `UT-IMP-WORKSPACE-PREVIEW-SEARCH-RESILIENCE-GUARD-001` を Workspace Preview / Quick Search 節の関連未タスクへ追加し、fuzzy no-match、renderer timeout+retry、error taxonomy を再利用用未タスクへ接続 |
 | 2026-03-11 | v1.14.34   | TASK-UI-04C-WORKSPACE-PREVIEW を反映: 収録機能一覧へ Workspace Preview / Quick Search を追加し、専用セクションへ `PreviewPanel` / `QuickFileSearch` / timeout+retry / screenshot 11件 / 苦戦箇所 3件を同期 |

--- a/.claude/skills/aiworkflow-requirements/references/ui-ux-navigation.md
+++ b/.claude/skills/aiworkflow-requirements/references/ui-ux-navigation.md
@@ -162,11 +162,11 @@ Global navigation とは別に、app header 右端には view 横断の utility 
 
 #### 同種課題の5分解決カード
 
-1. 一次導線と画面責務は `skillLifecycleJourney.ts` のような契約正本へまとめる。  
-2. domain UI spec は「入口」「destination surface」「例外」を 1 画面設計として書く。  
-3. legacy alias は shell で canonical 化し、仕様書・テスト・UI 表示の正本値を 1 つに固定する。  
-4. representative screenshot は route 全景ではなく、責務境界が読める要素 capture を優先する。  
-5. Phase 12 では `ui-ux-navigation` / `task-workflow` / `lessons-learned` を同一ターンで同期する。  
+1. 一次導線と画面責務は `skillLifecycleJourney.ts` のような契約正本へまとめる。
+2. domain UI spec は「入口」「destination surface」「例外」を 1 画面設計として書く。
+3. legacy alias は shell で canonical 化し、仕様書・テスト・UI 表示の正本値を 1 つに固定する。
+4. representative screenshot は route 全景ではなく、責務境界が読める要素 capture を優先する。
+5. Phase 12 では `ui-ux-navigation` / `task-workflow` / `lessons-learned` を同一ターンで同期する。
 
 ### Settings 公開シェル到達性（TASK-FIX-AUTHGUARD-TIMEOUT-SETTINGS-BYPASS-001）
 
@@ -238,11 +238,11 @@ Global navigation とは別に、app header 右端には view 横断の utility 
 
 #### 同種課題の簡潔解決手順（5ステップ）
 
-1. `navContract.ts` を導線正本にし、`AppLayout` / nav / shortcut / state の責務を先に分離する。  
-2. `navigationSlice` は current view/history、`uiSlice` は nav UI state、`useNavShortcuts` は DOM 条件判定に限定する。  
-3. rollback path は feature flag に閉じ、legacy/new の両導線で同じ契約と状態を参照させる。  
-4. mobile は `mobileLabel` と `aria-label` を分離し、Phase 11 スクリーンショットで可読性を最終確認する。  
-5. `ui-ux-components` / `ui-ux-feature-components` / `ui-ux-navigation` / `arch-state-management` / `task-workflow` / `lessons-learned` と workflow 本文を同一ターンで同期する。  
+1. `navContract.ts` を導線正本にし、`AppLayout` / nav / shortcut / state の責務を先に分離する。
+2. `navigationSlice` は current view/history、`uiSlice` は nav UI state、`useNavShortcuts` は DOM 条件判定に限定する。
+3. rollback path は feature flag に閉じ、legacy/new の両導線で同じ契約と状態を参照させる。
+4. mobile は `mobileLabel` と `aria-label` を分離し、Phase 11 スクリーンショットで可読性を最終確認する。
+5. `ui-ux-components` / `ui-ux-feature-components` / `ui-ux-navigation` / `arch-state-management` / `task-workflow` / `lessons-learned` と workflow 本文を同一ターンで同期する。
 
 ### 関連未タスク（2026-03-06 追補）
 
@@ -272,11 +272,11 @@ Global navigation とは別に、app header 右端には view 横断の utility 
 
 #### 同種課題の5分解決カード（最短手順）
 
-1. `navContract.ts` を導線正本にし、UI側の重複定義を削除する。  
-2. `meta/ctrl` 条件 + 編集要素除外 + `alt/shift` 抑止をセットで実装する。  
-3. `TC-xx` と `screenshots/*.png` を1対1で管理し、coverage validator を必ず実行する。  
-4. Step 2 で `ui-ux-navigation` / `arch-state-management` / `task-workflow` / `lessons-learned` を同一ターンで同期する。  
-5. `lsof -nP -iTCP:5177 -sTCP:LISTEN` の結果と分岐（停止/再利用/別ポート）を成果物へ残し、必要時は未タスク化する。  
+1. `navContract.ts` を導線正本にし、UI側の重複定義を削除する。
+2. `meta/ctrl` 条件 + 編集要素除外 + `alt/shift` 抑止をセットで実装する。
+3. `TC-xx` と `screenshots/*.png` を1対1で管理し、coverage validator を必ず実行する。
+4. Step 2 で `ui-ux-navigation` / `arch-state-management` / `task-workflow` / `lessons-learned` を同一ターンで同期する。
+5. `lsof -nP -iTCP:5177 -sTCP:LISTEN` の結果と分岐（停止/再利用/別ポート）を成果物へ残し、必要時は未タスク化する。
 
 ---
 
@@ -381,3 +381,50 @@ ChatViewには履歴ページへの導線として、ヘッダー右上にナビ
 - [システムプロンプト設定UI](./ui-ux-system-prompt.md)
 - [LLM選択機能](./ui-ux-llm-selector.md)
 - [UI/UXパネル設計](./ui-ux-panels.md)
+
+---
+
+## Onboarding overlay / rerun 契約（TASK-UI-09-ONBOARDING-WIZARD）
+
+### 実装内容（要点）
+
+| 観点 | 内容 |
+| --- | --- |
+| 初回起動 | `onboarding.completed=false` の場合、通常画面の上に wizard overlay を表示する |
+| 完了後導線 | wizard 完了後は通常画面へ戻し、以後の自動再表示を抑止する |
+| rerun 導線 | Settings から rerun を選ぶと completed flag を reset し、dashboard 経由で overlay を再表示する |
+| keyboard | キーボード進行は手動 spot check を残し、visual TC とは分離して記録する |
+
+### 画面証跡
+
+| TC | 証跡 | 観点 |
+| --- | --- | --- |
+| TC-11-01 | `outputs/phase-11/screenshots/TC-11-01-desktop-step1-light.png` | 初回起動時の overlay |
+| TC-11-02 | `outputs/phase-11/screenshots/TC-11-02-tablet-step3-dark.png` | 中盤 step の navigation |
+| TC-11-03 | `outputs/phase-11/screenshots/TC-11-03-mobile-step4-kanagawa.png` | mobile での最終 step |
+| TC-11-04 | `outputs/phase-11/screenshots/TC-11-04-settings-rerun-entry-dark.png` | Settings 内 rerun 入口 |
+| TC-11-05 | `outputs/phase-11/screenshots/TC-11-05-settings-rerun-triggered-dark.png` | rerun での overlay 再表示 |
+
+### 苦戦箇所（再発条件付き）
+
+| 苦戦箇所 | 再発条件 | 対処 |
+| --- | --- | --- |
+| overlay と通常ナビゲーションの責務が混ざる | wizard を単なる modal として扱い、戻り先を曖昧にする | 「初回 overlay」「完了後通常画面」「Settings rerun」の3状態に分けて記録した |
+| coverage validator に必要な台帳形式が崩れる | `phase-11-manual-test.md` に matrix を置かずに screenshot だけ残す | `## 画面カバレッジマトリクス` を正本にした |
+| 非視覚 TC が visual matrix を汚染する | keyboard spot check を screenshot TC と同列に置く | 非視覚 TC は result 側へ分離した |
+| rerun card が埋もれる | overlay 再表示動作だけで navigation UX を完了扱いにする | discoverability は follow-up task に切り出した |
+
+### 同種課題の5分解決カード
+
+1. overlay UI は「表示条件」「完了後導線」「rerun 導線」を別行で書く。
+2. Phase 11 では visual TC と非視覚 TC を分離して管理する。
+3. screenshot coverage validator が要求する matrix 形式を先に揃える。
+4. rerun 動作確認と発見性評価を別の判断軸にする。
+5. navigation の変更は `ui-ux-settings` と同時に同期する。
+
+### 関連未タスク
+
+| 未タスクID | 概要 | 参照 |
+| --- | --- | --- |
+| UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001 | screenshot / test hardening と warning 解消 | `docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md` |
+| UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001 | rerun 入口の情報設計改善 | `docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md` |

--- a/.claude/skills/aiworkflow-requirements/references/ui-ux-settings.md
+++ b/.claude/skills/aiworkflow-requirements/references/ui-ux-settings.md
@@ -468,6 +468,47 @@ loadProviders における Preload 境界の防御ガードにより、以下の
 - [deployment-electron.md](./deployment-electron.md) - Electronデプロイ
 - [期間フィルタ実装ガイド](../../../docs/30-workflows/TASK-IMP-permission-date-filter/outputs/phase-12/implementation-guide.md) - 期間別フィルタリング実装詳細
 
+## Onboarding rerun card（TASK-UI-09-ONBOARDING-WIZARD）
+
+### UI 構成
+
+| 項目 | 内容 |
+| --- | --- |
+| セクション名 | `はじめよう` |
+| CTA | `はじめようを再表示` |
+| test id | `rerun-onboarding-button` |
+| 役割 | 初回 onboarding の再体験を Settings から起動する |
+
+### persist / handoff 契約
+
+| 観点 | 内容 |
+| --- | --- |
+| reset key | `onboarding.completed=false` を保存する |
+| handoff | reset 後に `setCurrentView("dashboard")` で通常画面へ戻し、overlay を再評価させる |
+| responsibility | Settings は rerun の起点だけを持ち、wizard 本体の表示条件は onboarding 側で判定する |
+
+### 画面証跡
+
+| TC | 証跡 | 観点 |
+| --- | --- | --- |
+| TC-11-04 | `outputs/phase-11/screenshots/TC-11-04-settings-rerun-entry-dark.png` | rerun card の表示 |
+| TC-11-05 | `outputs/phase-11/screenshots/TC-11-05-settings-rerun-triggered-dark.png` | rerun 実行後の overlay |
+
+### 苦戦箇所（再利用形式）
+
+| 苦戦箇所 | 内容 | 解決方針 |
+| --- | --- | --- |
+| reset と handoff の順序 | Settings だけで overlay を制御しようとすると state が競合しやすい | Settings は reset 起点、overlay は表示条件判定に専念させる |
+| full settings page での発見性 | isolated screenshot では見えるが、長い設定画面では埋もれる | discoverability は IA 改善として未タスク化する |
+| test warning | integration test に `act(...)` warning が残る | rerun UX の本体完了とは切り離して hardening task へ送る |
+
+### 関連未タスク
+
+| 未タスクID | 概要 | 参照 |
+| --- | --- | --- |
+| UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001 | rerun を含む integration / harness hardening | `docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md` |
+| UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001 | rerun card の配置・文言・発見性改善 | `docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md` |
+
 ---
 
 ## 実装ファイル
@@ -499,6 +540,7 @@ loadProviders における Preload 境界の防御ガードにより、以下の
 
 | Version | Date       | Changes                                                                                                                                                                         |
 | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.9.0   | 2026-03-13 | TASK-UI-09-ONBOARDING-WIZARD を反映: `はじめよう` rerun card、`onboarding.completed=false` reset、`setCurrentView("dashboard")` handoff、Phase 11 screenshot 2件、苦戦箇所 3件を追加 |
 | 1.8.0   | 2026-03-11 | TASK-FIX-APIKEY-CHAT-TOOL-INTEGRATION-001 反映: `authMode === "api-key"` 時のみ `AuthKeySection` を表示する契約と、`auth-key:exists.source`（saved/env-fallback/not-set）優先表示を追加。Phase 11 screenshot 3件を同期 |
 | 1.6.0   | 2026-03-08 | TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001 拡充: 防御レイヤーテーブル（L1-L4）、normalizeProviders フィルタ仕様（P49準拠 in 演算子）、テスト合計46件、関連タスクテーブルを追加 |
 | 1.5.1   | 2026-03-07 | TASK-FIX-SETTINGS-APIKEY-CONTRACT-GUARD-001 反映: providers 要素 shape フィルタ（`provider/status` 必須）と実画面検証（TC-11-01〜03）を追記                                     |

--- a/.claude/skills/skill-creator/assets/phase12-spec-sync-subagent-template.md
+++ b/.claude/skills/skill-creator/assets/phase12-spec-sync-subagent-template.md
@@ -294,3 +294,44 @@ ps -ef | rg "capture-.*phase11|vite" | rg -v rg || true
 - [ ] 仕様書間で検証値（13/13, 28項目, current=0 など）の値が一致している
 - [ ] 3仕様書（`task-workflow.md` / `lessons-learned.md` / `<domain-spec or ui-ux-feature-components.md>`）で5分解決カードの5ステップ順序が一致している
 - [ ] UIタスクでは画面証跡の時刻が仕様書間で一致している
+
+## 8. 追補プロファイル: Onboarding Wizard / Settings rerun
+
+### 8.1 適用条件
+
+- 初回表示オーバーレイ
+- multi-step onboarding
+- Settings からの rerun 導線
+- persist key による再表示抑制
+
+### 8.2 最低限更新する canonical docs
+
+1. `/.claude/skills/aiworkflow-requirements/references/task-workflow.md`
+2. `/.claude/skills/aiworkflow-requirements/references/ui-ux-feature-components.md`
+3. `/.claude/skills/aiworkflow-requirements/references/ui-ux-navigation.md`
+4. `/.claude/skills/aiworkflow-requirements/references/ui-ux-settings.md`
+5. `/.claude/skills/aiworkflow-requirements/references/lessons-learned.md`
+
+### 8.3 関心ごとの分離
+
+- 画面導線担当:
+  - overlay 表示条件
+  - step 遷移
+  - 完了後の戻り先
+  - screenshot 証跡の照合
+- 設定導線担当:
+  - rerun button 文言
+  - persist key 更新
+  - dashboard への handoff
+  - discoverability 課題の backlog 化要否
+- 品質/未タスク担当:
+  - verification report の MINOR 抽出
+  - `docs/30-workflows/unassigned-task/` への formalize
+  - `verify-unassigned-links.js`
+  - `audit-unassigned-tasks.js --diff-from HEAD`
+
+### 8.4 完了条件
+
+- Phase 12 側に implementation-guide / spec-update-summary / documentation-changelog / unassigned-task-detection / skill-feedback-report が揃っている
+- canonical docs 側に実装内容と苦戦箇所が同一用語で残っている
+- UI 本体完了と follow-up backlog が責務分離されている

--- a/.claude/skills/skill-creator/references/patterns.md
+++ b/.claude/skills/skill-creator/references/patterns.md
@@ -3587,3 +3587,24 @@ cd apps/desktop && pnpm vitest run src/renderer/components/AuthGuard/
 - **教訓**: Preload テストでは `Object.defineProperty(process, "contextIsolated", { value: true })` が必須。`electronAPI` が `undefined` の場合は contextBridge パスの通過を確認
 - **発見日**: 2026-03-10
 - **関連タスク**: TASK-FIX-SAFEINVOKE-TIMEOUT-001
+
+### [Phase12] Onboarding overlay / Settings rerun / MINOR formalization の三点同期（TASK-UI-09-ONBOARDING-WIZARD）
+
+- **状況**: Onboarding Wizard のような multi-step UI では、本体実装は完了していても、`verification-report.md` に coverage 不足や `act(...)` warning、手動試験には rerun 導線の discoverability 課題が残ることがある
+- **アプローチ**:
+  1. **本体完了と follow-up を分離**: workflow 本体は completed 系ステータスを維持し、軽微課題のみ未タスク化する
+  2. **raw 候補を精査**: `verification-report.md` / `manual-test-result.md` / `documentation-changelog.md` から候補を抽出し、責務単位で統合する
+  3. **canonical spec を 5 点同期**: `task-workflow.md` / `ui-ux-feature-components.md` / `ui-ux-navigation.md` / `ui-ux-settings.md` / `lessons-learned.md` を同一ターンで更新する
+  4. **苦戦箇所を再利用知識へ昇格**: 状態同期、画面導線、テスト warning、discoverability の 4 軸で lessons learned に残す
+  5. **差分監査で閉じる**: `verify-unassigned-links.js` と `audit-unassigned-tasks.js --diff-from HEAD` を実行し、`currentViolations=0` を確認する
+- **成功パターン**:
+  - UI 完了判定を崩さずに、軽微事項だけを formalized backlog として管理できる
+  - Phase 12 成果物、system spec、unassigned-task の 3 点に同じ未タスク ID が残り、検索経路がぶれない
+  - スクリーンショット証跡と backlog が直接結びつき、再確認時に迷わない
+- **失敗パターン**:
+  - `verification-report.md` の MINOR を文書内コメントのまま放置する
+  - `ui-ux-feature-components.md` だけ更新し、navigation / settings / lessons learned を更新しない
+  - 苦戦ポイントを会話で消費し、次回のスキル改善へ残さない
+- **適用条件**: 初回起動オーバーレイ、Settings からの rerun、persist key、Phase 11 screenshot を含む UI タスク
+- **発見日**: 2026-03-13
+- **関連タスク**: TASK-UI-09-ONBOARDING-WIZARD

--- a/.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md
+++ b/.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md
@@ -497,3 +497,25 @@ mv docs/30-workflows/unassigned-task/task-{{task-name}}.md \
 
 - テンプレート: `assets/unassigned-task-template.md`
 - エージェント: `agents/generate-unassigned-task.md`
+
+---
+
+## 追加ルール: verification-report / MINOR formalization（2026-03-13）
+
+### 未タスク化の起点
+
+- `outputs/verification-report.md` の `MINOR` / remaining issues
+- Phase 11 のスクリーンショット検証・手動試験で発見した discoverability / 情報設計課題
+- system spec 更新時に「本体完了と切り分けた方が責務が明確」と判断できる follow-up 項目
+
+### formalize 判断基準
+
+- 本体完了判定は維持できるが、放置すると再発・理解コスト増につながる
+- 複数の軽微事項を 1 つの品質テーマへ統合した方が実装責務が明確になる
+- `task-workflow.md` と Phase 12 成果物の両方に同一 ID を残したい
+
+### 記述ルール
+
+- `3.5 実装課題と解決策` に、なぜ残件化したかと再発防止の観点を 2〜4 項目で残す
+- `## 8. 参照情報` に `verification-report.md` や `manual-test-result.md` など発見元を入れる
+- `verify-unassigned-links.js` と `audit-unassigned-tasks.js --diff-from HEAD` の結果を Phase 12 成果物側にも記録する

--- a/docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md
+++ b/docs/30-workflows/unassigned-task/task-imp-onboarding-test-hardening-guard-001.md
@@ -1,0 +1,265 @@
+# Onboarding Wizard テストハードニングと回帰ガード強化 - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------ |
+| タスクID     | UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001                                           |
+| タスク名     | Onboarding Wizard テストハードニングと回帰ガード強化                                 |
+| 分類         | 改善                                                                                 |
+| 対象機能     | Onboarding Wizard / Settings rerun / OnboardingGate / SettingsView integration tests |
+| 優先度       | 中                                                                                   |
+| 見積もり規模 | 中規模                                                                               |
+| ステータス   | 未実施                                                                               |
+| Issue        | #1191                                                                                |
+| 発見元       | Phase 12                                                                             |
+| 発見日       | 2026-03-13                                                                           |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+TASK-UI-09-ONBOARDING-WIZARD の Phase 12 再確認で、Onboarding Wizard の本体実装は完了している一方、テスト品質に軽微な残課題が残っていることが分かった。system spec には `function coverage 76.92%`、`act(...)` warning、rerun 系 integration の hardening 必要性を反映済みであり、次回類似 UI を短く直すために follow-up task として独立管理する必要がある。
+
+### 1.2 問題点・課題
+
+- Onboarding 関連テストの function coverage が 80% 未満で止まっている。
+- `SettingsView.integration.test.tsx` と `OnboardingGate.test.tsx` 系で `act(...)` warning が残る。
+- rerun 導線は `persist reset -> view handoff -> overlay 再評価` の連鎖を持つため、分岐が多く回帰しやすい。
+- warning と coverage 不足を report の文章だけで残すと、次の担当者が着手点を特定しにくい。
+
+### 1.3 放置した場合の影響
+
+- rerun や初回表示の回帰が発生しても検出が遅れる。
+- CI やローカル検証で warning ノイズが残り、本当に壊れた差分の判別が難しくなる。
+- Onboarding 系 UI を再利用する際に、どの分岐を守るべきかがドキュメントだけでは伝わらない。
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+Onboarding Wizard 周辺のテストを hardening し、warning のない安定した回帰ガードを用意する。
+
+### 2.2 最終ゴール
+
+- Onboarding 関連の target test で `act(...)` warning が出ない。
+- first launch / skip / complete / rerun / already-completed の主要分岐がテストで明示的に守られる。
+- touched scope の function coverage が 80% 以上になる。
+- completion 後に必要なら system spec / verification note に最終値を反映できる状態になる。
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- OnboardingGate / SettingsView rerun 導線の integration test 強化
+- テストヘルパー、fixture、非同期待機の安定化
+- warning 解消のための `act` / wait 制御見直し
+- 結果として必要になる verification / documentation の同期
+
+#### 含まないもの
+
+- Onboarding Wizard の UI デザイン変更
+- Settings rerun card の発見性改善
+- onboarding step 内容の追加・削除
+
+### 2.4 成果物
+
+- 更新された Onboarding 関連テストファイル
+- 必要に応じた test helper / harness
+- 実行ログまたは検証メモ
+- 必要に応じた system spec 更新差分
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- TASK-UI-09-ONBOARDING-WIZARD の実装が存在していること
+- Onboarding rerun 契約が `onboarding.completed=false` reset と dashboard handoff で定義されていること
+- system spec 側に Onboarding Wizard の実装内容と苦戦箇所が反映済みであること
+
+### 3.2 依存タスク
+
+- TASK-UI-09-ONBOARDING-WIZARD
+
+### 3.3 必要な知識
+
+- Vitest / React Testing Library / happy-dom
+- React の `act(...)` と非同期状態更新
+- persist state と navigation handoff の扱い
+- `/.claude/skills/aiworkflow-requirements/` の UI / lessons / task-workflow 正本
+
+### 3.4 推奨アプローチ
+
+rerun 契約を 1 本のテストシナリオとしてではなく、`first launch`、`already completed`、`complete after walkthrough`、`rerun from settings`、`edge/error path` に分解して守る。非同期更新は helper 化し、warning を消すことと coverage を上げることを同じハーネスで達成する。
+
+### 3.5 実装課題と解決策
+
+| 実装課題                         | 内容                                                                               | 解決策                                                                         |
+| -------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| rerun 契約が複数層にまたがる     | `persist reset -> dashboard handoff -> overlay 再表示` が 1 回の UI 操作に含まれる | helper で手順を固定し、分岐を個別テストに分解する                              |
+| warning の原因が見えにくい       | state update と assertion の境界が曖昧だと `act(...)` warning が残る               | async wait と flush ポイントを明示し、暗黙待機を減らす                         |
+| coverage gap が再発しやすい      | complete 済み分岐や rerun edge 分岐が後回しになりやすい                            | 主要 5 分岐を coverage 対象として列挙し、抜けを防ぐ                            |
+| system spec との接続が切れやすい | report の数値だけでは後続担当が背景を読めない                                      | task-workflow / settings / lessons で同じ UT ID を参照し、完了時は同値更新する |
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+3フェーズで進める。`再現と分岐棚卸し`、`hardening 実装`、`検証と文書同期` の順に進める。
+
+### Phase 1: 再現と分岐棚卸し
+
+#### 目的
+
+warning と coverage gap の正確な発生点を固定する。
+
+#### 手順
+
+1. Onboarding 関連 target test を実行し、warning 発生箇所を記録する。
+2. first launch / skip / complete / rerun / already-completed の未保証分岐を洗い出す。
+3. shared helper 化すべき待機処理と fixture を決める。
+
+#### 成果物
+
+- warning 発生箇所メモ
+- target branch 一覧
+
+#### 完了条件
+
+- どのテストが warning を出しているか説明できる。
+- coverage を埋める対象分岐が列挙されている。
+
+### Phase 2: テストとハーネスの hardening
+
+#### 目的
+
+warning を消し、主要分岐の回帰ガードを実装する。
+
+#### 手順
+
+1. rerun 契約用 helper / fixture を追加または整理する。
+2. target branch ごとにテストを追加し、暗黙待機を明示待機へ置き換える。
+3. `act(...)` warning が消えるまで state update の境界を調整する。
+
+#### 成果物
+
+- 更新済みテスト
+- helper / harness 差分
+
+#### 完了条件
+
+- warning の再現が止まっている。
+- 主要分岐のテストが揃っている。
+
+### Phase 3: 検証と文書同期
+
+#### 目的
+
+数値と文書の整合を閉じる。
+
+#### 手順
+
+1. target test と coverage を再実行し、最終値を確認する。
+2. 必要に応じて verification note と system spec を更新する。
+3. 未タスク完了時は task-workflow の参照先とステータスを更新する。
+
+#### 成果物
+
+- 検証ログ
+- 必要に応じた system spec 更新
+
+#### 完了条件
+
+- function coverage 80% 以上を確認できる。
+- target scope で `act(...)` warning が出ない。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] first launch を守るテストがある
+- [ ] complete 後に再表示されないことを守るテストがある
+- [ ] Settings rerun を守るテストがある
+- [ ] already-completed 分岐を守るテストがある
+
+### 品質要件
+
+- [ ] target scope の function coverage が 80% 以上
+- [ ] target scope で `act(...)` warning が 0 件
+- [ ] helper / harness の責務が分離されている
+
+### ドキュメント要件
+
+- [ ] 必要なら `task-workflow.md` に完了反映を行う
+- [ ] 必要なら `ui-ux-settings.md` / `lessons-learned.md` に再利用知識を追記する
+- [ ] 実行ログまたは検証メモに最終値を残す
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+| テストケース      | 目的                                                            |
+| ----------------- | --------------------------------------------------------------- |
+| 初回表示          | 初回起動時のみ wizard が出ることを確認する                      |
+| 完了後抑止        | walkthrough 完了後は再表示されないことを確認する                |
+| rerun             | Settings から rerun すると overlay が再表示されることを確認する |
+| already-completed | completed state では通常画面へ進むことを確認する                |
+| edge path         | async handoff 中の warning や未待機更新が残らないことを確認する |
+
+### 検証手順
+
+1. `pnpm --filter @repo/desktop exec vitest run <onboarding-target-tests>` を実行する。
+2. warning が 0 件であることを確認する。
+3. target scope の coverage を確認する。
+4. 文書を更新した場合は `verify-unassigned-links.js` で参照切れがないことを確認する。
+
+---
+
+## 7. リスクと対策
+
+| リスク                                             | 影響度 | 発生確率 | 対策                                                      |
+| -------------------------------------------------- | ------ | -------- | --------------------------------------------------------- |
+| warning を消すために実装コードへ不要な調整を入れる | 中     | 中       | まず test helper と待機制御で解消し、実装変更は最小化する |
+| coverage 数値だけを追ってテスト意図が弱くなる      | 中     | 中       | 分岐ごとに目的を書いたテストへ分解する                    |
+| rerun 契約の責務が再び混ざる                       | 高     | 中       | reset と表示判定の責務分離を守る                          |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `/.claude/skills/aiworkflow-requirements/references/task-workflow.md`
+- `/.claude/skills/aiworkflow-requirements/references/ui-ux-navigation.md`
+- `/.claude/skills/aiworkflow-requirements/references/ui-ux-settings.md`
+- `/.claude/skills/aiworkflow-requirements/references/lessons-learned.md`
+- `/.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md`
+
+### 参考資料
+
+- TASK-UI-09-ONBOARDING-WIZARD の Phase 12 検証結果
+- Onboarding Wizard の representative screenshot 証跡
+
+---
+
+## 9. 備考
+
+### レビュー指摘の原文（該当する場合）
+
+`function coverage 76.92%`、`act(...) warning`、rerun 導線の hardening 必要性が Phase 12 で検出された。
+
+### 補足事項
+
+このタスクは UI デザイン変更ではなく、回帰しやすい状態遷移を test/harness で安定化することが主目的である。

--- a/docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md
+++ b/docs/30-workflows/unassigned-task/task-imp-settings-onboarding-rerun-discoverability-001.md
@@ -1,0 +1,259 @@
+# Settings Onboarding rerun 導線の発見性改善 - タスク指示書
+
+## メタ情報
+
+| 項目         | 内容                                                        |
+| ------------ | ----------------------------------------------------------- |
+| タスクID     | UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001        |
+| タスク名     | Settings Onboarding rerun 導線の発見性改善                  |
+| 分類         | 改善                                                        |
+| 対象機能     | SettingsView / Onboarding rerun card / Getting Started 導線 |
+| 優先度       | 中                                                          |
+| 見積もり規模 | 小規模                                                      |
+| ステータス   | 未実施                                                      |
+| Issue        | #1190                                                       |
+| 発見元       | Phase 11, Phase 12                                          |
+| 発見日       | 2026-03-13                                                  |
+
+---
+
+## 1. なぜこのタスクが必要か（Why）
+
+### 1.1 背景
+
+TASK-UI-09-ONBOARDING-WIZARD の手動確認では Settings から rerun できること自体は確認できたが、full settings page では rerun card が fold 下に落ちやすく、初見ユーザーが導線を見つけにくいことが分かった。system spec にはこの課題を「動作完了とは別の IA 問題」として反映済みであり、独立タスクとして扱う。
+
+### 1.2 問題点・課題
+
+- `はじめようを再表示` は動作するが、Settings 全体の中で目立ちにくい。
+- representative screenshot だけを見ると十分に明快に見えるため、full page での発見性問題を見落としやすい。
+- 導線の説明文が弱いと、何が再表示されるのかが直感的に伝わりにくい。
+- 実装本体と IA 改善を同じタスクに抱えると、完了判定がぶれやすい。
+
+### 1.3 放置した場合の影響
+
+- onboarding を再確認したいユーザーが rerun 入口を見つけにくい。
+- support / QA / 手動検証で rerun 導線の説明コストが増える。
+- 「機能はあるが使われない」状態が続き、導線価値が薄れる。
+
+---
+
+## 2. 何を達成するか（What）
+
+### 2.1 目的
+
+Settings 上の onboarding rerun 導線を、ユーザーが自然に見つけられる配置と文言に改善する。
+
+### 2.2 最終ゴール
+
+- rerun card の配置または見せ方が改善され、full settings page でも視認しやすい。
+- CTA の意味が非技術者にも分かる。
+- rerun の内部契約（`onboarding.completed=false` reset と dashboard handoff）は変えずに改善できる。
+- representative screenshot と manual note で改善結果を説明できる。
+
+### 2.3 スコープ
+
+#### 含むもの
+
+- rerun card の配置見直し
+- タイトル、説明文、CTA 文言、視覚的強調の改善
+- full settings page 観点での screenshot / manual verification
+- 必要に応じた system spec 更新
+
+#### 含まないもの
+
+- Onboarding Wizard の step 内容変更
+- onboarding state 契約の変更
+- Settings 全体の大規模 IA 再設計
+
+### 2.4 成果物
+
+- 改善後の Settings rerun UI
+- representative screenshot または manual verification note
+- 必要に応じた system spec 更新
+
+---
+
+## 3. どのように実行するか（How）
+
+### 3.1 前提条件
+
+- Onboarding Wizard の rerun 機能自体が正常動作していること
+- Settings 側が reset 起点、Onboarding 側が表示判定という責務分離を守っていること
+- current system spec に rerun card と discoverability 課題が記録されていること
+
+### 3.2 依存タスク
+
+- TASK-UI-09-ONBOARDING-WIZARD
+
+### 3.3 必要な知識
+
+- SettingsView の情報設計
+- CTA 文言と説明文の UI/UX 設計
+- representative screenshot と full-page screenshot の使い分け
+- `/.claude/skills/aiworkflow-requirements/` の settings / navigation / lessons 正本
+
+### 3.4 推奨アプローチ
+
+まず「なぜ見つけにくいか」を layout、grouping、文言、視覚的強調の4観点で切り分ける。そのうえで、状態契約は変えずに card の位置と説明を改善し、full settings page の representative screenshot で評価する。
+
+### 3.5 実装課題と解決策
+
+| 実装課題                                         | 内容                                                          | 解決策                                                 |
+| ------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------ |
+| isolated では良く見えるが full page では埋もれる | コンポーネント単体の見栄えとページ全体の発見性は別問題        | full settings page を基準に再評価する                  |
+| UI 改善と状態契約を混ぜやすい                    | card の改善中に onboarding state の責務まで触りやすい         | Settings は入口、onboarding は表示判定という境界を守る |
+| CTA の意味が伝わりにくい                         | 「再表示」だけでは何が起きるか想像しづらい                    | タイトルと説明文で再体験の目的を補う                   |
+| Phase 12 の完了判定を揺らしやすい                | 動作完了済みの UI に IA 課題を混ぜると完了/未完の判断がぶれる | discoverability を独立 task として扱う                 |
+
+---
+
+## 4. 実行手順
+
+### Phase構成
+
+3フェーズで進める。`問題の見える化`、`UI 改善`、`画面検証と文書同期` の順に進める。
+
+### Phase 1: 発見性問題の可視化
+
+#### 目的
+
+どの要因で rerun 入口が見つけにくいかを明確にする。
+
+#### 手順
+
+1. current Settings 画面で rerun card の位置と周辺情報量を確認する。
+2. layout、grouping、copy、visual emphasis の4観点で原因を整理する。
+3. 改善候補を 2〜3 案に絞る。
+
+#### 成果物
+
+- discoverability 問題メモ
+- 改善候補一覧
+
+#### 完了条件
+
+- 何が見つけにくさの主因か説明できる。
+
+### Phase 2: UI 改善
+
+#### 目的
+
+rerun 入口の見つけやすさを上げる。
+
+#### 手順
+
+1. card の配置または grouping を見直す。
+2. タイトル、説明文、CTA 文言を調整する。
+3. 必要に応じて視覚的強調を加える。
+
+#### 成果物
+
+- 更新済み UI 差分
+
+#### 完了条件
+
+- full page で rerun 入口を説明なしでも見つけやすい構成になっている。
+
+### Phase 3: 画面検証と文書同期
+
+#### 目的
+
+改善内容を再利用できる形で固定する。
+
+#### 手順
+
+1. representative screenshot または manual verification を取得する。
+2. 必要に応じて `ui-ux-settings.md`、`ui-ux-navigation.md`、`lessons-learned.md` を更新する。
+3. タスク完了時は未タスク参照先と status を同期する。
+
+#### 成果物
+
+- 検証証跡
+- 必要に応じた system spec 更新
+
+#### 完了条件
+
+- 改善前後の差分と意図を説明できる。
+- 文書上で rerun 導線の責務と UI 改善点が残っている。
+
+---
+
+## 5. 完了条件チェックリスト
+
+### 機能要件
+
+- [ ] rerun card の配置または grouping が改善されている
+- [ ] CTA の意味が説明文込みで分かる
+- [ ] rerun の内部契約は変更していない
+
+### 品質要件
+
+- [ ] full settings page 観点で発見性が改善されている
+- [ ] representative screenshot または manual verification を残している
+- [ ] UI 改善が onboarding state 契約を侵食していない
+
+### ドキュメント要件
+
+- [ ] 必要に応じて `ui-ux-settings.md` を更新している
+- [ ] 必要に応じて `ui-ux-navigation.md` / `lessons-learned.md` も同期している
+- [ ] 改善理由を文書で説明できる
+
+---
+
+## 6. 検証方法
+
+### テストケース
+
+| テストケース   | 目的                                                       |
+| -------------- | ---------------------------------------------------------- |
+| rerun 入口視認 | Settings を開いたときに rerun 導線を見つけやすいか確認する |
+| CTA 理解       | ボタン文言だけで役割が分かるか確認する                     |
+| 動作維持       | rerun を押したときの既存契約が壊れていないか確認する       |
+| full page 評価 | isolated ではなく full settings page で発見性を確認する    |
+
+### 検証手順
+
+1. Settings 画面を representative state で表示する。
+2. rerun 入口の位置、見出し、説明文、CTA を確認する。
+3. rerun 実行後に既存契約どおり overlay が再表示されることを確認する。
+4. 文書更新を伴う場合は system spec の関連箇所も同期する。
+
+---
+
+## 7. リスクと対策
+
+| リスク                                             | 影響度 | 発生確率 | 対策                                     |
+| -------------------------------------------------- | ------ | -------- | ---------------------------------------- |
+| 見つけやすさ改善のために設定画面全体の構成が崩れる | 中     | 低       | onboarding 周辺の局所改善に限定する      |
+| 文言改善で rerun 動作を誤解させる                  | 中     | 中       | 説明文で「再体験できる」ことを明記する   |
+| UI 改善のついでに state 契約へ手を入れてしまう     | 高     | 中       | reset 起点と表示判定の責務分離を維持する |
+
+---
+
+## 8. 参照情報
+
+### 関連ドキュメント
+
+- `/.claude/skills/aiworkflow-requirements/references/ui-ux-feature-components.md`
+- `/.claude/skills/aiworkflow-requirements/references/ui-ux-navigation.md`
+- `/.claude/skills/aiworkflow-requirements/references/ui-ux-settings.md`
+- `/.claude/skills/aiworkflow-requirements/references/lessons-learned.md`
+- `/.claude/skills/task-specification-creator/references/unassigned-task-guidelines.md`
+
+### 参考資料
+
+- TASK-UI-09-ONBOARDING-WIZARD の Phase 11 手動検証結果
+- Onboarding rerun representative screenshot
+
+---
+
+## 9. 備考
+
+### レビュー指摘の原文（該当する場合）
+
+rerun card は isolated screenshot では明快だが、full settings page 内では fold 下に落ちやすく、discoverability に改善余地がある。
+
+### 補足事項
+
+このタスクは「機能不全」ではなく「情報設計改善」である。動作完了と discoverability 改善を分離して扱うことが前提になる。


### PR DESCRIPTION
## 概要

TASK-UI-09-ONBOARDING-WIZARD の Phase 11 / Phase 12 再確認で見つかった follow-up を unassigned task として formalize し、関連する system spec / skill assets を同一ターンで同期します。今回の差分は実装変更ではなく、Onboarding Wizard と Settings rerun 導線の残課題を次回着手可能な粒度へ固定するための docs/spec 更新です。

## 変更内容

## 主な変更点をリストアップ

- `UT-IMP-ONBOARDING-TEST-HARDENING-GUARD-001` と `UT-IMP-SETTINGS-ONBOARDING-RERUN-DISCOVERABILITY-001` を `docs/30-workflows/unassigned-task/` に追加しました。
- `task-workflow.md` / `lessons-learned.md` / `ui-ux-feature-components.md` / `ui-ux-navigation.md` / `ui-ux-settings.md` に TASK-UI-09-ONBOARDING-WIZARD の苦戦箇所、follow-up 2 件、再利用ルールを同期しました。
- `skill-creator` / `task-specification-creator` 側の Phase 12 テンプレートとガイドラインへ、Onboarding overlay / Settings rerun の formalize パターンを反映しました。

## 変更タイプ

- [ ] 🐛 バグ修正 (bug fix)
- [ ] ✨ 新機能 (new feature)
- [ ] 🔨 リファクタリング (refactoring)
- [x] 📝 ドキュメント (documentation)
- [ ] 🧪 テスト (test)
- [ ] 🔧 設定変更 (configuration)
- [ ] 🚀 CI/CD (continuous integration)

## テスト

- [x] ユニットテスト実行 (`pnpm test --testTimeout=900000`) ※ユーザー実行済み
- [x] 型チェック実行 (`pnpm typecheck`) ※ユーザー実行済み
- [x] ESLint チェック実行 (`pnpm lint`) ※ユーザー実行済み
- [x] ビルド確認 (`pnpm --filter @repo/shared build`, `pnpm --filter @repo/desktop build`) ※ユーザー実行済み
- [ ] 手動テスト実施

## 関連 Issue

Closes #1190
Closes #1191

## 破壊的変更

- [ ] この PR には破壊的変更が含まれます

## チェックリスト

- [x] コードが既存のスタイルに従っている
- [x] 必要に応じてドキュメントを更新した
- [ ] 新規・変更機能にテストを追加した
- [x] すべてのテストがローカルで成功する
- [x] Pre-commit hooks が成功する

## その他

- Phase 12 実装ガイド反映元: `docs/30-workflows/completed-tasks/05-TASK-FIX-SETTINGS-AUTHKEY-UI-ALIGNMENT-001/outputs/phase-12/implementation-guide.md`
- 反映理由: Onboarding Wizard 専用の `implementation-guide.md` は repo 上に存在しないため、今回の follow-up が依存する SettingsView 内導線・条件付きセクション設計の最も近い Phase 12 ガイドとして参照しました。
- 反映ポイント: Settings は入口、Onboarding は表示判定という責務分離を保ったまま follow-up task を独立管理する方針を PR 説明へ反映しました。
- 反映ポイント: rerun 導線の discoverability と warning / coverage hardening を別 task に切り分ける運用を PR 説明へ反映しました。
- 反映ポイント: `task-workflow` / `lessons-learned` / `ui-ux-*` / skill template を同一ターンで同期する Phase 12 formalize パターンを PR 説明へ反映しました。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
