### PR TITLE
docs(skill-creator): TASK-P0-02 verify→improve→re-verify 閉ループ仕様改善

### DIFF
--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/artifacts.json
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/artifacts.json
@@ -1,7 +1,7 @@
 {
   "feature": "step-10-seq-task-p0-02-verify-improve-reverify-closed-loop",
   "created": "2026-03-29T08:03:00.000Z",
-  "lastUpdated": "2026-03-29T08:03:33.000Z",
+  "lastUpdated": "2026-03-30T11:30:00.000Z",
   "status": "in_progress",
   "phases": {
     "1": { "status": "completed", "artifacts": ["phase-1-requirements.md"] },

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/index.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/index.md
@@ -13,8 +13,10 @@
 | ステータス     | spec_created                                               |
 | 発見元         | p0-verify-manifest-remediation-pack 監査                   |
 | 作成日         | 2026-03-29                                                 |
-| 依存タスク     | TASK-P0-01（verify engine 本体）                           |
+| 更新日         | 2026-03-30                                                 |
+| 依存タスク     | TASK-P0-01（verify engine 本体） ✅ 完了済み               |
 | 後続タスク     | なし                                                       |
+| 関連Issue      | #1725                                                      |
 | 親ワークフロー | step-10-seq-task-p0-02-verify-improve-reverify-closed-loop |
 
 ---
@@ -82,6 +84,21 @@ WorkflowEngine は execute→verify→improve の前半経路を持つが、以�
 | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`  | plan / execute / improve の public bridge。re-verify 経路が不完全 | improve→verify 遷移を追加し閉ループを成立させる                |
 | `apps/desktop/src/main/ipc/creatorHandlers.ts`                         | IPC handler。verify/improve の IPC エントリポイント               | 閉ループに対応した handler 更新                                |
 | `packages/shared/src/types/skillCreator.ts`                            | `SkillCreatorVerifyResult` 型。status `"pass"` のハンドラが未実装 | `"pass"` status に対応するハンドラを追加                       |
+
+## システム仕様参照（aiworkflow-requirements連携）
+
+各 Phase の「参照資料」セクションに以下のシステム仕様を含めること:
+
+| 参照資料                  | パス                                                                                                  | 内容                                               |
+| ------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md`           | SkillCreatorService、Facade injection パターン     |
+| Agent IPC チャネル仕様    | `.agents/skills/aiworkflow-requirements/references/api-ipc-agent-core.md`                             | agent:execute、agent:verify 等の IPC チャネル定義  |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`                         | IPC修正時の Main/Preload/型定義 同時更新チェック   |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`                        | パストラバーサル防止、コマンドインジェクション防止 |
+| Skill lifecycle hooks     | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-details.md`             | Skill lifecycle hooks 仕様                         |
+| テスト標準化              | `.agents/skills/aiworkflow-requirements/references/lessons-learned-skill-lifecycle-test-hardening.md` | Main Process ハンドラの単体テスト標準化            |
+
+---
 
 ## 要件レビュー一次結論
 
@@ -155,12 +172,31 @@ graph TD
 
 ## テストカバレッジ目標
 
-| カテゴリ | 対象                                                        | 目標     |
-| -------- | ----------------------------------------------------------- | -------- |
-| ユニット | `recordVerifyPass()` phase 遷移                             | 100%     |
-| ユニット | verify→improve / improve→verify 遷移                        | 100%     |
-| ユニット | `requestReverify()` eligibility と verification engine 統合 | 100%     |
-| 統合     | execute→verify(fail)→improve→verify(pass) 完全サイクル      | E2E 検出 |
+### ユニットテスト
+
+| 指標              | 最低基準 | 推奨基準 |
+| ----------------- | -------- | -------- |
+| Line Coverage     | 80%      | 90%      |
+| Branch Coverage   | 60%      | 70%      |
+| Function Coverage | 80%      | 90%      |
+
+### テスト対象と目標
+
+| カテゴリ | 対象                                                   | 目標     | テストファイル                       |
+| -------- | ------------------------------------------------------ | -------- | ------------------------------------ |
+| ユニット | `recordVerifyPass()` phase 遷移                        | 100%     | `SkillCreatorWorkflowEngine.test.ts` |
+| ユニット | verify→improve / improve→verify 遷移                   | 100%     | `SkillCreatorWorkflowEngine.test.ts` |
+| ユニット | `requestReverify()` eligibility と engine 統合         | 100%     | `SkillCreatorWorkflowEngine.test.ts` |
+| ユニット | Facade `processVerifyResult()` / `requestReVerify()`   | 100%     | `RuntimeSkillCreatorFacade.test.ts`  |
+| 統合     | execute→verify(fail)→improve→verify(pass) 完全サイクル | E2E 検出 | 統合テスト                           |
+
+### 結合テスト
+
+| 指標                             | 目標 |
+| -------------------------------- | ---- |
+| 遷移テーブル全 edge              | 100% |
+| 正常系シナリオ（完全サイクル）   | 100% |
+| 異常系シナリオ（不正遷移ガード） | 80%+ |
 
 ---
 

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-1-requirements.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-1-requirements.md
@@ -11,55 +11,115 @@
 | 次Phase    | Phase 2: 設計                                    |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
-verify→improve→re-verify の閉ループが成立しない根本原因を特定し、§14 verify/improve closed loop の phase 遷移要件を確定する。
+verify→improve→re-verify の閉ループが成立しない根本原因を特定し、phase 遷移要件を確定する。
+
+## 実行手順
+
+### 0. P50チェック: 既実装状態の調査（必須）
+
+Phase 1 開始時に、対象ファイルの現在の実装状態を確認する。
+
+```bash
+# WorkflowEngine の verify/improve 関連メソッド
+grep -n "recordVerify\|requestReverify\|improve" apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts
+
+# recordVerifyPass の存在有無
+grep -rn "recordVerifyPass" apps/desktop/src/main/services/runtime/
+
+# Facade の verify 経路
+grep -n "verifySkill\|recordVerify\|improve" apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts
+
+# IPC handler の verify 関連
+grep -n "verify\|improve" apps/desktop/src/main/ipc/creatorHandlers.ts
+
+# VerificationEngine テストの最新状態
+grep -n "describe\|it(" apps/desktop/src/main/services/runtime/__tests__/SkillCreatorVerificationEngine.test.ts | head -20
+```
+
+| 判定           | 条件                              | 対応                           |
+| -------------- | --------------------------------- | ------------------------------ |
+| 未実装（想定） | `recordVerifyPass()` が存在しない | 新規実装として進行             |
+| 部分実装       | メソッドは存在するがテスト未整備  | テスト追加・改善として進行     |
+| 既実装         | メソッドもテストも存在する        | スコープ見直しをユーザーに確認 |
 
 ## 実行タスク
 
 ### Task 1: 現状の phase 遷移マッピング
 
-- WorkflowEngine の既存 phase transitions を網羅的に洗い出す
-  - plan→review, review→execute/handoff, execute→verify, verify→review/improve, improve→execute
-- `recordVerifyFailure()` の挙動を記録する（nextAction: "improve" | "review"）
+WorkflowEngine (`SkillCreatorWorkflowEngine.ts`) の既存 phase transitions を網羅的に洗い出す:
+
+- **既存遷移**: plan→review, review→execute/handoff, execute→verify, verify→review/improve, improve→execute
+- `recordVerifyFailure()` の挙動を記録する（nextAction: `"improve"` | `"review"`）
 - `recordVerifyPass()` が不在であることを問題として固定する
-- `requestReverify()` (lines 403-426) の eligibility check を記録する
+- `requestReverify()` (行421-444) の eligibility check を記録する:
+  - execute phase ongoing → re-verify 禁止
+  - terminal_handoff route → re-verify 禁止
+  - no execute result → re-verify 禁止
+  - last execution failed → re-verify 禁止
+- 遷移テーブル（行579-580付近）の `verify: ["review", "improve"]` と `improve: ["execute"]` を記録する
 
 ### Task 2: 欠損遷移の特定
 
-- verify 成功時 → 次 phase が未定義であることを確定する
+- verify 成功時 → 次 phase（complete 等）が未定義であることを確定する
 - improve 完了時 → verify（re-verify）への直接遷移が存在しないことを確定する
-- improve→execute→verify の間接経路が存在するが冗長であることを記録する
+- improve→execute→verify の間接経路が存在するが、verify を経由するのに execute を再実行する冗長性を記録する
+- `SkillCreatorVerifyResult` の status `"pass"` に対応するハンドラが不在であることを確定する
 
 ### Task 3: 受入条件の確定
 
-- AC-1: `recordVerifyPass()` メソッドが WorkflowEngine に存在する
-- AC-2: verify→improve phase 遷移が正しく動作する
-- AC-3: improve→verify (re-verify) phase 遷移が動作する
-- AC-4: execute→verify(fail)→improve→verify(pass) の完全サイクルがテスト可能
-- AC-5: UI snapshot が verify の pass/fail/pending 状態を正しく反映する
-- AC-6: `requestReverify()` が verification engine 結果と統合される
+| AC   | 条件                                                                        | 検証方法       |
+| ---- | --------------------------------------------------------------------------- | -------------- |
+| AC-1 | `recordVerifyPass(planId, checks)` が WorkflowEngine に実装されている       | ユニットテスト |
+| AC-2 | `recordVerifyFailure()` で verify→improve 遷移が正しく動作する（既存確認）  | ユニットテスト |
+| AC-3 | improve→verify (re-verify) phase 遷移が追加され動作する                     | ユニットテスト |
+| AC-4 | execute→verify(fail)→improve→verify(pass) の完全サイクルが1テストで検証可能 | 統合テスト     |
+| AC-5 | UI snapshot が verify の pass/fail/pending 状態を正しく反映する             | 手動テスト     |
+| AC-6 | `requestReverify()` が VerificationEngine 結果を受けて re-verify を発行する | ユニットテスト |
 
 ### Task 4: スコープ境界
 
-- 含む: 閉ループの phase 遷移修復、`recordVerifyPass()` 実装、improve→verify 遷移追加、IPC handler 更新、UI snapshot 連携
-- 含まない: verify engine 本体（P0-01）、manifest 配置（P0-03/04）、WorkflowEngine の全面再設計
+- **含む**: 閉ループの phase 遷移修復、`recordVerifyPass()` 実装、improve→verify 遷移追加、IPC handler 更新、UI snapshot 連携
+- **含まない**: verify engine 本体（P0-01 完了済み）、manifest 配置（P0-03/04）、WorkflowEngine の全面再設計、Layer 3/4 検証ロジック
 
 ## 参照資料
 
-| 資料名             | パス                                                                                    | 説明                        |
-| ------------------ | --------------------------------------------------------------------------------------- | --------------------------- |
-| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts`                  | 閉ループ欠損の本体          |
-| RuntimeFacade      | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`                   | Facade 経由の呼び出し元     |
-| creatorHandlers    | `apps/desktop/src/main/ipc/creatorHandlers.ts`                                          | IPC handler の verify 経路  |
-| skillCreator types | `packages/shared/src/types/skillCreator.ts`                                             | SkillCreatorVerifyResult 型 |
-| remediation pack   | `docs/30-workflows/skill-creator-agent-sdk-lane/p0-verify-manifest-remediation-pack.md` | P0 監査元                   |
+| 資料名             | パス                                                                                    | 説明                           |
+| ------------------ | --------------------------------------------------------------------------------------- | ------------------------------ |
+| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts`                  | 閉ループ欠損の本体             |
+| RuntimeFacade      | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`                   | Facade 経由の呼び出し元        |
+| creatorHandlers    | `apps/desktop/src/main/ipc/creatorHandlers.ts`                                          | IPC handler の verify 経路     |
+| skillCreator types | `packages/shared/src/types/skillCreator.ts`                                             | SkillCreatorVerifyResult 型    |
+| VerificationEngine | `apps/desktop/src/main/services/runtime/SkillCreatorVerificationEngine.ts`              | P0-01 で実装済みの検証エンジン |
+| remediation pack   | `docs/30-workflows/skill-creator-agent-sdk-lane/p0-verify-manifest-remediation-pack.md` | P0 監査元                      |
+
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService、Facade injection パターンの仕様 |
+| Agent IPC チャネル仕様    | `.agents/skills/aiworkflow-requirements/references/api-ipc-agent-core.md`                   | agent:execute、agent:verify 等の IPC チャネル定義    |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時のインターフェース不整合防止チェックリスト  |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`              | パストラバーサル防止、コマンドインジェクション防止   |
 
 ## 統合テスト連携
 
 - Phase 4 で完全サイクルテスト（execute→verify→improve→verify）のケースを定義する
+- Phase 6 でエッジケース（二重verify、improve without fail）を追加する
 - Phase 10 で AC-1〜AC-6 との対応表を再利用する
+
+## 多角的チェック観点
+
+| 観点           | 適用判断                                       | 確認内容                                       |
+| -------------- | ---------------------------------------------- | ---------------------------------------------- |
+| アーキテクチャ | state machine 設計変更のため適用               | 遷移テーブル変更が既存の状態管理と矛盾しないか |
+| IPC通信        | creatorHandlers.ts への handler 追加のため適用 | IPC契約チェックリスト準拠                      |
+| セキュリティ   | IPC handler 追加のため適用                     | sender検証、ホワイトリスト登録                 |
 
 ## 成果物
 
@@ -69,10 +129,12 @@ verify→improve→re-verify の閉ループが成立しない根本原因を特
 
 ## 完了条件
 
+- [ ] P50チェックで対象ファイルの現在状態を確認した
 - [ ] 現状の phase 遷移が網羅的にマッピングされている
-- [ ] 欠損遷移が明確に特定されている
+- [ ] 欠損遷移が明確に特定されている（verify pass / improve→verify）
 - [ ] AC-1〜AC-6 が検証可能な形で定義されている
 - [ ] 含む / 含まないが明確である
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-10-final-review.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-10-final-review.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 11: 手動テスト                             |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -57,6 +58,34 @@ AC-1〜AC-6 の総合判定を行い、閉ループ修復が完全に機能す�
 | カバレッジ       | `outputs/phase-7/coverage-report.md`       | AC 対応表        |
 | 品質保証         | `phase-9-quality-assurance.md`             | gate 入力        |
 | 最終レビュー結果 | `outputs/phase-10/final-review-result.md`  | 判定出力         |
+
+## AC 対応表
+
+| AC   | 条件                                                  | 対応Phase/テスト            | 判定 |
+| ---- | ----------------------------------------------------- | --------------------------- | ---- |
+| AC-1 | recordVerifyPass() が WorkflowEngine に実装されている | Phase 5 Task 1 / UT         | TBD  |
+| AC-2 | verify→improve 遷移が正しく動作する                   | Phase 4 Task 2 / UT         | TBD  |
+| AC-3 | improve→verify (re-verify) 遷移が動作する             | Phase 4 Task 2 / UT         | TBD  |
+| AC-4 | 完全サイクルがテスト可能                              | Phase 4 Task 2 / 統合テスト | TBD  |
+| AC-5 | UI snapshot が verify 状態を反映する                  | Phase 11 / 手動テスト       | TBD  |
+| AC-6 | requestReverify() が engine 結果と統合される          | Phase 4 Task 3 / UT         | TBD  |
+
+## システム仕様（aiworkflow-requirements）
+
+本タスクに関連する正本仕様への確認事項:
+
+### IPC 契約チェックリスト
+
+- [ ] `creatorHandlers.ts` の IPC チャネル定義が `packages/shared/src/ipc/channels.ts` と整合している
+- [ ] verify/improve 関連の IPC メッセージ型が `packages/shared/src/types/skill-*.ts` に定義されている
+- [ ] `preload/skill-api.ts` に verify/improve 操作のブリッジが公開されている
+- [ ] safeInvoke のタイムアウト設定が正本仕様と一致している
+
+### Skill Creator Service 仕様
+
+- [ ] `interfaces-agent-sdk-skill-reference.md` の verify/improve 遷移仕様を確認した
+- [ ] WorkflowEngine の phase transition spec が正本仕様と一致している
+- [ ] `task-workflow-phases.md` のフェーズ遷移テーブルとの整合性を確認した
 
 ## 統合テスト連携
 

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-11-manual-test.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-11-manual-test.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 12: ドキュメント更新                       |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -34,7 +35,17 @@
 - verify pass 状態の UI 表示を確認する（成功表示）
 - improve 中の UI 表示を確認する（進行状態）
 
-### Task 3: 非視覚証跡方針の定義
+### Task 3: AC-5 手動テスト項目（UI snapshot が verify 状態を反映）
+
+本タスクはバックエンド（Main Process）の state machine 修正が中心であるため、スクリーンショットは「推奨」レベルとする。ただし AC-5 の検証として以下を手動で確認する:
+
+- [ ] verify pending 状態の UI 表示確認
+- [ ] verify pass 状態の UI 表示確認
+- [ ] verify fail 状態の UI 表示確認
+- [ ] improve 中の UI 表示確認
+- [ ] 完全サイクル（execute→verify→improve→verify）の画面遷移確認
+
+### Task 4: 非視覚証跡方針の定義
 
 - 現時点は `NON_VISUAL` として PNG 証跡を要求しないことを記録する
 - 実装完了後に再実施すべき手順を残す
@@ -49,6 +60,14 @@
 | 最終レビュー    | `phase-10-final-review.md`                                             | 手動確認対象           |
 | WorkflowEngine  | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | 操作対象               |
 | creatorHandlers | `apps/desktop/src/main/ipc/creatorHandlers.ts`                         | IPC 経路確認           |
+
+## 適用判断
+
+| タスク種別                      | スクリーンショット | 判断基準                         |
+| ------------------------------- | ------------------ | -------------------------------- |
+| IPC/API変更 + UI snapshot 連携  | 推奨               | DevTools動作確認エビデンスとして |
+| バックエンド state machine のみ | 不要               | UT/統合テストで十分              |
+| UI コンポーネント新規/大幅変更  | 必須               | 視覚的な回帰検出に不可欠         |
 
 ## 統合テスト連携
 

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-12-documentation.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-12-documentation.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 13: PR作成                                 |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -24,7 +25,9 @@ task-specification-creator の Phase 12 必須 6 成果物を canonical filename
 - **Part 1: 中学生レベルの概念説明**
   - 「検証 → 改善 → 再検証」のループを日常的な比喩で説明する
   - テストの答え合わせ → 間違い直し → 再テストの流れとして説明する
+    - たとえば、学校のテストで答え合わせをして（verify）、間違えた問題を解き直して（improve）、もう一度テストを受ける（re-verify）という流れと同じ。最初のテストで 80 点だったら、間違えた 20 点分の問題を復習してから、もう一度テストを受けて 100 点を目指す。このプログラムでも「スキルを作る → 出来を確認する → ダメなところを直す → もう一度確認する」というサイクルを自動で回している
   - なぜこのループが大切なのかを平易な言葉で説明する
+  - `たとえば` を最低 1 回含めること（validator 安定化ルール準拠）
 - **Part 2: 技術詳細**
   - `recordVerifyPass()` の追加内容と使い方
   - phase 遷移テーブルの変更点
@@ -36,6 +39,9 @@ task-specification-creator の Phase 12 必須 6 成果物を canonical filename
 
 - `system-spec-update-summary.md` に参照した正本仕様と no-op / update 判定を書く
 - WorkflowEngine の phase transition spec への反映有無を記録する
+- **更新対象として以下を明記すること**:
+  - `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` — Skill Creator Service の verify/improve 仕様更新
+  - `.agents/skills/aiworkflow-requirements/references/task-workflow-phases.md` — フェーズ遷移テーブルの更新反映
 
 ### Task 12-3: 変更履歴
 
@@ -76,12 +82,24 @@ task-specification-creator の Phase 12 必須 6 成果物を canonical filename
 | スキルフィードバック  | `outputs/phase-12/skill-feedback-report.md`              | skill 改善案       |
 | Phase 12 準拠チェック | `outputs/phase-12/phase12-task-spec-compliance-check.md` | 6 成果物確認       |
 
+## 漏れやすいポイント（06-known-pitfalls.md参照）
+
+| ID  | ポイント                            | 対策                                                                |
+| --- | ----------------------------------- | ------------------------------------------------------------------- |
+| P1  | LOGS.md 2ファイル更新漏れ           | aiworkflow-requirements + task-specification-creator 両方を同時更新 |
+| P2  | topic-map.md 再生成忘れ             | セクション変更時は必ず generate-index.js を実行                     |
+| P27 | topic-map.md 再生成トリガー判断ミス | 追加だけでなく削除・更新も再生成トリガー                            |
+| P29 | SKILL.md 変更履歴の更新漏れ         | LOGS.md とは別に SKILL.md の変更履歴テーブルも必ず更新              |
+
 ## 完了条件
 
 - [ ] 必須 6 成果物が揃っている
 - [ ] Part 1（中学生レベル）と Part 2（技術詳細）が分離されている
 - [ ] 計画系文言が除去されている
 - [ ] skill 準拠結果が記録されている
+- [ ] aiworkflow-requirements/LOGS.md にタスク完了エントリを追加した
+- [ ] task-specification-creator/LOGS.md にタスク完了記録を追加した
+- [ ] topic-map.md を再生成した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-13-pr-creation.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-13-pr-creation.md
@@ -11,6 +11,7 @@
 | 次Phase    | -                                                |
 | ステータス | blocked                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -33,6 +34,33 @@
 
 - ユーザー承認がない限り commit / push / PR を実行しない
 - TASK-P0-01 の完了状況を PR 前提条件として記録する
+
+### Task 3: PR 作成手順
+
+- `/ai:diff-to-pr` スキルを使用して PR を作成する
+- PR 本文に関連 Issue `#1725` を含める（`Closes #1725` または `Related: #1725`）
+- PR 本文のテンプレート:
+
+  ```
+  ## Summary
+  - TASK-P0-02: verify→improve→re-verify 閉ループ修復
+  - recordVerifyPass() の追加、phase 遷移テーブルの修正、improve→verify 遷移の実装
+
+  ## Related Issue
+  - #1725
+
+  ## Test plan
+  - [ ] UT: recordVerifyPass() のユニットテスト
+  - [ ] UT: improve→verify 遷移テスト
+  - [ ] 統合テスト: 完全サイクル（execute→verify→improve→verify）
+  - [ ] 手動テスト: UI snapshot の verify 状態反映
+  ```
+
+### Task 4: タスクディレクトリの完了時移動
+
+- PR マージ後、タスクディレクトリを以下に移動する:
+  - 移動元: `docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/`
+  - 移動先: `docs/30-workflows/completed-tasks/`
 
 ## 参照資料
 

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-2-design.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-2-design.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 3: 設計レビュー                            |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -20,60 +21,213 @@
 
 ### Task 1: recordVerifyPass() シグネチャ設計
 
-- `recordVerifyFailure()` と対称的なインターフェースで `recordVerifyPass()` を定義する
-- 引数: `SkillCreatorVerifyResult` (status: "pass")
-- 戻り値: phase 遷移結果（verify→complete or verify→handoff）
-- verify pass 後の nextAction を定義する（"complete" | "handoff"）
+`recordVerifyFailure()` と対称的なインターフェースで設計する:
+
+```typescript
+// 既存: recordVerifyFailure() (WorkflowEngine.ts:258-285)
+recordVerifyFailure(
+  planId: string,
+  message: string,
+  nextAction: "review" | "improve" = "improve",
+): SkillCreatorWorkflowStateSnapshot
+
+// 新規: recordVerifyPass()
+recordVerifyPass(
+  planId: string,
+  checks: RuntimeSkillCreatorVerifyCheck[],
+): SkillCreatorWorkflowStateSnapshot
+```
+
+設計ポイント:
+
+- `checks` 引数で VerificationEngine の結果を受け取る（P0-01 の `verify()` の戻り値と同型）
+- verify pass 後の遷移先は `"complete"` phase（新規追加）
+- 戻り値は既存の snapshot パターンに準拠する
 
 ### Task 2: phase 遷移テーブル修正設計
 
-- 現行遷移テーブルに以下を追加:
-  - verify(pass) → complete（または次フェーズ）
-  - improve → verify（re-verify 直接遷移）
-- improve→execute→verify の間接経路を残しつつ、improve→verify のショートカットを追加する
-- 遷移テーブルの一貫性を state machine 図で確認する
+現行遷移テーブル（WorkflowEngine.ts:579-580付近）に以下を追加:
+
+```typescript
+// 現行
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  plan: ["review"],
+  review: ["execute", "handoff"],
+  execute: ["verify"],
+  verify: ["review", "improve"], // ← pass 時の遷移先がない
+  improve: ["execute"], // ← re-verify への直接遷移がない
+  // ...
+};
+
+// 修正後
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  plan: ["review"],
+  review: ["execute", "handoff"],
+  execute: ["verify"],
+  verify: ["review", "improve", "complete"], // ← pass 時に complete へ遷移
+  improve: ["execute", "verify"], // ← re-verify 直接遷移を追加
+  complete: [], // ← terminal state
+  // ...
+};
+```
 
 ```mermaid
 stateDiagram-v2
+    [*] --> plan
+    plan --> review
+    review --> execute
+    review --> handoff
     execute --> verify
-    verify --> improve : fail
-    verify --> complete : pass (NEW)
-    improve --> execute : 既存
-    improve --> verify : re-verify (NEW)
+    verify --> improve : fail (recordVerifyFailure)
+    verify --> complete : pass (recordVerifyPass) [NEW]
+    verify --> review : review requested
+    improve --> execute : 既存経路
+    improve --> verify : re-verify [NEW]
+    complete --> [*]
 ```
 
 ### Task 3: verification engine 統合設計
 
-- P0-01 の SkillCreatorVerificationEngine から verify 結果を受け取る interface を定義する
-- `requestReverify()` の eligibility check を verification engine の状態と連動させる
-- auto-populate checks の結果を `recordVerifyPass()` / `recordVerifyFailure()` に渡す流れを設計する
+P0-01 の SkillCreatorVerificationEngine からの data flow を設計する:
+
+```
+Facade.verifySkill(skillDir)
+  → VerificationEngine.verify(skillDir)
+  → RuntimeSkillCreatorVerifyCheck[]
+  → determineVerifyStatus(checks)
+     → "skip"               : engine 未注入（空配列）
+     → "pass"               : 全チェック pass（warning なし）
+     → "pass_with_warnings" : fail なし、warning あり
+     → "fail"               : 1件以上 fail
+```
+
+- verify ステータス判定ロジック（**方針 B + Y** を採用）:
+
+  ```typescript
+  type VerifyStatus = "skip" | "pass" | "pass_with_warnings" | "fail";
+
+  function determineVerifyStatus(
+    checks: RuntimeSkillCreatorVerifyCheck[],
+  ): VerifyStatus {
+    // engine 未注入時は空配列 → 検証スキップを明示
+    if (checks.length === 0) return "skip";
+
+    const hasFail = checks.some((c) => c.status === "fail");
+    if (hasFail) return "fail";
+
+    const hasWarning = checks.some((c) => c.severity === "warning");
+    if (hasWarning) return "pass_with_warnings";
+
+    return "pass";
+  }
+  ```
+
+- **設計根拠**:
+  - `"skip"`: graceful degradation を維持しつつ、「検証していない」ことをUI/ログで明示する。暗黙の pass を防ぐ
+  - `"pass_with_warnings"`: warning を記録しつつフローはブロックしない。UIで⚠️表示し開発者に注意を促す
+  - `"pass"` / `"fail"`: 従来通りの明確な分岐
+- `recordVerifyPass()` は `"pass"` と `"pass_with_warnings"` の両方で呼び出す。`"skip"` 時は遷移せずスキップを記録のみ
+- `requestReverify()` の eligibility check を新遷移と整合させる:
+  - improve phase からの re-verify: eligibility check を緩和し、improve phase からの直接遷移を許可する
+  - verify phase からの再 verify: 既存の disabled conditions を維持する
 
 ### Task 4: UI snapshot 変更設計
 
-- verify 状態の pass/fail/pending を SkillCreatorSnapshot に反映する
-- creatorHandlers.ts の IPC 経路で verify 結果を renderer に通知する設計
-- 既存の `getCreatorSnapshot` が verify 状態を含むよう拡張する
+SkillCreatorSnapshot（`getCreatorSnapshot` の戻り値）に verify 状態を追加:
+
+```typescript
+interface SkillCreatorWorkflowStateSnapshot {
+  // 既存フィールド
+  phase: string;
+  planId: string;
+  // ...
+
+  // 新規追加
+  verifyStatus?: "pending" | "pass" | "pass_with_warnings" | "fail" | "skip";
+  verifyChecks?: RuntimeSkillCreatorVerifyCheck[];
+  lastVerifyTimestamp?: string;
+}
+```
+
+IPC 経路:
+
+- `creatorHandlers.ts` で verify 結果を snapshot に含めて renderer に通知する
+- 既存の `getCreatorSnapshot` IPC ハンドラを拡張する（新規ハンドラ追加は不要）
 
 ### Task 5: RuntimeSkillCreatorFacade 統合設計
 
-- Facade 経由で `recordVerifyPass()` を呼び出す経路を定義する
-- 既存の `recordVerifyFailure()` と並列に配置する
-- improve 後の re-verify 要求を Facade から発行する方法を定義する
+Facade に以下のメソッドを追加/修正:
+
+```typescript
+// 新規: verify 結果に基づく閉ループ処理
+async processVerifyResult(planId: string, skillDir: string): Promise<VerifyStatus> {
+  const checks = await this.verifySkill(skillDir);
+  const status = determineVerifyStatus(checks);
+
+  switch (status) {
+    case "skip":
+      // engine 未注入 — 遷移せずスキップを記録
+      this.workflowEngine.recordVerifySkip(planId);
+      break;
+    case "pass":
+    case "pass_with_warnings":
+      // 成功（warning 含む）— complete へ遷移
+      this.workflowEngine.recordVerifyPass(planId, checks);
+      break;
+    case "fail":
+      // 失敗 — improve へ遷移
+      const failMessages = checks.filter(c => c.status === "fail").map(c => c.message);
+      this.workflowEngine.recordVerifyFailure(planId, failMessages.join("; "), "improve");
+      break;
+  }
+  return status;
+}
+
+// 新規: improve 後の re-verify
+async requestReVerify(planId: string, skillDir: string): Promise<void> {
+  // improve phase から直接 verify phase へ遷移
+  this.workflowEngine.transitionToVerify(planId);
+  await this.processVerifyResult(planId, skillDir);
+}
+```
 
 ## 参照資料
 
-| 資料名             | パス                                                                   | 説明                        |
-| ------------------ | ---------------------------------------------------------------------- | --------------------------- |
-| 要件定義           | `phase-1-requirements.md`                                              | AC-1〜AC-6                  |
-| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | 遷移テーブル修正対象        |
-| RuntimeFacade      | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`  | Facade 統合対象             |
-| creatorHandlers    | `apps/desktop/src/main/ipc/creatorHandlers.ts`                         | IPC handler 更新対象        |
-| skillCreator types | `packages/shared/src/types/skillCreator.ts`                            | SkillCreatorVerifyResult 型 |
+| 資料名             | パス                                                                       | 説明                         |
+| ------------------ | -------------------------------------------------------------------------- | ---------------------------- |
+| 要件定義           | `phase-1-requirements.md`                                                  | AC-1〜AC-6                   |
+| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts`     | 遷移テーブル修正対象         |
+| RuntimeFacade      | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`      | Facade 統合対象              |
+| VerificationEngine | `apps/desktop/src/main/services/runtime/SkillCreatorVerificationEngine.ts` | P0-01 実装済みの verify 本体 |
+| creatorHandlers    | `apps/desktop/src/main/ipc/creatorHandlers.ts`                             | IPC handler 更新対象         |
+| skillCreator types | `packages/shared/src/types/skillCreator.ts`                                | SkillCreatorVerifyResult 型  |
+
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService、Facade injection パターン、verify/improve の詳細仕様 |
+| Agent IPC チャネル仕様    | `.agents/skills/aiworkflow-requirements/references/api-ipc-agent-core.md`                   | IPC チャネル定義。verify 結果通知の IPC 設計に参照                        |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時の Main/Preload/型定義 同時更新チェック                          |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`              | IPC handler のセキュリティパターン                                        |
+| Skill lifecycle hooks     | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-details.md`   | Skill lifecycle hooks 仕様。improve/verify の hook 連携                   |
 
 ## 統合テスト連携
 
 - 遷移テーブルの全 edge を Phase 4 のテストケースに落とす
 - UI snapshot の verify 状態が renderer テストで観測可能であることを確認する
+- Facade の `processVerifyResult()` と `requestReVerify()` の統合テストを Phase 6 で追加する
+
+## 多角的チェック観点
+
+| 観点               | 適用判断                                       | 確認内容                                                   |
+| ------------------ | ---------------------------------------------- | ---------------------------------------------------------- |
+| アーキテクチャ     | state machine 遷移テーブル変更のため適用       | dead state がないこと、既存遷移との矛盾がないこと          |
+| IPC通信            | verify 結果の snapshot 通知設計のため適用      | IPC契約チェックリスト準拠（Main/Preload/型定義の同時更新） |
+| セキュリティ       | IPC handler 変更のため適用                     | sender検証、ホワイトリスト登録、パストラバーサル防止       |
+| エラーハンドリング | verify 失敗時の improve 遷移ロジックのため適用 | graceful degradation（engine 未注入時は空配列）の維持      |
 
 ## 成果物
 
@@ -83,11 +237,13 @@ stateDiagram-v2
 
 ## 完了条件
 
-- [ ] `recordVerifyPass()` のシグネチャが確定している
-- [ ] phase 遷移テーブルに improve→verify と verify(pass) が追加されている
-- [ ] verification engine との統合 interface が定義されている
-- [ ] UI snapshot 変更が設計されている
-- [ ] Facade 統合経路が定義されている
+- [ ] `recordVerifyPass(planId, checks)` のシグネチャが確定している
+- [ ] phase 遷移テーブルに `verify→complete` と `improve→verify` が追加されている
+- [ ] `complete` terminal state が定義されている
+- [ ] verification engine との統合 data flow が `allPass` 判定基準を含めて設計されている
+- [ ] UI snapshot に `verifyStatus` / `verifyChecks` が追加されている
+- [ ] Facade に `processVerifyResult()` / `requestReVerify()` が設計されている
+- [ ] aiworkflow-requirements の関連仕様との整合性を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-3-design-review.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-3-design-review.md
@@ -1,16 +1,17 @@
-# Phase 3: 設計レビュー
+# Phase 3: 設計レビューゲート
 
 ## メタ情報
 
 | 項目       | 内容                                             |
 | ---------- | ------------------------------------------------ |
 | Phase      | 3                                                |
-| Phase名    | 設計レビュー                                     |
+| Phase名    | 設計レビューゲート                               |
 | 対象機能   | TASK-P0-02 verify→improve→re-verify 閉ループ修復 |
 | 前提Phase  | Phase 2: 設計                                    |
 | 次Phase    | Phase 4: テスト作成                              |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -24,53 +25,92 @@ state machine の一貫性、遷移テーブルの完全性、verification engin
 - dead state（到達不能状態）が存在しないことを確認する
 - verify(pass) と verify(fail) の分岐が対称的であることを確認する
 - improve→verify と improve→execute の選択基準が明確であることを確認する
+- `complete` terminal state が正しい終了条件を持つことを確認する
 
 ### Task 2: 遷移テーブル完全性検証
 
-- 全 phase 対の遷移可否を表にして漏れを検出する
+全 phase 対の遷移可否マトリクスを作成して漏れを検出する:
+
+| from\to  | plan | review | execute | verify  | improve | complete | handoff |
+| -------- | ---- | ------ | ------- | ------- | ------- | -------- | ------- |
+| plan     | -    | ✅     | ❌      | ❌      | ❌      | ❌       | ❌      |
+| review   | ❌   | -      | ✅      | ❌      | ❌      | ❌       | ✅      |
+| execute  | ❌   | ❌     | -       | ✅      | ❌      | ❌       | ❌      |
+| verify   | ❌   | ✅     | ❌      | -       | ✅      | ✅(NEW)  | ❌      |
+| improve  | ❌   | ❌     | ✅      | ✅(NEW) | -       | ❌       | ❌      |
+| complete | ❌   | ❌     | ❌      | ❌      | ❌      | -        | ❌      |
+
+確認項目:
+
 - 不正遷移（例: plan→verify）が禁止されていることを確認する
 - reverify disabled conditions が新遷移と矛盾しないことを確認する:
-  - execute phase ongoing
-  - terminal_handoff route
-  - no execute result
-  - last execution failed
+  - execute phase ongoing → re-verify 禁止（improve phase なら許可）
+  - terminal_handoff route → re-verify 禁止
+  - no execute result → re-verify 禁止
+  - last execution failed → re-verify 禁止
 
 ### Task 3: P0-01 との統合整合性
 
-- TASK-P0-01 の verification engine interface と P0-02 の統合設計に矛盾がないことを確認する
-- auto-populate checks → verify result → recordVerifyPass/Failure の data flow に断絶がないことを確認する
+- TASK-P0-01 の `SkillCreatorVerificationEngine.verify()` の戻り値 `RuntimeSkillCreatorVerifyCheck[]` が `recordVerifyPass()` の引数と型一致することを確認する
+- `allPass` 判定基準（`checks.every(c => c.status === "pass" || c.severity === "warning")`）が P0-01 の Layer 1/2 チェック結果と整合することを確認する
+- Facade の graceful degradation（engine 未注入時は空配列→allPass→pass）が意図した挙動かを判定する
+  - 空配列→pass は検証をスキップすることを意味するため、許容するか要判断
 
-### Task 4: gate 判定
+### Task 4: IPC 契約整合性
 
-- PASS: 遷移テーブルが一貫しており実装に進める
-- MAJOR: 遷移テーブルに矛盾があり設計修正が必要
-- CRITICAL: state machine の根本設計を見直す必要がある
+Phase 2 で設計した IPC 変更が以下と矛盾しないことを確認する:
+
+- `ipc-contract-checklist.md` の必須項目（Main Process / Preload API / 型定義の同時更新）
+- 既存の creatorHandlers の登録パターンとの一貫性
+- `security-skill-ipc-core.md` のセキュリティパターン
+
+### Task 5: gate 判定
+
+| 判定     | 条件                                       | 対応                             |
+| -------- | ------------------------------------------ | -------------------------------- |
+| PASS     | 遷移テーブルが一貫しており実装に進める     | Phase 4 へ                       |
+| MINOR    | 軽微な設計修正が必要だが実装可能           | 修正内容を記録し Phase 4 へ      |
+| MAJOR    | 遷移テーブルに矛盾があり設計修正が必要     | Phase 2 へ差し戻し               |
+| CRITICAL | state machine の根本設計を見直す必要がある | Phase 1 へ差し戻しユーザーに確認 |
 
 ## 参照資料
 
-| 資料名             | パス                                                                   | 説明             |
-| ------------------ | ---------------------------------------------------------------------- | ---------------- |
-| 設計書             | `phase-2-design.md`                                                    | レビュー対象     |
-| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | 既存遷移テーブル |
-| skillCreator types | `packages/shared/src/types/skillCreator.ts`                            | 型定義の整合性   |
+| 資料名             | パス                                                                       | 説明                |
+| ------------------ | -------------------------------------------------------------------------- | ------------------- |
+| 設計書             | `phase-2-design.md`                                                        | レビュー対象        |
+| 要件定義           | `phase-1-requirements.md`                                                  | AC-1〜AC-6          |
+| WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts`     | 既存遷移テーブル    |
+| VerificationEngine | `apps/desktop/src/main/services/runtime/SkillCreatorVerificationEngine.ts` | P0-01 verify 結果型 |
+| skillCreator types | `packages/shared/src/types/skillCreator.ts`                                | 型定義の整合性      |
+
+### システム仕様（aiworkflow-requirements）
+
+> 設計レビューで必ず以下の仕様との整合性を確認してください。
+
+| 参照資料                  | パス                                                                                        | 内容                         |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------- |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC変更の整合性検証          |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`              | セキュリティパターン準拠確認 |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | Facade pattern との整合性    |
 
 ## 統合テスト連携
 
 - Phase 4 のテスト観点が AC-1〜AC-6 を 1:1 に覆うことを確認する
-- 遷移テーブルの全 edge がテストケースに対応することを確認する
+- 遷移テーブルの全 edge（新規追加の `verify→complete` と `improve→verify` を含む）がテストケースに対応することを確認する
 
 ## 成果物
 
-| 成果物           | パス                               | 説明                            |
-| ---------------- | ---------------------------------- | ------------------------------- |
-| 設計レビュー結果 | `outputs/phase-3/review-result.md` | gate 判定と遷移テーブル検証結果 |
+| 成果物           | パス                               | 説明                                                 |
+| ---------------- | ---------------------------------- | ---------------------------------------------------- |
+| 設計レビュー結果 | `outputs/phase-3/review-result.md` | gate 判定、遷移マトリクス検証結果、P0-01統合検証結果 |
 
 ## 完了条件
 
-- [ ] state machine の一貫性が確認されている
-- [ ] 遷移テーブルに漏れがないことが検証されている
-- [ ] P0-01 との統合に矛盾がないことが確認されている
-- [ ] gate 判定が明示されている
+- [ ] state machine の一貫性が確認されている（dead state なし、全 edge 到達可能）
+- [ ] 遷移テーブル完全性マトリクスが作成され漏れがないことが検証されている
+- [ ] P0-01 との統合に矛盾がないことが確認されている（型一致、allPass判定基準）
+- [ ] IPC契約整合性が確認されている
+- [ ] gate 判定（PASS/MINOR/MAJOR/CRITICAL）が明示されている
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-4-test-creation.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-4-test-creation.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 5: 実装                                    |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -20,6 +21,7 @@
 
 ### Task 1: recordVerifyPass() ユニットテスト
 
+- **テストファイル**: `apps/desktop/src/main/services/runtime/__tests__/SkillCreatorWorkflowEngine.test.ts`
 - verify phase で `recordVerifyPass()` を呼ぶと正しい phase に遷移する
 - verify phase 以外で `recordVerifyPass()` を呼ぶとエラーになる
 - `SkillCreatorVerifyResult` の status: "pass" が正しく処理される
@@ -30,6 +32,16 @@
 - 各遷移で phase が正しく変わることを assert する
 - verify(fail) 後の nextAction が "improve" であることを確認する
 - re-verify 後の verify(pass) で最終状態に到達することを確認する
+
+**テスト関数シグネチャ（推奨構造）**:
+
+```typescript
+describe("verify→improve→re-verify closed loop", () => {
+  it("should complete full cycle: execute→verify(fail)→improve→verify(pass)", () => {});
+  it("should transition verify→complete on pass", () => {});
+  it("should transition improve→verify for re-verify", () => {});
+});
+```
 
 ### Task 3: エッジケーステスト
 
@@ -47,6 +59,7 @@
 - verify pass 時の snapshot 形状を定義する
 - verify fail 時の snapshot 形状を定義する
 - improve 中の snapshot 形状を定義する
+- **参照**: `RuntimeSkillCreatorFacade.test.ts` の既存 snapshot テストパターンと整合させる
 
 ## 参照資料
 
@@ -55,6 +68,24 @@
 | 設計レビュー   | `phase-3-design-review.md`                                             | gate 結果          |
 | 設計成果物     | `outputs/phase-2/design-document.md`                                   | 遷移テーブルと設計 |
 | WorkflowEngine | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | テスト対象         |
+
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService、Facade injection パターンの仕様 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時のインターフェース不整合防止チェックリスト  |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`              | セキュリティパターン                                 |
+
+## 多角的チェック観点
+
+| 観点               | 適用判断                                       | 確認内容                                     |
+| ------------------ | ---------------------------------------------- | -------------------------------------------- |
+| アーキテクチャ     | state machine 設計変更のため適用               | 遷移テーブル変更が既存パターンと一致すること |
+| IPC通信            | creatorHandlers.ts への handler 追加のため適用 | IPC契約チェックリスト準拠                    |
+| エラーハンドリング | verify 失敗時の improve 遷移のため適用         | graceful degradation の維持                  |
 
 ## 統合テスト連携
 
@@ -74,6 +105,7 @@
 - [ ] エッジケース（二重 verify、improve without fail）が定義されている
 - [ ] UI snapshot の期待形状が定義されている
 - [ ] AC-1〜AC-6 とテストが対応している
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-5-implementation.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-5-implementation.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 6: テスト拡充                              |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -25,6 +26,16 @@ WorkflowEngine に `recordVerifyPass()` を追加し、improve→verify 遷移�
 - verify phase であることを前提条件として assert する
 - verify pass 後の phase 遷移先を設定する
 
+**既存シグネチャ（対称参照）**:
+
+```typescript
+// 既存: recordVerifyFailure (line 258-285)
+recordVerifyFailure(planId: string, message: string, nextAction: "review" | "improve" = "improve"): SkillCreatorWorkflowStateSnapshot
+
+// 新規: recordVerifyPass
+recordVerifyPass(planId: string, checks: RuntimeSkillCreatorVerifyCheck[]): SkillCreatorWorkflowStateSnapshot
+```
+
 ### Task 2: phase 遷移テーブルの修正
 
 - improve→verify（re-verify）遷移を遷移テーブルに追加する
@@ -32,11 +43,29 @@ WorkflowEngine に `recordVerifyPass()` を追加し、improve→verify 遷移�
 - `requestReverify()` の eligibility check を新遷移と整合させる
 - 不正遷移のガードを維持する
 
+**遷移テーブル修正内容（before/after）**:
+
+| 遷移           | Before（現状）           | After（修正後）               |
+| -------------- | ------------------------ | ----------------------------- |
+| verify(pass)   | 遷移先なし（未実装）     | verify → complete             |
+| improve→verify | 遷移不可                 | improve → verify（re-verify） |
+| verify(fail)   | verify → improve（既存） | 変更なし                      |
+
 ### Task 3: RuntimeSkillCreatorFacade 更新
 
 - `recordVerifyPass()` を Facade 経由で呼び出せるようにする
 - improve 完了後に re-verify を要求するメソッドを追加または修正する
 - 既存の `recordVerifyFailure()` 経路との並列配置を確認する
+
+**追加メソッド設計**:
+
+```typescript
+// verify 結果を処理し、pass/fail に応じて適切な遷移を実行する
+processVerifyResult(planId: string, result: SkillCreatorVerifyResult): SkillCreatorWorkflowStateSnapshot
+
+// improve 完了後に re-verify を要求する（eligibility check 付き）
+requestReVerify(planId: string): SkillCreatorWorkflowStateSnapshot
+```
 
 ### Task 4: IPC handler 更新
 
@@ -47,7 +76,17 @@ WorkflowEngine に `recordVerifyPass()` を追加し、improve→verify 遷移�
 ### Task 5: UI snapshot 拡張
 
 - `getCreatorSnapshot` が verify の pass/fail/pending 状態を含むよう修正する
-- `SkillCreatorVerifyResult` の status を snapshot に���映する
+- `SkillCreatorVerifyResult` の status を snapshot に反映する
+
+**追加 snapshot フィールド**:
+
+```typescript
+{
+  verifyStatus: "pending" | "pass" | "fail" | null;  // 現在の verify 状態
+  verifyChecks: RuntimeSkillCreatorVerifyCheck[];     // 個別チェック結果の配列
+  lastVerifyTimestamp: string | null;                 // 最終 verify 実行日時（ISO 8601）
+}
+```
 
 ## 参照資料
 
@@ -58,7 +97,25 @@ WorkflowEngine に `recordVerifyPass()` を追加し、improve→verify 遷移�
 | WorkflowEngine     | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | 修正本体        |
 | RuntimeFacade      | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`  | Facade 修正対象 |
 | creatorHandlers    | `apps/desktop/src/main/ipc/creatorHandlers.ts`                         | IPC 修正対象    |
-| skillCreator types | `packages/shared/src/types/skillCreator.ts`                            | 型定義の参��    |
+| skillCreator types | `packages/shared/src/types/skillCreator.ts`                            | 型定義の参照    |
+
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService、Facade injection パターンの仕様 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時のインターフェース不整合防止チェックリスト  |
+| スキル実行IPCセキュリティ | `.agents/skills/aiworkflow-requirements/references/security-skill-ipc-core.md`              | セキュリティパターン                                 |
+
+## 多角的チェック観点
+
+| 観点               | 適用判断                                       | 確認内容                                     |
+| ------------------ | ---------------------------------------------- | -------------------------------------------- |
+| アーキテクチャ     | state machine 設計変更のため適用               | 遷移テーブル変更が既存パターンと一致すること |
+| IPC通信            | creatorHandlers.ts への handler 追加のため適用 | IPC契約チェックリスト準拠                    |
+| エラーハンドリング | verify 失敗時の improve 遷移のため適用         | graceful degradation の維持                  |
 
 ## 統合テスト連携
 
@@ -79,6 +136,7 @@ WorkflowEngine に `recordVerifyPass()` を追加し、improve→verify 遷移�
 - [ ] IPC handler が verify pass を処理する
 - [ ] UI snapshot が verify 状態を含む
 - [ ] Phase 4 のテストが全て pass する
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-6-test-expansion.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-6-test-expansion.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 7: カバレッジ確認                          |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -42,6 +43,25 @@
 - verification engine のチェック結果が空の場合の挙動を確認する
 - P0-01 未完了時のフォールバック動作を確認する
 
+### Task 5: エッジケーステスト
+
+以下のエッジケースを網羅的にテストする:
+
+- **verify(pass) 後の重複呼び出し**: `recordVerifyPass()` で pass 遷移した後に再度 `recordVerifyPass()` を呼ぶとエラーになることを確認する
+- **improve without prior fail のガード**: verify fail を経ずに improve フェーズに入ろうとした場合のガードが機能することを確認する
+- **improve→verify→fail→improve サイクル**: improve→verify 遷移後、再度 fail して improve に戻るサイクルが正しく動作することを確認する
+- **`requestReverify()` eligibility check 全パターン**: 以下の 4 条件それぞれで eligibility が正しく判定されることを確認する
+  1. 現在の phase が improve でない場合 → 不可
+  2. verify 結果が未記録の場合 → 不可
+  3. improve 完了条件が満たされていない場合 → 不可
+  4. 全条件を満たしている場合 → 可
+
+### テストファイル
+
+| テストファイル        | パス                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| WorkflowEngine テスト | `apps/desktop/src/main/services/runtime/__tests__/SkillCreatorWorkflowEngine.test.ts` |
+
 ## 参照資料
 
 | 資料名         | パス                                                                   | 説明               |
@@ -50,32 +70,43 @@
 | WorkflowEngine | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | テスト対象         |
 | RuntimeFacade  | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`  | 並行フロー観測対象 |
 
-## 統合���スト連携
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService仕様との整合性確認 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時の整合性確認                 |
+
+## 統合テスト連携
 
 - 並行フローの排他制御が実装全体で一貫することを確認する
 - handoff 状態との整合が Phase 9 の品質保証で再確認される
 
-## 成果���
+## 成果物
 
 | 成果物         | パス                                      | 説明                              |
 | -------------- | ----------------------------------------- | --------------------------------- |
-| テスト拡充記�� | `outputs/phase-6/extended-test-record.md` | 並行フロー・handoff・多周回ケース |
+| テスト拡充記録 | `outputs/phase-6/extended-test-record.md` | 並行フロー・handoff・多周回ケース |
 
 ## 完了条件
 
-- [ ] 並行フローの境界ケースが追加��れている
+- [ ] 並行フローの境界ケースが追加されている
 - [ ] handoff 中の verify サイクルがテストされている
 - [ ] 複数回 re-verify がテストされている
-- [ ] verification engine 統合の境界がテ���トされている
-- [ ] 本Phase��の全タスクを100%実行完了
+- [ ] verification engine 統合の境界がテストされている
+- [ ] エッジケーステスト（verify(pass) 重複、improve without fail ガード、サイクル、eligibility 全パターン）が追加されている
+- [ ] aiworkflow-requirements の関連仕様を確認した
+- [ ] 本Phase内の全タスクを100%実行完了
 
-## タスク100%実行確認���必須】
+## タスク100%実行確認【必須】
 
 - [ ] 本Phase内の全タスクを100%実行完了
-- [ ] 各タスクの成果物が生成���れている
+- [ ] 各タスクの成果物が生成されている
 - [ ] artifacts.jsonが更新されている
-- [ ] Phase末端で各タスクを100%完了し、完了を��記している
+- [ ] Phase末端で各タスクを100%完了し、完了を明記している
 
-## ���Phase
+## 次Phase
 
 → [Phase 7: カバレッジ確認](./phase-7-coverage-check.md)

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-7-coverage-check.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-7-coverage-check.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 8: リファクタリング                        |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -39,6 +40,14 @@ AC-1〜AC-6 と全遷移 edge のカバレッジを照合し、閉ループ修�
 - WorkflowEngine、Facade、IPC handler の 3 層が各層でテストされていることを確認する
 - verification engine との統合レイヤーがテストされていることを確認する
 
+### カバレッジ測定対象ファイル
+
+| ファイル                   | パス                                                                   | 測定対象                                 |
+| -------------------------- | ---------------------------------------------------------------------- | ---------------------------------------- |
+| SkillCreatorWorkflowEngine | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | `recordVerifyPass`, 遷移テーブル         |
+| RuntimeSkillCreatorFacade  | `apps/desktop/src/main/services/runtime/RuntimeSkillCreatorFacade.ts`  | `processVerifyResult`, `requestReVerify` |
+| creatorHandlers            | `apps/desktop/src/main/services/runtime/creatorHandlers.ts`            | verify pass handler                      |
+
 ## 参照資料
 
 | 資料名       | パス                                       | 説明            |
@@ -47,6 +56,15 @@ AC-1〜AC-6 と全遷移 edge のカバレッジを照合し、閉ループ修�
 | 実装記録     | `outputs/phase-5/implementation-record.md` | coverage の根拠 |
 | テスト仕様書 | `outputs/phase-4/test-specifications.md`   | AC 対応の元     |
 
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService仕様との整合性確認 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時の整合性確認                 |
+
 ## 統合テスト連携
 
 - 完全サイクルテストを coverage の中核ケースに置く
@@ -54,9 +72,10 @@ AC-1〜AC-6 と全遷移 edge のカバレッジを照合し、閉ループ修�
 
 ## 成果物
 
-| 成果物             | パス                                 | 説明                          |
-| ------------------ | ------------------------------------ | ----------------------------- |
-| カバレッジレポート | `outputs/phase-7/coverage-report.md` | AC 対応表と遷移 edge coverage |
+| 成果物             | パス                                 | 説明                                    |
+| ------------------ | ------------------------------------ | --------------------------------------- |
+| カバレッジレポート | `outputs/phase-7/coverage-report.md` | AC 対応表と遷移 edge coverage           |
+| AC-テスト対応表    | `outputs/phase-7/ac-test-mapping.md` | AC-1〜AC-6 と具体的テストケースの対応表 |
 
 ## 完了条件
 
@@ -65,6 +84,7 @@ AC-1〜AC-6 と全遷移 edge のカバレッジを照合し、閉ループ修�
 - [ ] 不正遷移の禁止テストが確認されている
 - [ ] 3 層（Engine/Facade/IPC）の coverage が確認されている
 - [ ] Phase 8 に渡す重複削減候補が整理されている
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-8-refactoring.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-8-refactoring.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 9: 品質保証                                |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -36,6 +37,14 @@ phase 遷移テーブルの構造を整理し、recordVerifyPass/Failure の対�
 - disabled conditions を定数または設定として外出しできるか検討する
 - 新遷移との整合性を維持しつつ、冗長な条件分岐を削減する
 
+### リファクタリング候補
+
+以下を優先的に検討する:
+
+1. **`recordVerifyPass()` と `recordVerifyFailure()` の共通ロジック抽出**: 前提条件チェック、phase 遷移、ログ出力など共通パターンを private メソッドに抽出する
+2. **遷移テーブルバリデーションの一元化**: 遷移テーブルの整合性チェック（不正遷移検出、dead state 検出）を単一のバリデーション関数に集約する
+3. **verify 結果判定ロジックの Facade からの分離検討**: `processVerifyResult()` 内の verify 結果に基づく判定ロジックが Facade に残るべきか、Engine 層に移すべきかを検討する
+
 ## 参照資料
 
 | 資料名         | パス                                                                   | 説明             |
@@ -45,6 +54,15 @@ phase 遷移テーブルの構造を整理し、recordVerifyPass/Failure の対�
 | 実装記録       | `outputs/phase-5/implementation-record.md`                             | 整理対象の本体   |
 | カバレッジ     | `phase-7-coverage-check.md`                                            | 重複削減候補     |
 | WorkflowEngine | `apps/desktop/src/main/services/runtime/SkillCreatorWorkflowEngine.ts` | 整理対象         |
+
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService仕様との整合性確認 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時の整合性確認                 |
 
 ## 統合テスト連携
 
@@ -64,6 +82,7 @@ phase 遷移テーブルの構造を整理し、recordVerifyPass/Failure の対�
 - [ ] requestReverify() の条件分岐が整理されている
 - [ ] 不要な分岐が増えていない
 - [ ] 最小複雑性の判断理由が記録されている
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】

--- a/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-9-quality-assurance.md
+++ b/docs/30-workflows/skill-creator-agent-sdk-lane/step-10-seq-task-p0-02-verify-improve-reverify-closed-loop/phase-9-quality-assurance.md
@@ -11,6 +11,7 @@
 | 次Phase    | Phase 10: 最終レビュー                           |
 | ステータス | pending                                          |
 | 作成日     | 2026-03-29                                       |
+| 更新日     | 2026-03-30                                       |
 
 ## 目的
 
@@ -31,8 +32,20 @@ state machine の不変条件を検証し、閉ループの全遷移が安全で
 - Facade と Engine の責務分離が適切であることを確認する
 - IPC handler が Engine の内部状態に直接アクセスしていないことを確認する
 - 型安全性: any 型の使用がないことを確認する
+- セキュリティ: IPC handler の sender 検証（`event.senderFrame` / `webContents.id` チェック）が適切に実装されていることを確認する
 
-### Task 3: 仕様書品質チェック
+### Task 3: IPC契約ドリフト検証
+
+品質ゲートとして IPC 契約のドリフトがないことを検証する:
+
+- 以下のコマンドを実行し、IPC 契約の整合性を確認する:
+  ```bash
+  pnpm tsx apps/desktop/scripts/check-ipc-contracts.ts --report-only
+  ```
+- 新規追加した verify pass handler が IPC 契約チェックの対象に含まれていることを確認する
+- ドリフトが検出された場合は blocker として Phase 10 に報告する
+
+### Task 4: 仕様書品質チェック
 
 - phase 名、成果物名、artifacts 名称を統一する
 - Phase 11/12 の補助成果物を先に定義する
@@ -46,6 +59,15 @@ state machine の不変条件を検証し、閉ループの全遷移が安全で
 | リファクタリング記録 | `phase-8-refactoring.md`                   | 品質ゲート対象   |
 | カバレッジレポート   | `outputs/phase-7/coverage-report.md`       | AC 対応表        |
 
+### システム仕様（aiworkflow-requirements）
+
+> 実装前に必ず以下のシステム仕様を確認し、既存設計との整合性を確保してください。
+
+| 参照資料                  | パス                                                                                        | 内容                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Skill Creator Service仕様 | `.agents/skills/aiworkflow-requirements/references/interfaces-agent-sdk-skill-reference.md` | SkillCreatorService仕様との整合性確認 |
+| IPC契約チェックリスト     | `.agents/skills/aiworkflow-requirements/references/ipc-contract-checklist.md`               | IPC修正時の整合性確認                 |
+
 ## 統合テスト連携
 
 - 不変条件のテストが Phase 4/6 で定義されていることを cross-check する
@@ -57,13 +79,16 @@ state machine の不変条件を検証し、閉ループの全遷移が安全で
 | ---------------- | ----------------------------------- | ---------------------------------- |
 | 品質保証レポート | `outputs/phase-9/quality-report.md` | 不変条件検証、実装品質、仕様書品質 |
 
-## 完了��件
+## 完了条件
 
 - [ ] state 不変条件が全て検証されている
 - [ ] 実装品質の blocker が整理されている
 - [ ] 仕様書品質の drift が解消されている
 - [ ] artifacts と実ファイル名が揃っている
 - [ ] Phase 10 に渡す gate 材料が揃っている
+- [ ] IPC契約ドリフト検証（`check-ipc-contracts.ts --report-only`）を実行し問題がないことを確認した
+- [ ] IPC handler の sender 検証が適切に実装されていることを確認した
+- [ ] aiworkflow-requirements の関連仕様を確認した
 - [ ] 本Phase内の全タスクを100%実行完了
 
 ## タスク100%実行確認【必須】


### PR DESCRIPTION
## Summary

- TASK-P0-02（verify→improve→re-verify 閉ループ修復）の Phase 1-13 全仕様書を改善
- Phase 2 設計で `recordVerifyPass()` シグネチャ、4値 VerifyStatus（skip/pass/pass_with_warnings/fail）、遷移テーブル修正（verify→complete, improve→verify）を確定
- Phase 3 設計レビューで完全遷移マトリクス、IPC契約整合性、P0-01統合検証を追加

## 変更内容

### Phase 1（要件定義）
- P50チェック（既実装状態調査）を追加
- aiworkflow-requirements 参照テーブル（4件）を追加
- 多角的チェック観点（アーキテクチャ / IPC / セキュリティ）を追加

### Phase 2（設計）— 最重要
- `recordVerifyPass(planId, checks)` シグネチャ設計
- 4値 `VerifyStatus` 型設計（方針 B+Y 採用）:
  - `"skip"`: engine 未注入時（暗黙 pass 防止）
  - `"pass"`: 全チェック pass
  - `"pass_with_warnings"`: fail なし・warning あり（UI で ⚠️ 表示、フローはブロックしない）
  - `"fail"`: 1件以上 fail
- 遷移テーブル修正: `verify→complete`（pass 時）、`improve→verify`（re-verify 直接遷移）
- Facade `processVerifyResult()` / `requestReVerify()` 統合設計
- UI snapshot に `verifyStatus` / `verifyChecks` / `lastVerifyTimestamp` を追加

### Phase 3（設計レビュー）
- 完全遷移マトリクス（7 phase × 7 phase）を作成
- IPC契約チェックリスト整合性タスクを追加
- P0-01 VerificationEngine との型一致・allPass判定基準検証を追加
- `requestReverify()` disabled conditions と新遷移の矛盾チェックを追加

### Phase 4-13（テスト〜PR作成）
- 各 Phase に aiworkflow-requirements 参照を追加
- テストケースの具体化（テストファイルパス、describe/it ブロック名）
- 多角的チェック観点の追加
- 文字化け（U+FFFD）の修正

## 品質検証

- [x] `pnpm store prune` — ✅
- [x] `pnpm install --force` — ✅
- [x] `pnpm typecheck` — ✅ エラー 0
- [x] `pnpm lint` — ✅ エラー 0（warning 10 は既存）
- [x] `pnpm --filter @repo/shared build` — ✅
- [x] `pnpm --filter @repo/desktop build` — ✅

## State Machine 遷移図

```mermaid
stateDiagram-v2
    [*] --> plan
    plan --> review
    review --> execute
    review --> handoff
    execute --> verify
    verify --> improve : fail (recordVerifyFailure)
    verify --> complete : pass (recordVerifyPass) [NEW]
    verify --> review : review requested
    improve --> execute : 既存経路
    improve --> verify : re-verify [NEW]
    complete --> [*]
```

## Test plan

- [ ] Phase 4-13 の仕様に従い TDD で実装を進める
- [ ] 遷移テーブル全 edge のユニットテスト（Phase 4）
- [ ] execute→verify(fail)→improve→verify(pass) 完全サイクルテスト（Phase 6）
- [ ] UI snapshot の verify 状態反映を手動確認（Phase 11）

Closes #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)